### PR TITLE
perf(bench): seed grid search once instead of 1440x

### DIFF
--- a/benches/longmemeval/grid_search.rs
+++ b/benches/longmemeval/grid_search.rs
@@ -202,14 +202,23 @@ pub(crate) async fn run_grid_search(verbose: bool) -> Result<Vec<GridSearchResul
 
     let embedder: std::sync::Arc<dyn mag::memory_core::embedder::Embedder> =
         std::sync::Arc::new(OnnxEmbedder::new()?);
+
+    // Seed the database ONCE — all parameter combos share the same data.
+    // Only ScoringParams change between iterations (they affect ranking,
+    // not stored content), so re-seeding is unnecessary.
+    let mut storage = SqliteStorage::new_in_memory_with_embedder(embedder.clone())?;
+    let mut rss = PeakRss::default();
+    rss.sample();
+
+    let seed_start = Instant::now();
+    seed_memories(&storage, &embedder, &mut rss).await?;
+    let seed_ms = seed_start.elapsed().as_millis();
+    eprintln!("Grid search: seeded once in {seed_ms} ms ({total} combos to evaluate)");
+
     for (index, (label, params)) in parameter_sets.into_iter().enumerate() {
         let start = Instant::now();
-        let storage = SqliteStorage::new_in_memory_with_embedder(embedder.clone())?
-            .with_scoring_params(params.clone());
-        let mut rss = PeakRss::default();
-        rss.sample();
+        storage.set_scoring_params(params.clone());
 
-        seed_memories(&storage, &embedder, &mut rss).await?;
         let categories = run_benchmark(
             &storage,
             false,

--- a/src/memory_core/storage/sqlite/mod.rs
+++ b/src/memory_core/storage/sqlite/mod.rs
@@ -183,7 +183,18 @@ impl SqliteStorage {
     }
 
     #[allow(dead_code)]
-    pub fn with_scoring_params(mut self, mut params: ScoringParams) -> Self {
+    pub fn with_scoring_params(mut self, params: ScoringParams) -> Self {
+        self.set_scoring_params(params);
+        self
+    }
+
+    /// Replaces the scoring parameters on an existing instance.
+    ///
+    /// Also invalidates the query cache so subsequent searches use the new
+    /// parameters.  This is cheaper than rebuilding the entire storage when
+    /// only the ranking configuration changes (e.g. during grid search).
+    #[allow(dead_code)]
+    pub fn set_scoring_params(&mut self, mut params: ScoringParams) {
         if params.graph_seed_min > params.graph_seed_max {
             std::mem::swap(&mut params.graph_seed_min, &mut params.graph_seed_max);
         }
@@ -191,7 +202,7 @@ impl SqliteStorage {
             params.rrf_k = ScoringParams::default().rrf_k;
         }
         self.scoring_params = params;
-        self
+        self.invalidate_query_cache();
     }
 
     /// Clears the query result cache. Called after every write operation.


### PR DESCRIPTION
## Summary
- Grid search now seeds the database **once** instead of re-seeding 80 memories for each of 1,440 parameter combinations
- Added `set_scoring_params()` method to `SqliteStorage` for in-place param updates with cache invalidation
- `with_scoring_params()` now delegates to `set_scoring_params()` to avoid duplication

## Impact
- **~150x speedup** on grid search seeding phase (from ~460s → ~3s)
- Total grid search: ~10min → ~4-5min

## Test plan
- [x] `cargo test --all-features` (328 tests pass)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] Verified `scoring_params` is never persisted to SQLite (read-only in search path)

Closes #16 (Tier 1 quick win)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized grid search benchmark to reduce redundant database initialization overhead across parameter iterations.

* **Refactor**
  * Refined scoring parameters API with improved cache handling to ensure consistency when parameters are updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->