### PR TITLE
feat(sqlite): add bounded retry with backoff for lock contention

### DIFF
--- a/src/memory_core/storage/sqlite/admin.rs
+++ b/src/memory_core/storage/sqlite/admin.rs
@@ -277,8 +277,7 @@ impl MaintenanceManager for SqliteStorage {
 
                     let keep_id = &candidates[cluster[0]].0;
 
-                    let tx = conn
-                        .unchecked_transaction()
+                    let tx = retry_on_lock(|| conn.unchecked_transaction())
                         .context("failed to start compaction transaction")?;
 
                     tx.execute(
@@ -441,8 +440,7 @@ impl MaintenanceManager for SqliteStorage {
 
                 if !valid_clusters.is_empty() && !dry_run {
                     // Single transaction for all clusters of this event type
-                    let tx = conn
-                        .unchecked_transaction()
+                    let tx = retry_on_lock(|| conn.unchecked_transaction())
                         .context("failed to start auto_compact transaction")?;
 
                     for cluster in &valid_clusters {
@@ -508,8 +506,7 @@ impl MaintenanceManager for SqliteStorage {
         tokio::task::spawn_blocking(move || {
             let conn = pool.writer()?;
 
-            let tx = conn
-                .unchecked_transaction()
+            let tx = retry_on_lock(|| conn.unchecked_transaction())
                 .context("failed to start clear_session transaction")?;
 
             // Delete relationships first

--- a/src/memory_core/storage/sqlite/crud.rs
+++ b/src/memory_core/storage/sqlite/crud.rs
@@ -28,8 +28,7 @@ impl Storage for SqliteStorage {
             let c_hash = content_hash(&data);
             let normalized_hash = canonical_hash(&data);
             let conn = pool.writer()?;
-            let tx = conn
-                .unchecked_transaction()
+            let tx = retry_on_lock(|| conn.unchecked_transaction())
                 .context("failed to start sqlite transaction")?;
 
             // ── Phase 1: Combined canonical-hash + Jaccard dedup (single query) ──
@@ -409,8 +408,7 @@ impl Retriever for SqliteStorage {
 
         tokio::task::spawn_blocking(move || {
             let conn = pool.writer()?;
-            let tx = conn
-                .unchecked_transaction()
+            let tx = retry_on_lock(|| conn.unchecked_transaction())
                 .context("failed to start sqlite transaction")?;
 
             let content: Option<String> = tx
@@ -450,8 +448,7 @@ impl Deleter for SqliteStorage {
 
         let deleted = tokio::task::spawn_blocking(move || {
             let conn = pool.writer()?;
-            let tx = conn
-                .unchecked_transaction()
+            let tx = retry_on_lock(|| conn.unchecked_transaction())
                 .context("failed to start delete transaction")?;
             tx.execute("DELETE FROM memories_fts WHERE id = ?1", params![id])
                 .context("failed to delete memory from FTS index")?;
@@ -588,8 +585,7 @@ impl Updater for SqliteStorage {
                 params.push(value);
             }
 
-            let tx = conn
-                .unchecked_transaction()
+            let tx = retry_on_lock(|| conn.unchecked_transaction())
                 .context("failed to start update transaction")?;
 
             let changes = tx

--- a/src/memory_core/storage/sqlite/graph.rs
+++ b/src/memory_core/storage/sqlite/graph.rs
@@ -430,8 +430,7 @@ impl VersionChainQuerier for SqliteStorage {
 
         tokio::task::spawn_blocking(move || {
             let conn = pool.writer()?;
-            let tx = conn
-                .unchecked_transaction()
+            let tx = retry_on_lock(|| conn.unchecked_transaction())
                 .context("failed to start supersede transaction")?;
 
             let old_exists: Option<String> = tx

--- a/src/memory_core/storage/sqlite/helpers.rs
+++ b/src/memory_core/storage/sqlite/helpers.rs
@@ -1,9 +1,76 @@
 use std::sync::MutexGuard;
+use std::time::Duration;
 
 use super::*;
 
 /// Fallback timestamp used when a row's `created_at` column is missing or unparseable.
 pub(super) const EPOCH_FALLBACK: &str = "1970-01-01T00:00:00.000Z";
+
+/// Returns `true` when a rusqlite error indicates SQLite lock contention
+/// (`SQLITE_BUSY`). Used to decide whether to retry a transaction.
+pub(super) fn is_lock_error(err: &rusqlite::Error) -> bool {
+    matches!(
+        err,
+        rusqlite::Error::SqliteFailure(e, _)
+            if e.code == rusqlite::ffi::ErrorCode::DatabaseBusy
+    )
+}
+
+/// Maximum number of retry attempts for lock contention.
+const RETRY_MAX_ATTEMPTS: u32 = 5;
+
+/// Base delay between retries (doubled each attempt).
+const RETRY_BASE_DELAY_MS: u64 = 10;
+
+/// Retries `f` with exponential backoff when it returns a lock contention error.
+///
+/// This is a **synchronous** function intended to run inside `spawn_blocking`.
+/// Uses `std::thread::sleep` (not tokio) for delays.
+///
+/// - Max attempts: 5
+/// - Backoff: 10ms, 20ms, 40ms, 80ms, 160ms (+ random 0-50% jitter)
+/// - Non-lock errors are returned immediately without retry.
+pub(super) fn retry_on_lock<T, F>(mut f: F) -> std::result::Result<T, rusqlite::Error>
+where
+    F: FnMut() -> std::result::Result<T, rusqlite::Error>,
+{
+    let mut attempt = 0_u32;
+    loop {
+        match f() {
+            Ok(val) => return Ok(val),
+            Err(err) if is_lock_error(&err) && attempt + 1 < RETRY_MAX_ATTEMPTS => {
+                attempt += 1;
+                let base_ms = RETRY_BASE_DELAY_MS * 2_u64.pow(attempt - 1);
+                // Simple jitter: add 0-50% of base_ms using a cheap hash of the attempt
+                // counter and a timestamp nanos component to avoid pulling in a rand dependency.
+                let jitter_ms = {
+                    let nanos = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.subsec_nanos() as u64)
+                        .unwrap_or(0);
+                    let seed = nanos.wrapping_mul(u64::from(attempt).wrapping_add(7));
+                    seed % (base_ms / 2 + 1)
+                };
+                let delay = Duration::from_millis(base_ms + jitter_ms);
+                tracing::debug!(
+                    attempt,
+                    delay_ms = delay.as_millis(),
+                    "sqlite lock contention, retrying"
+                );
+                std::thread::sleep(delay);
+            }
+            Err(err) => {
+                if is_lock_error(&err) {
+                    tracing::warn!(
+                        attempts = RETRY_MAX_ATTEMPTS,
+                        "sqlite lock contention persisted after all retries"
+                    );
+                }
+                return Err(err);
+            }
+        }
+    }
+}
 
 /// Computes a u64 hash key for the query result cache.
 pub(super) fn query_cache_key(query: &str, limit: usize, opts: &super::SearchOptions) -> u64 {
@@ -1169,5 +1236,97 @@ mod tests {
         assert!(!is_keyword_query("what framework are we using"));
         assert!(!is_keyword_query("database connection pool"));
         assert!(!is_keyword_query(""));
+    }
+
+    // ── is_lock_error / retry_on_lock tests ────────────────────────────
+
+    #[test]
+    fn is_lock_error_detects_busy() {
+        let err = rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error {
+                code: rusqlite::ffi::ErrorCode::DatabaseBusy,
+                extended_code: 5,
+            },
+            Some("database is locked".to_string()),
+        );
+        assert!(is_lock_error(&err));
+    }
+
+    #[test]
+    fn is_lock_error_rejects_other_errors() {
+        let err = rusqlite::Error::SqliteFailure(
+            rusqlite::ffi::Error {
+                code: rusqlite::ffi::ErrorCode::ReadOnly,
+                extended_code: 8,
+            },
+            None,
+        );
+        assert!(!is_lock_error(&err));
+
+        let err2 = rusqlite::Error::QueryReturnedNoRows;
+        assert!(!is_lock_error(&err2));
+    }
+
+    #[test]
+    fn retry_on_lock_returns_immediately_for_non_lock_error() {
+        let mut attempts = 0u32;
+        let result: std::result::Result<(), rusqlite::Error> = retry_on_lock(|| {
+            attempts += 1;
+            Err(rusqlite::Error::QueryReturnedNoRows)
+        });
+        assert!(result.is_err());
+        assert_eq!(attempts, 1, "should not retry for non-lock errors");
+    }
+
+    #[test]
+    fn retry_on_lock_succeeds_on_first_try() {
+        let mut attempts = 0u32;
+        let result = retry_on_lock(|| {
+            attempts += 1;
+            Ok(42)
+        });
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(attempts, 1);
+    }
+
+    #[test]
+    fn retry_on_lock_retries_on_busy_then_succeeds() {
+        let mut attempts = 0u32;
+        let result = retry_on_lock(|| {
+            attempts += 1;
+            if attempts < 3 {
+                Err(rusqlite::Error::SqliteFailure(
+                    rusqlite::ffi::Error {
+                        code: rusqlite::ffi::ErrorCode::DatabaseBusy,
+                        extended_code: 5,
+                    },
+                    None,
+                ))
+            } else {
+                Ok("success")
+            }
+        });
+        assert_eq!(result.unwrap(), "success");
+        assert_eq!(attempts, 3);
+    }
+
+    #[test]
+    fn retry_on_lock_exhausts_retries() {
+        let mut attempts = 0u32;
+        let result: std::result::Result<(), rusqlite::Error> = retry_on_lock(|| {
+            attempts += 1;
+            Err(rusqlite::Error::SqliteFailure(
+                rusqlite::ffi::Error {
+                    code: rusqlite::ffi::ErrorCode::DatabaseBusy,
+                    extended_code: 5,
+                },
+                None,
+            ))
+        });
+        assert!(result.is_err());
+        assert_eq!(
+            attempts, 5,
+            "should attempt exactly RETRY_MAX_ATTEMPTS times"
+        );
     }
 }

--- a/src/memory_core/storage/sqlite/lifecycle.rs
+++ b/src/memory_core/storage/sqlite/lifecycle.rs
@@ -96,8 +96,7 @@ impl ExpirationSweeper for SqliteStorage {
 
         tokio::task::spawn_blocking(move || {
             let conn = pool.writer()?;
-            let tx = conn
-                .unchecked_transaction()
+            let tx = retry_on_lock(|| conn.unchecked_transaction())
                 .context("failed to start sweep transaction")?;
 
             let mut stmt = tx

--- a/src/memory_core/storage/sqlite/mod.rs
+++ b/src/memory_core/storage/sqlite/mod.rs
@@ -561,8 +561,7 @@ impl SqliteStorage {
         tokio::task::spawn_blocking(move || {
             let conn = pool.writer()?;
 
-            let tx = conn
-                .unchecked_transaction()
+            let tx = retry_on_lock(|| conn.unchecked_transaction())
                 .context("failed to start import transaction")?;
 
             let mut mem_count = 0usize;
@@ -1025,7 +1024,7 @@ use helpers::{
     content_hash, decode_embedding, encode_embedding, escape_like_pattern, event_type_from_sql,
     event_type_to_sql, expand_temporal_query, is_keyword_query, matches_search_options,
     normalize_for_dedup, parse_metadata_from_db, parse_tags_from_db, query_cache_key,
-    search_result_from_row, to_param_refs, validate_iso8601,
+    retry_on_lock, search_result_from_row, to_param_refs, validate_iso8601,
 };
 use hot_cache::{HOT_CACHE_CAPACITY, HOT_CACHE_REFRESH_SECS, HotTierCache};
 use schema::{default_db_path, initialize_parent_dir, initialize_schema};

--- a/src/memory_core/storage/sqlite/schema.rs
+++ b/src/memory_core/storage/sqlite/schema.rs
@@ -186,8 +186,7 @@ pub(super) fn initialize_vec_table(conn: &Connection, embedding_dim: usize) -> R
         .query_row("SELECT count(*) FROM vec_memories", [], |row| row.get(0))
         .context("failed to count vec_memories rows")?;
     if vec_count == 0 {
-        let tx = conn
-            .unchecked_transaction()
+        let tx = retry_on_lock(|| conn.unchecked_transaction())
             .context("failed to begin vec migration transaction")?;
 
         let mut read_stmt = tx


### PR DESCRIPTION
## Summary
- Added `retry_on_lock()` function with exponential backoff + jitter (5 attempts, 10-160ms)
- Added `is_lock_error()` classifier for `rusqlite::Error::SqliteFailure` with `DatabaseBusy` code
- Wrapped all 11 `unchecked_transaction()` sites across 7 files: crud, lifecycle, admin, graph, schema, mod
- Uses `SystemTime::now().subsec_nanos()` for jitter (no rand crate dependency)
- Debug-level logging on retry, warn-level on exhaustion

## Files changed
- `helpers.rs` — Core retry logic + 5 unit tests
- `crud.rs` — 4 transaction sites (store, retrieve, delete, update)
- `lifecycle.rs` — sweep_expired transaction
- `admin.rs` — 3 transactions (compaction, auto_compact, clear_session)
- `graph.rs` — supersede transaction
- `schema.rs` — vec migration transaction
- `mod.rs` — import_all transaction + import

## Test plan
- [x] `cargo test --all-features` (334 tests pass, 6 new)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] Non-lock errors return immediately (unit tested)
- [x] Lock errors retry with bounded backoff (unit tested)

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience to SQLite lock contention by implementing automatic retry logic with exponential backoff for database operations during concurrent access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->