### PR TITLE
chore: replace pre-commit hook with prek

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .cargo-cache/
 
 .env
+.env.local
 # Local provenance / legal notes (not published)
 PROVENANCE.local.md
 

--- a/prek.toml
+++ b/prek.toml
@@ -1,0 +1,28 @@
+# Configuration file for `prek`, a git hook framework written in Rust.
+# See https://prek.j178.dev for more information.
+#:schema https://www.schemastore.org/prek.json
+
+# ── Builtin checks (instant, Rust-native) ───────────────────────────────
+[[repos]]
+repo = "builtin"
+hooks = [
+    { id = "trailing-whitespace" },
+    { id = "end-of-file-fixer" },
+    { id = "check-added-large-files", args = ["--maxkb=1024"] },
+]
+
+# ── Rust toolchain checks ────────────────────────────────────────────────
+[[repos]]
+repo = "local"
+hooks = [
+    # fmt must run first (auto-fixes), then clippy checks the formatted code
+    { id = "rustfmt", name = "rustfmt", language = "system", entry = "cargo fmt --all", pass_filenames = false, types = ["rust"], priority = 10 },
+    { id = "clippy", name = "clippy", language = "system", entry = "cargo clippy --all-targets --all-features -- -D warnings", pass_filenames = false, types = ["rust"], require_serial = true, priority = 20 },
+]
+
+# ── CodeRabbit (optional, non-blocking) ──────────────────────────────────
+[[repos]]
+repo = "local"
+hooks = [
+    { id = "coderabbit", name = "CodeRabbit lint", language = "system", entry = "sh -c 'coderabbit review --type uncommitted --plain || true'", pass_filenames = false, always_run = true, priority = 30, verbose = true },
+]


### PR DESCRIPTION
## Summary
- Replace hand-written `.git/hooks/pre-commit` shell script with [prek](https://github.com/j178/prek) (Rust-native pre-commit framework)
- Hook config is now in committed `prek.toml` — shared across all agents and sessions
- Add `.env.local` to `.gitignore` (stops CodeRabbit from flagging API key on every PR)

### Hooks configured
| Priority | Hook | Type | Blocking |
|---|---|---|---|
| - | trailing-whitespace | builtin | yes |
| - | end-of-file-fixer | builtin | yes |
| - | check-added-large-files | builtin | yes |
| 10 | rustfmt | local/system | yes |
| 20 | clippy -D warnings | local/system | yes |
| 30 | CodeRabbit lint | local/system | no (non-blocking) |

### Setup
```bash
brew install prek
prek install
```

## Test plan
- [x] `prek run --all-files` passes all 6 hooks
- [x] Commit through prek hook succeeds (this commit itself)
- [x] `prek validate-config` passes
- [x] `prek list` shows all 6 hooks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced version control configuration to exclude local environment files, preventing accidental exposure of sensitive configuration.
  * Added automated code quality checks including formatting and linting validation for the development workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->