### PR TITLE
fix(cli): validate --importance-min range (0.0-1.0)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -951,6 +951,12 @@ fn build_search_options(
         anyhow::bail!("invalid --event-type: {kind}");
     }
 
+    if let Some(imp) = filters.importance_min
+        && !(0.0..=1.0).contains(&imp)
+    {
+        anyhow::bail!("--importance-min must be between 0.0 and 1.0, got {imp}");
+    }
+
     let times = normalize_search_time_filters(SearchTimeFilters {
         created_after: &filters.created_after,
         created_before: &filters.created_before,

--- a/tests/cli_output_smoke.rs
+++ b/tests/cli_output_smoke.rs
@@ -23,6 +23,15 @@ fn run_cli(home: &std::path::Path, args: &[&str]) -> anyhow::Result<(String, Str
     ))
 }
 
+fn run_cli_raw(home: &std::path::Path, args: &[&str]) -> std::process::Output {
+    Command::new(env!("CARGO_BIN_EXE_mag"))
+        .args(args)
+        .env("HOME", home)
+        .env("USERPROFILE", home)
+        .output()
+        .expect("failed to execute process")
+}
+
 fn assert_entity_agent_fields(
     result: &serde_json::Value,
     entity_id: &str,
@@ -540,4 +549,35 @@ fn cli_commands_emit_json_payloads() -> anyhow::Result<()> {
 
     let _ = std::fs::remove_dir_all(&test_home);
     Ok(())
+}
+
+#[test]
+fn cli_rejects_out_of_range_importance_min() {
+    let test_home = std::env::temp_dir().join(format!("mag-cli-imp-{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&test_home).unwrap();
+
+    // Values above 1.0 should be rejected
+    let output = run_cli_raw(&test_home, &["search", "test", "--importance-min", "2.0"]);
+    assert!(
+        !output.status.success(),
+        "expected failure for --importance-min 2.0"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--importance-min must be between 0.0 and 1.0"),
+        "unexpected stderr: {stderr}"
+    );
+
+    // Negative values should be rejected
+    let output = run_cli_raw(&test_home, &["search", "test", "--importance-min", "-0.5"]);
+    assert!(
+        !output.status.success(),
+        "expected failure for --importance-min -0.5"
+    );
+
+    // Valid value should succeed (the command itself may find no results, but shouldn't error)
+    let result = run_cli(&test_home, &["search", "test", "--importance-min", "0.5"]);
+    assert!(result.is_ok(), "expected success for --importance-min 0.5");
+
+    let _ = std::fs::remove_dir_all(&test_home);
 }


### PR DESCRIPTION
## Summary
- Add validation in `build_search_options()` to reject `--importance-min` values outside 0.0-1.0
- Add `run_cli_raw` helper and `cli_rejects_out_of_range_importance_min` negative test
- Closes #19

## Test plan
- [x] `cargo run --release --bin mag -- search "test" --importance-min 2.0` errors with clear message
- [x] `cargo run --release --bin mag -- search "test" --importance-min -0.5` errors
- [x] `cargo run --release --bin mag -- search "test" --importance-min 0.5` succeeds
- [x] `cargo test --all-features` passes (647 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for the --importance-min parameter to reject values outside the 0.0–1.0 range with a clear error message, preventing unexpected behavior from invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->