### PR TITLE
feat: rename runtime to MAG and expand benchmark surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ Query → ONNX embed → Vector search + FTS5 BM25 → RRF fusion → Score refi
 ## Gotchas
 
 - The `conductor/` directory contains product planning docs (tracks, specs, style guides) — it's not runtime code
-- Model files (~134 MB) auto-download to `~/.mag/models/` on first use; use `cargo run --release -- download-model` to pre-download
+- Model files (~134 MB) auto-download under the active app root on first use; check `~/.mag/models/` first, and `~/.romega-memory/models/` if MAG is reusing the legacy root. Use `cargo run --release -- download-model` to pre-download.
 - Event types use the `EventType` enum (22 variants + `Unknown(String)`); priority auto-maps via `EventType::default_priority()`
 - Store lifecycle includes canonicalized-content dedup and event-type Jaccard dedup thresholds
 - CI runs on GitHub Actions (ubuntu-latest): fmt → clippy → test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ doctest = false
 
 [features]
 default = ["real-embeddings"]
-real-embeddings = ["dep:ort", "dep:tokenizers", "dep:ndarray", "dep:reqwest", "dep:dotenvy"]
+real-embeddings = ["dep:ort", "dep:tokenizers", "dep:ndarray", "dep:dotenvy"]
 mimalloc = ["dep:mimalloc"]
 sqlite-vec = ["dep:sqlite-vec"]
 
@@ -32,7 +32,7 @@ rmcp = { version = "0.16.0", features = ["server", "client", "transport-io", "tr
 ort = { version = "=2.0.0-rc.11", optional = true }
 tokenizers = { version = "0.22", optional = true, default-features = false, features = ["onig"] }
 ndarray = { version = "0.16", optional = true }
-reqwest = { version = "0.12", optional = true, default-features = false, features = ["rustls-tls", "json"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 dotenvy = { version = "0.15", optional = true }
 num_cpus = "1.16"
 lru = "0.12"

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ cargo run --release --bin longmemeval_bench -- --json
 cargo run --release --bin longmemeval_bench -- --official --questions 10 --json
 cargo run --release --bin locomo_bench -- --json
 cargo run --release --bin scale_bench -- --max-scale 10000 --search-queries 50
-OMEGA_REPO=/path/to/omega-memory uv run --project "$OMEGA_REPO" python benches/python_comparison.py --omega-repo "$OMEGA_REPO"
+OMEGA_REPO=/path/to/omega-memory uv run --project "$OMEGA_REPO" python benches/python_comparison.py
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ MAG and `omega-memory` solve the same class of problem: durable memory for local
 - MAG uses SQLite directly for storage and retrieval.
 - MAG is benchmarked directly against `omega-memory` on the shared local workload in this repo.
 
-On the shared local benchmark in this repo, MAG scored higher overall (`98 / 100` vs `90 / 100`). On that same workload, `omega-memory` was faster on both seeding and query latency.
+On this shared local workload, MAG scored higher overall while `omega-memory` was faster on seeding and query latency. See the [Benchmarks](#benchmarks) section below for current numbers.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ MAG and `omega-memory` solve the same class of problem: durable memory for local
 
 - MAG is Rust-native and ships as a single local binary.
 - MAG uses SQLite directly for storage and retrieval.
-- MAG keeps `omega-memory` as a comparison target and lineage reference, not as the product identity.
+- MAG is benchmarked directly against `omega-memory` on the shared local workload in this repo.
 
-On the shared local benchmark in this repo, MAG scored higher overall (`98 / 100` vs `90 / 100`). On that same workload, `omega-memory` was faster on both seeding and query latency. The README reflects that tradeoff directly instead of collapsing it into a one-line “winner” claim.
+On the shared local benchmark in this repo, MAG scored higher overall (`98 / 100` vs `90 / 100`). On that same workload, `omega-memory` was faster on both seeding and query latency.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -140,13 +140,15 @@ cargo test --all-features
 
 ### Benchmark Commands
 
+Clone `omega-memory` locally first. The comparison script accepts either `--omega-repo` or the `OMEGA_REPO` environment variable.
+
 ```bash
 cargo run --release --bin fetch_benchmark_data -- --dataset all
 cargo run --release --bin longmemeval_bench -- --json
 cargo run --release --bin longmemeval_bench -- --official --questions 10 --json
 cargo run --release --bin locomo_bench -- --json
 cargo run --release --bin scale_bench -- --max-scale 10000 --search-queries 50
-uv run --project ~/repos/omega-memory python benches/python_comparison.py
+OMEGA_REPO=/path/to/omega-memory uv run --project "$OMEGA_REPO" python benches/python_comparison.py --omega-repo "$OMEGA_REPO"
 ```
 
 ## License

--- a/benches/locomo/main.rs
+++ b/benches/locomo/main.rs
@@ -342,6 +342,9 @@ fn main() -> Result<()> {
     if args.top_k == Some(0) {
         bail!("--top-k must be greater than 0");
     }
+    if args.dataset_path.is_some() && (args.force_refresh || args.temp_dataset) {
+        bail!("--dataset-path cannot be combined with --force-refresh or --temp-dataset");
+    }
 
     let runtime = tokio::runtime::Runtime::new()?;
     let dataset = runtime.block_on(benchmarking::resolve_dataset(
@@ -367,10 +370,18 @@ fn main() -> Result<()> {
     let mut total_query_ms = 0u128;
     let mut total_correct = 0usize;
     let mut categories = BTreeMap::new();
+    let mut samples_evaluated = 0usize;
 
     'samples: for sample in &samples {
+        if let Some(limit) = args.questions
+            && total_queries >= limit
+        {
+            break;
+        }
+
         let storage = SqliteStorage::new_in_memory_with_embedder(embedder.clone())?;
         total_memories += runtime.block_on(seed_sample(&storage, sample))?;
+        samples_evaluated += 1;
         rss.sample();
 
         for qa in &sample.qa {
@@ -416,7 +427,7 @@ fn main() -> Result<()> {
     let summary = LoCoMoSummary {
         metadata,
         dataset: "LoCoMo10".to_string(),
-        samples_evaluated: samples.len(),
+        samples_evaluated,
         questions_evaluated: total_queries,
         total_memories_ingested: total_memories,
         total_duration_seconds,
@@ -432,6 +443,5 @@ fn main() -> Result<()> {
     } else {
         print_summary(&summary);
     }
-    dataset.cleanup()?;
     Ok(())
 }

--- a/benches/longmemeval/main.rs
+++ b/benches/longmemeval/main.rs
@@ -103,7 +103,7 @@ fn main() -> Result<()> {
             judge::load_api_key_from_dotenv();
             judge::init_llm_judge(args.judge_model.as_str())?;
         }
-        let dataset = runtime.block_on(benchmarking::resolve_dataset(
+        let mut dataset = runtime.block_on(benchmarking::resolve_dataset(
             DatasetKind::LongMemEval,
             args.dataset_path.clone(),
             args.force_refresh,

--- a/benches/longmemeval/main.rs
+++ b/benches/longmemeval/main.rs
@@ -73,6 +73,9 @@ fn main() -> Result<()> {
     if args.top_k == Some(0) {
         bail!("--top-k must be greater than 0");
     }
+    if args.dataset_path.is_some() && (args.force_refresh || args.temp_dataset) {
+        bail!("--dataset-path cannot be combined with --force-refresh or --temp-dataset");
+    }
     let mut rss = helpers::PeakRss::default();
     rss.sample();
 

--- a/benches/python_comparison.py
+++ b/benches/python_comparison.py
@@ -6,12 +6,13 @@ omega-memory's SQLiteStore. All 100 questions match the Rust benchmark 1:1.
 
 Usage:
     cd /path/to/mag
-    uv run --project ~/repos/omega-memory python benches/python_comparison.py [--verbose]
+    OMEGA_REPO=/path/to/omega-memory uv run --project "$OMEGA_REPO" python benches/python_comparison.py --omega-repo "$OMEGA_REPO" [--verbose]
 """
 
 import argparse
 import json
 import os
+import platform
 import resource
 import shutil
 import sys
@@ -282,7 +283,7 @@ def parse_args():
 
 
 def machine_descriptor() -> str:
-    return f"{os.uname().sysname} {os.uname().machine}"
+    return f"{platform.system()} {platform.machine()}"
 
 
 def git_commit() -> str | None:
@@ -321,7 +322,7 @@ def main():
     sys.path.insert(0, omega_src)
     try:
         from omega.sqlite_store import SQLiteStore  # noqa: E402
-    except Exception as exc:
+    except (ImportError, ModuleNotFoundError) as exc:
         emit_skip(f"failed to import omega-memory from {omega_repo}: {exc}")
         return
 

--- a/benches/python_comparison_nocache.py
+++ b/benches/python_comparison_nocache.py
@@ -3,7 +3,8 @@
 import os
 import sys
 
-sys.path.insert(0, os.path.expanduser("~/repos/omega-memory/src"))
+omega_repo = os.path.expanduser(os.environ.get("OMEGA_REPO", "~/repos/omega-memory"))
+sys.path.insert(0, os.path.join(omega_repo, "src"))
 
 # Disable embedding cache BEFORE any store/query calls
 import omega.graphs as g  # noqa: E402

--- a/benches/python_comparison_nocache.py
+++ b/benches/python_comparison_nocache.py
@@ -4,7 +4,13 @@ import os
 import sys
 
 omega_repo = os.path.expanduser(os.environ.get("OMEGA_REPO", "~/repos/omega-memory"))
-sys.path.insert(0, os.path.join(omega_repo, "src"))
+omega_src = os.path.join(omega_repo, "src")
+if not os.path.isdir(omega_src):
+    raise SystemExit(
+        f"omega-memory repo not found at {omega_repo} "
+        f"(resolved OMEGA_REPO={os.environ.get('OMEGA_REPO', '~/repos/omega-memory')})"
+    )
+sys.path.insert(0, omega_src)
 
 # Disable embedding cache BEFORE any store/query calls
 import omega.graphs as g  # noqa: E402

--- a/conductor/product.md
+++ b/conductor/product.md
@@ -3,6 +3,7 @@
 ## Initial Concept
 i want to do a rust rewrite of /repos/omega-memory
 
+
 ## Vision
 The goal of `mag` is to create a robust, high-performance, and highly portable memory system by rewriting the original `omega-memory` project in Rust. This rewrite aims to eliminate Python dependency requirements, providing a standalone CLI tool and a modular library that can be integrated into various environments, from local development tools to hosted services.
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -149,7 +149,7 @@ Clone `omega-memory` locally first and point the comparison script at that check
 
 ```bash
 COMPARISON_REPO=/path/to/omega-memory
-OMEGA_REPO="$COMPARISON_REPO" UV_CACHE_DIR=/tmp/uv-cache-mag uv run --project "$COMPARISON_REPO" python benches/python_comparison.py --omega-repo "$COMPARISON_REPO"
+OMEGA_REPO="$COMPARISON_REPO" UV_CACHE_DIR=/tmp/uv-cache-mag uv run --project "$COMPARISON_REPO" python benches/python_comparison.py
 ```
 
 Result:

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -145,8 +145,11 @@ Degradation from `1K` to `10K`:
 
 Command:
 
+Clone `omega-memory` locally first and point the comparison script at that checkout.
+
 ```bash
-UV_CACHE_DIR=/tmp/uv-cache-mag uv run --project ~/repos/omega-memory python benches/python_comparison.py
+COMPARISON_REPO=/path/to/omega-memory
+OMEGA_REPO="$COMPARISON_REPO" UV_CACHE_DIR=/tmp/uv-cache-mag uv run --project "$COMPARISON_REPO" python benches/python_comparison.py --omega-repo "$COMPARISON_REPO"
 ```
 
 Result:

--- a/src/app_paths.rs
+++ b/src/app_paths.rs
@@ -1,8 +1,6 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Result, anyhow};
-use serde_json::json;
-
 const APP_DIR: &str = ".mag";
 const LEGACY_APP_DIR: &str = ".romega-memory";
 
@@ -29,20 +27,10 @@ pub fn resolve_app_paths() -> Result<AppPaths> {
     Ok(app_paths_for_home(&home_dir()?))
 }
 
-pub fn runtime_paths_json() -> Result<serde_json::Value> {
-    let paths = resolve_app_paths()?;
-    Ok(json!({
-        "data_root": paths.data_root,
-        "preferred_data_root": paths.preferred_data_root,
-        "legacy_data_root": paths.legacy_data_root,
-        "using_legacy_root": paths.using_legacy_root,
-    }))
-}
-
 fn app_paths_for_home(home: &Path) -> AppPaths {
     let preferred = home.join(APP_DIR);
     let legacy = home.join(LEGACY_APP_DIR);
-    let use_legacy = !preferred.exists() && legacy.exists();
+    let use_legacy = !has_runtime_data(&preferred) && has_runtime_data(&legacy);
     let data_root = if use_legacy {
         legacy.clone()
     } else {
@@ -59,6 +47,12 @@ fn app_paths_for_home(home: &Path) -> AppPaths {
         model_root: data_root.join("models"),
         benchmark_root: data_root.join("benchmarks"),
     }
+}
+
+fn has_runtime_data(root: &Path) -> bool {
+    root.join("memory.db").exists()
+        || root.join("models").exists()
+        || root.join("benchmarks").exists()
 }
 
 #[cfg(test)]
@@ -78,6 +72,7 @@ mod tests {
     fn legacy_root_is_used_when_mag_root_is_absent() {
         let home = std::env::temp_dir().join(format!("mag-paths-{}", Uuid::new_v4()));
         std::fs::create_dir_all(home.join(".romega-memory")).unwrap();
+        std::fs::write(home.join(".romega-memory").join("memory.db"), []).unwrap();
 
         let paths = app_paths_for_home(&home);
         assert_eq!(paths.data_root, home.join(".romega-memory"));
@@ -95,6 +90,20 @@ mod tests {
         let paths = app_paths_for_home(&home);
         assert_eq!(paths.data_root, home.join(".mag"));
         assert!(!paths.using_legacy_root);
+
+        let _ = std::fs::remove_dir_all(home);
+    }
+
+    #[test]
+    fn empty_mag_root_does_not_block_populated_legacy_root() {
+        let home = std::env::temp_dir().join(format!("mag-paths-{}", Uuid::new_v4()));
+        std::fs::create_dir_all(home.join(".mag")).unwrap();
+        std::fs::create_dir_all(home.join(".romega-memory")).unwrap();
+        std::fs::write(home.join(".romega-memory").join("memory.db"), []).unwrap();
+
+        let paths = app_paths_for_home(&home);
+        assert_eq!(paths.data_root, home.join(".romega-memory"));
+        assert!(paths.using_legacy_root);
 
         let _ = std::fs::remove_dir_all(home);
     }

--- a/src/benchmarking.rs
+++ b/src/benchmarking.rs
@@ -199,7 +199,10 @@ async fn download_file(url: &str, path: &Path) -> Result<()> {
         tokio::fs::write(&part_path, &bytes)
             .await
             .with_context(|| format!("failed to write {}", part_path.display()))?;
-        validate_json_file(&part_path)?;
+        let validate_path = part_path.clone();
+        tokio::task::spawn_blocking(move || validate_json_file(&validate_path))
+            .await
+            .context("dataset validation task failed")??;
         tokio::fs::rename(&part_path, path)
             .await
             .with_context(|| format!("failed to finalize {}", path.display()))?;
@@ -286,11 +289,7 @@ fn sanitize_dataset_path(dataset_path: &str) -> String {
 }
 
 fn looks_like_path(arg: &str) -> bool {
-    Path::new(arg).is_absolute()
-        || arg.starts_with('~')
-        || arg.contains('/')
-        || arg.contains('\\')
-        || arg.contains("/home/")
+    Path::new(arg).is_absolute() || arg.starts_with('~') || arg.contains('/') || arg.contains('\\')
 }
 
 fn git_commit() -> Option<String> {

--- a/src/benchmarking.rs
+++ b/src/benchmarking.rs
@@ -248,12 +248,15 @@ fn temporary_dataset_path(kind: DatasetKind) -> PathBuf {
 }
 
 impl DatasetArtifact {
-    pub fn cleanup(&self) -> Result<()> {
+    pub fn cleanup(&mut self) -> Result<()> {
         if !self.temporary || !self.path.exists() {
             return Ok(());
         }
-        std::fs::remove_file(&self.path)
-            .with_context(|| format!("failed to remove temporary dataset {}", self.path.display()))
+        std::fs::remove_file(&self.path).with_context(|| {
+            format!("failed to remove temporary dataset {}", self.path.display())
+        })?;
+        self.temporary = false;
+        Ok(())
     }
 }
 
@@ -267,7 +270,7 @@ impl Drop for DatasetArtifact {
 
 fn sanitize_command(args: impl IntoIterator<Item = String>) -> String {
     args.into_iter()
-        .map(|arg| sanitize_arg(&arg))
+        .map(|arg| quote_shell_arg(&sanitize_arg(&arg)))
         .collect::<Vec<_>>()
         .join(" ")
 }
@@ -275,6 +278,17 @@ fn sanitize_command(args: impl IntoIterator<Item = String>) -> String {
 fn sanitize_arg(arg: &str) -> String {
     if looks_like_path(arg) {
         "<redacted_path>".to_string()
+    } else {
+        arg.to_string()
+    }
+}
+
+fn quote_shell_arg(arg: &str) -> String {
+    if arg
+        .chars()
+        .any(|ch| ch.is_whitespace() || matches!(ch, '"' | '\\' | '$' | '`'))
+    {
+        format!("\"{}\"", arg.replace('\\', "\\\\").replace('"', "\\\""))
     } else {
         arg.to_string()
     }

--- a/src/benchmarking.rs
+++ b/src/benchmarking.rs
@@ -69,6 +69,11 @@ pub async fn resolve_dataset(
     force_refresh: bool,
     temporary: bool,
 ) -> Result<DatasetArtifact> {
+    if dataset_path.is_some() && (force_refresh || temporary) {
+        return Err(anyhow!(
+            "--dataset-path cannot be combined with --force-refresh or --temp-dataset"
+        ));
+    }
     if let Some(path) = dataset_path {
         validate_json_file(&path)?;
         return Ok(DatasetArtifact {
@@ -124,12 +129,12 @@ pub fn benchmark_metadata_from_parts(
 ) -> BenchmarkMetadata {
     BenchmarkMetadata {
         benchmark: benchmark.to_string(),
-        command: std::env::args().collect::<Vec<_>>().join(" "),
+        command: sanitize_command(std::env::args()),
         date: Utc::now().to_rfc3339(),
         commit: git_commit(),
         machine: machine_descriptor(),
         dataset_source: dataset_source.to_string(),
-        dataset_path: dataset_path.to_string(),
+        dataset_path: sanitize_dataset_path(dataset_path),
     }
 }
 
@@ -190,12 +195,21 @@ async fn download_file(url: &str, path: &Path) -> Result<()> {
         .to_os_string();
     part_name.push(".part");
     let part_path = path.with_file_name(part_name);
-    tokio::fs::write(&part_path, &bytes)
-        .await
-        .with_context(|| format!("failed to write {}", part_path.display()))?;
-    tokio::fs::rename(&part_path, path)
-        .await
-        .with_context(|| format!("failed to finalize {}", path.display()))?;
+    let write_result: Result<()> = async {
+        tokio::fs::write(&part_path, &bytes)
+            .await
+            .with_context(|| format!("failed to write {}", part_path.display()))?;
+        validate_json_file(&part_path)?;
+        tokio::fs::rename(&part_path, path)
+            .await
+            .with_context(|| format!("failed to finalize {}", path.display()))?;
+        Ok(())
+    }
+    .await;
+    if let Err(err) = write_result {
+        let _ = tokio::fs::remove_file(&part_path).await;
+        return Err(err);
+    }
     Ok(())
 }
 
@@ -238,6 +252,45 @@ impl DatasetArtifact {
         std::fs::remove_file(&self.path)
             .with_context(|| format!("failed to remove temporary dataset {}", self.path.display()))
     }
+}
+
+impl Drop for DatasetArtifact {
+    fn drop(&mut self) {
+        if self.temporary {
+            let _ = std::fs::remove_file(&self.path);
+        }
+    }
+}
+
+fn sanitize_command(args: impl IntoIterator<Item = String>) -> String {
+    args.into_iter()
+        .map(|arg| sanitize_arg(&arg))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn sanitize_arg(arg: &str) -> String {
+    if looks_like_path(arg) {
+        "<redacted_path>".to_string()
+    } else {
+        arg.to_string()
+    }
+}
+
+fn sanitize_dataset_path(dataset_path: &str) -> String {
+    Path::new(dataset_path)
+        .file_name()
+        .and_then(|value| value.to_str())
+        .map(ToOwned::to_owned)
+        .unwrap_or_else(|| "<redacted_path>".to_string())
+}
+
+fn looks_like_path(arg: &str) -> bool {
+    Path::new(arg).is_absolute()
+        || arg.starts_with('~')
+        || arg.contains('/')
+        || arg.contains('\\')
+        || arg.contains("/home/")
 }
 
 fn git_commit() -> Option<String> {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1111,6 +1111,16 @@ mod tests {
     }
 
     #[test]
+    fn test_cli_paths_command() {
+        let args = vec!["mag", "paths"];
+        let cli = Cli::parse_from(args);
+        match cli.command {
+            Commands::Paths => {}
+            _ => panic!("Expected Paths command"),
+        }
+    }
+
+    #[test]
     fn test_cli_maintain_command() {
         let args = vec!["mag", "maintain", "--action", "health", "--warn-mb", "100"];
         let cli = Cli::parse_from(args);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 pub mod app_paths;
-#[cfg(feature = "real-embeddings")]
 pub mod benchmarking;
 pub mod memory_core;
 

--- a/src/memory_core/storage/sqlite/mod.rs
+++ b/src/memory_core/storage/sqlite/mod.rs
@@ -397,7 +397,6 @@ impl SqliteStorage {
                 "total_access_count": total_access,
                 "fts5_indexed": fts_count,
                 "fts5_in_sync": fts_count == total_memories,
-                "paths": crate::app_paths::runtime_paths_json()?,
             }))
         })
         .await

--- a/src/memory_core/storage/sqlite/mod.rs
+++ b/src/memory_core/storage/sqlite/mod.rs
@@ -928,7 +928,13 @@ impl SqliteStorage {
 }
 
 fn build_stats_paths_json(db_path: &Path) -> serde_json::Value {
-    let app_paths = crate::app_paths::resolve_app_paths().ok();
+    let app_paths = match crate::app_paths::resolve_app_paths() {
+        Ok(paths) => Some(paths),
+        Err(error) => {
+            tracing::warn!(error = %error, "failed to resolve app paths for stats");
+            None
+        }
+    };
     let data_root = if db_path.as_os_str() == ":memory:" {
         serde_json::Value::Null
     } else {

--- a/src/memory_core/storage/sqlite/mod.rs
+++ b/src/memory_core/storage/sqlite/mod.rs
@@ -64,6 +64,7 @@ use crate::memory_core::reranker::CrossEncoderReranker;
 
 #[derive(Clone)]
 pub struct SqliteStorage {
+    db_path: PathBuf,
     pool: Arc<ConnPool>,
     embedder: Arc<dyn Embedder>,
     scoring_params: ScoringParams,
@@ -135,6 +136,7 @@ impl SqliteStorage {
         };
 
         Ok(Self {
+            db_path: path,
             pool: Arc::new(pool),
             embedder,
             scoring_params: ScoringParams::default(),
@@ -358,6 +360,7 @@ impl SqliteStorage {
     /// Returns storage statistics as a JSON Value.
     pub async fn stats(&self) -> Result<serde_json::Value> {
         let pool = Arc::clone(&self.pool);
+        let db_path = self.db_path.clone();
 
         tokio::task::spawn_blocking(move || {
             let conn = pool.reader()?;
@@ -397,6 +400,7 @@ impl SqliteStorage {
                 "total_access_count": total_access,
                 "fts5_indexed": fts_count,
                 "fts5_in_sync": fts_count == total_memories,
+                "paths": build_stats_paths_json(&db_path),
             }))
         })
         .await
@@ -697,6 +701,7 @@ impl SqliteStorage {
     pub fn new_in_memory_with_embedder(embedder: Arc<dyn Embedder>) -> Result<Self> {
         let pool = ConnPool::open_in_memory(embedder.dimension())?;
         Ok(Self {
+            db_path: PathBuf::from(":memory:"),
             pool: Arc::new(pool),
             embedder,
             scoring_params: ScoringParams::default(),
@@ -920,6 +925,38 @@ impl SqliteStorage {
 
         Ok(())
     }
+}
+
+fn build_stats_paths_json(db_path: &Path) -> serde_json::Value {
+    let app_paths = crate::app_paths::resolve_app_paths().ok();
+    let data_root = if db_path.as_os_str() == ":memory:" {
+        serde_json::Value::Null
+    } else {
+        db_path
+            .parent()
+            .map(|path| serde_json::Value::String(path.display().to_string()))
+            .unwrap_or(serde_json::Value::Null)
+    };
+    let preferred_data_root = app_paths
+        .as_ref()
+        .map(|paths| serde_json::Value::String(paths.preferred_data_root.display().to_string()))
+        .unwrap_or(serde_json::Value::Null);
+    let legacy_data_root = app_paths
+        .as_ref()
+        .map(|paths| serde_json::Value::String(paths.legacy_data_root.display().to_string()))
+        .unwrap_or(serde_json::Value::Null);
+    let using_legacy_root = app_paths
+        .as_ref()
+        .map(|paths| db_path.starts_with(&paths.legacy_data_root))
+        .unwrap_or(false);
+
+    serde_json::json!({
+        "database_path": db_path.display().to_string(),
+        "data_root": data_root,
+        "preferred_data_root": preferred_data_root,
+        "legacy_data_root": legacy_data_root,
+        "using_legacy_root": using_legacy_root,
+    })
 }
 
 #[derive(Debug, Clone)]

--- a/src/memory_core/storage/sqlite/tests.rs
+++ b/src/memory_core/storage/sqlite/tests.rs
@@ -28,7 +28,7 @@ impl Embedder for KeywordEmbedder {
 
 #[test]
 fn test_new_with_path_creates_parent_and_db() {
-    let base = std::env::temp_dir().join(format!("romega-sqlite-test-{}", Uuid::new_v4()));
+    let base = std::env::temp_dir().join(format!("mag-sqlite-test-{}", Uuid::new_v4()));
     let db_path = base.join("nested").join("memory.db");
 
     let storage = SqliteStorage::new_with_path(
@@ -44,13 +44,14 @@ fn test_new_with_path_creates_parent_and_db() {
 
 #[tokio::test]
 async fn test_stats_include_instance_paths_for_custom_storage() {
-    let base = std::env::temp_dir().join(format!("romega-sqlite-test-{}", Uuid::new_v4()));
+    let base = std::env::temp_dir().join(format!("mag-sqlite-test-{}", Uuid::new_v4()));
     let db_path = base.join("stats").join("memory.db");
     let storage = SqliteStorage::new_with_path(
         db_path.clone(),
         std::sync::Arc::new(crate::memory_core::PlaceholderEmbedder),
     )
     .unwrap();
+    let app_paths = crate::app_paths::resolve_app_paths().unwrap();
 
     let stats = storage.stats().await.unwrap();
     assert_eq!(
@@ -64,6 +65,15 @@ async fn test_stats_include_instance_paths_for_custom_storage() {
             .map(|path| path.display().to_string())
             .as_deref()
     );
+    assert_eq!(
+        stats["paths"]["preferred_data_root"].as_str(),
+        Some(app_paths.preferred_data_root.display().to_string().as_str())
+    );
+    assert_eq!(
+        stats["paths"]["legacy_data_root"].as_str(),
+        Some(app_paths.legacy_data_root.display().to_string().as_str())
+    );
+    assert_eq!(stats["paths"]["using_legacy_root"].as_bool(), Some(false));
 
     let _ = fs::remove_dir_all(base);
 }

--- a/src/memory_core/storage/sqlite/tests.rs
+++ b/src/memory_core/storage/sqlite/tests.rs
@@ -4197,16 +4197,6 @@ async fn test_access_rate_stats() {
 }
 
 #[tokio::test]
-async fn test_storage_stats_include_resolved_paths() {
-    let storage = SqliteStorage::new_in_memory().unwrap();
-    let result = storage.stats().await.unwrap();
-    assert!(result["paths"]["data_root"].as_str().is_some());
-    assert!(result["paths"]["preferred_data_root"].as_str().is_some());
-    assert!(result["paths"]["legacy_data_root"].as_str().is_some());
-    assert!(result["paths"]["using_legacy_root"].as_bool().is_some());
-}
-
-#[tokio::test]
 async fn test_dual_match_boost_default() {
     // Verify the default value for dual_match_boost
     let params = ScoringParams::default();

--- a/src/memory_core/storage/sqlite/tests.rs
+++ b/src/memory_core/storage/sqlite/tests.rs
@@ -42,6 +42,32 @@ fn test_new_with_path_creates_parent_and_db() {
     let _ = fs::remove_dir_all(base);
 }
 
+#[tokio::test]
+async fn test_stats_include_instance_paths_for_custom_storage() {
+    let base = std::env::temp_dir().join(format!("romega-sqlite-test-{}", Uuid::new_v4()));
+    let db_path = base.join("stats").join("memory.db");
+    let storage = SqliteStorage::new_with_path(
+        db_path.clone(),
+        std::sync::Arc::new(crate::memory_core::PlaceholderEmbedder),
+    )
+    .unwrap();
+
+    let stats = storage.stats().await.unwrap();
+    assert_eq!(
+        stats["paths"]["database_path"].as_str(),
+        Some(db_path.display().to_string().as_str())
+    );
+    assert_eq!(
+        stats["paths"]["data_root"].as_str(),
+        db_path
+            .parent()
+            .map(|path| path.display().to_string())
+            .as_deref()
+    );
+
+    let _ = fs::remove_dir_all(base);
+}
+
 #[test]
 fn test_schema_contains_required_tables_and_columns() {
     let storage = SqliteStorage::new_in_memory().unwrap();


### PR DESCRIPTION
## Summary
- rename the runtime surface from romega-memory to MAG
- add benchmark dataset fetch/cache support and LoCoMo harnesses
- publish benchmark/docs updates and follow-up review fixes

## Notes
- includes the latest review follow-ups that were only pushed to the private repo branch after the initial public mirror
- broader benchmark methodology follow-up is tracked separately in the MAG issue backlog after migration


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Benchmarking metadata now redacts sensitive values
  - Stats/diagnostics include the specific database path for custom storage instances

* **Bug Fixes**
  - Prevent incompatible dataset flags to avoid ambiguous runs
  - More robust download with partial-file validation and cleanup
  - Improved detection of legacy app data when selecting data roots

* **Documentation**
  - Benchmark setup accepts an env var/flag for the comparison repo
  - Model download path clarified to live under the active app root

* **Chores**
  - Simplified embeddings build configuration

* **Tests**
  - Added CLI and storage tests for paths and stats reporting
<!-- end of auto-generated comment: release notes by coderabbit.ai -->