### PR TITLE
perf(cache): targeted invalidation and fix missing invalidation in import/sweep

### DIFF
--- a/src/memory_core/storage/sqlite/admin.rs
+++ b/src/memory_core/storage/sqlite/admin.rs
@@ -74,7 +74,7 @@ impl MaintenanceManager for SqliteStorage {
     async fn consolidate(&self, prune_days: i64, max_summaries: i64) -> Result<serde_json::Value> {
         let pool = Arc::clone(&self.pool);
 
-        tokio::task::spawn_blocking(move || {
+        let result = tokio::task::spawn_blocking(move || {
             let conn = pool.writer()?;
 
             let before: i64 = conn
@@ -168,7 +168,12 @@ impl MaintenanceManager for SqliteStorage {
             }))
         })
         .await
-        .context("spawn_blocking join error")?
+        .context("spawn_blocking join error")?;
+
+        // Maintenance may have pruned memories — full cache clear.
+        self.invalidate_query_cache();
+
+        result
     }
 
     async fn compact(
@@ -181,7 +186,7 @@ impl MaintenanceManager for SqliteStorage {
         let pool = Arc::clone(&self.pool);
         let event_type = event_type.to_string();
 
-        tokio::task::spawn_blocking(move || {
+        let result = tokio::task::spawn_blocking(move || {
             let conn = pool.writer()?;
 
             // Get candidates
@@ -328,7 +333,14 @@ impl MaintenanceManager for SqliteStorage {
             }))
         })
         .await
-        .context("spawn_blocking join error")?
+        .context("spawn_blocking join error")?;
+
+        if !dry_run {
+            // Compaction may have modified/deleted memories — full cache clear.
+            self.invalidate_query_cache();
+        }
+
+        result
     }
 
     async fn auto_compact(
@@ -338,7 +350,7 @@ impl MaintenanceManager for SqliteStorage {
     ) -> Result<serde_json::Value> {
         let pool = Arc::clone(&self.pool);
 
-        tokio::task::spawn_blocking(move || {
+        let result = tokio::task::spawn_blocking(move || {
             let conn = pool.writer()?;
 
             let total: i64 = conn
@@ -498,14 +510,21 @@ impl MaintenanceManager for SqliteStorage {
             }))
         })
         .await
-        .context("spawn_blocking join error")?
+        .context("spawn_blocking join error")?;
+
+        if !dry_run {
+            // Auto-compaction may have superseded memories — full cache clear.
+            self.invalidate_query_cache();
+        }
+
+        result
     }
 
     async fn clear_session(&self, session_id: &str) -> Result<usize> {
         let pool = Arc::clone(&self.pool);
         let session_id = session_id.to_string();
 
-        tokio::task::spawn_blocking(move || {
+        let deleted = tokio::task::spawn_blocking(move || {
             let conn = pool.writer()?;
 
             let tx = conn
@@ -547,7 +566,14 @@ impl MaintenanceManager for SqliteStorage {
             Ok::<_, anyhow::Error>(deleted)
         })
         .await
-        .context("spawn_blocking join error")?
+        .context("spawn_blocking join error")??;
+
+        if deleted > 0 {
+            // Bulk session deletion — full cache clear.
+            self.invalidate_query_cache();
+        }
+
+        Ok(deleted)
     }
 }
 

--- a/src/memory_core/storage/sqlite/advanced.rs
+++ b/src/memory_core/storage/sqlite/advanced.rs
@@ -967,10 +967,10 @@ impl AdvancedSearcher for SqliteStorage {
 
         // ── Cache check ──────────────────────────────────────────────────
         if let Ok(mut cache) = self.query_cache.lock()
-            && let Some((cached_at, results)) = cache.get(&cache_key)
-            && cached_at.elapsed().as_secs() < super::QUERY_CACHE_TTL_SECS
+            && let Some(cached) = cache.get(&cache_key)
+            && cached.inserted_at.elapsed().as_secs() < super::QUERY_CACHE_TTL_SECS
         {
-            return Ok(results.clone());
+            return Ok(cached.results.clone());
         }
 
         let pool = Arc::clone(&self.pool);
@@ -1079,6 +1079,11 @@ impl AdvancedSearcher for SqliteStorage {
             .context("spawn_blocking join error")??
         };
 
+        // Capture filter dimensions for cache metadata before opts moves into closure.
+        let cache_event_type_filter = opts.event_type.as_ref().map(|et| et.to_string());
+        let cache_project_filter = opts.project.clone();
+        let cache_session_id_filter = opts.session_id.clone();
+
         // Phases 3-6: RRF fusion, score refinement, graph enrichment,
         // abstention + dedup. Needs one reader for graph queries.
         #[cfg(feature = "real-embeddings")]
@@ -1125,7 +1130,16 @@ impl AdvancedSearcher for SqliteStorage {
 
         // ── Cache store ──────────────────────────────────────────────────
         if let Ok(mut cache) = self.query_cache.lock() {
-            cache.put(cache_key, (std::time::Instant::now(), results.clone()));
+            cache.put(
+                cache_key,
+                super::CachedQuery {
+                    inserted_at: std::time::Instant::now(),
+                    results: results.clone(),
+                    event_type_filter: cache_event_type_filter,
+                    project_filter: cache_project_filter,
+                    session_id_filter: cache_session_id_filter,
+                },
+            );
         }
 
         Ok(results)

--- a/src/memory_core/storage/sqlite/crud.rs
+++ b/src/memory_core/storage/sqlite/crud.rs
@@ -8,12 +8,17 @@ impl Storage for SqliteStorage {
         let metadata_json = serde_json::to_string(&input.metadata)
             .context("failed to serialize metadata to JSON")?;
 
+        // Capture filter dimensions for selective cache invalidation.
+        let invalidation_event_type = event_type_to_sql(&input.event_type);
+        let invalidation_project = input.project.clone();
+        let invalidation_session_id = input.session_id.clone();
+
         let pool = Arc::clone(&self.pool);
         let embedder = Arc::clone(&self.embedder);
         let id = id.to_string();
         let data = data.to_string();
         let importance = input.importance;
-        let event_type = event_type_to_sql(&input.event_type);
+        let event_type = invalidation_event_type.clone();
         let event_type_enum = input.event_type.clone();
         let session_id = input.session_id.clone();
         let project = input.project.clone();
@@ -379,7 +384,11 @@ impl Storage for SqliteStorage {
         .await
         .context("spawn_blocking join error")??;
 
-        self.invalidate_query_cache();
+        self.invalidate_cache_selective(
+            invalidation_event_type.as_deref(),
+            invalidation_project.as_deref(),
+            invalidation_session_id.as_deref(),
+        );
         self.refresh_hot_cache_best_effort();
 
         if matches!(outcome, StoreOutcome::Inserted)

--- a/src/memory_core/storage/sqlite/lifecycle.rs
+++ b/src/memory_core/storage/sqlite/lifecycle.rs
@@ -94,7 +94,7 @@ impl ExpirationSweeper for SqliteStorage {
     async fn sweep_expired(&self) -> Result<usize> {
         let pool = Arc::clone(&self.pool);
 
-        tokio::task::spawn_blocking(move || {
+        let count = tokio::task::spawn_blocking(move || {
             let conn = pool.writer()?;
             let tx = conn
                 .unchecked_transaction()
@@ -137,7 +137,14 @@ impl ExpirationSweeper for SqliteStorage {
             Ok::<_, anyhow::Error>(expired_ids.len())
         })
         .await
-        .context("spawn_blocking join error")?
+        .context("spawn_blocking join error")??;
+
+        if count > 0 {
+            // Expired memories could belong to any type/project/session, so full clear.
+            self.invalidate_query_cache();
+        }
+
+        Ok(count)
     }
 }
 

--- a/src/memory_core/storage/sqlite/mod.rs
+++ b/src/memory_core/storage/sqlite/mod.rs
@@ -28,7 +28,26 @@ use crate::memory_core::{
 const QUERY_CACHE_TTL_SECS: u64 = 60;
 /// Maximum number of entries in the query result cache.
 const QUERY_CACHE_CAPACITY: usize = 128;
-type QueryCache = Arc<Mutex<lru::LruCache<u64, (Instant, Vec<SemanticResult>)>>>;
+
+/// A cached query result with filter metadata for selective invalidation.
+///
+/// Storing the filter dimensions that were active when the query was cached
+/// allows `invalidate_cache_selective` to evict only entries whose results
+/// *could* be affected by a write with known attributes, instead of clearing
+/// the entire cache on every write.
+#[derive(Clone, Debug)]
+struct CachedQuery {
+    inserted_at: Instant,
+    results: Vec<SemanticResult>,
+    /// The event_type filter active when this query was cached (None = any type could match).
+    event_type_filter: Option<String>,
+    /// The project filter active when this query was cached (None = any project could match).
+    project_filter: Option<String>,
+    /// The session_id filter active when this query was cached (None = any session could match).
+    session_id_filter: Option<String>,
+}
+
+type QueryCache = Arc<Mutex<lru::LruCache<u64, CachedQuery>>>;
 
 /// Cosine similarity threshold for auto-supersession detection (primary signal).
 /// Semantic similarity catches updates even when wording changes significantly.
@@ -194,7 +213,10 @@ impl SqliteStorage {
         self
     }
 
-    /// Clears the query result cache. Called after every write operation.
+    /// Clears all query and hot cache entries unconditionally.
+    ///
+    /// Use for broad mutations (import, schema migration, clear_session)
+    /// where the scope of change is unknown or affects many records.
     pub(super) fn invalidate_query_cache(&self) {
         if let Ok(mut cache) = self.query_cache.lock() {
             cache.clear();
@@ -202,6 +224,77 @@ impl SqliteStorage {
         if let Some(hot_cache) = &self.hot_cache {
             hot_cache.clear();
         }
+    }
+
+    /// Selectively invalidate cache entries that *could* be affected by a
+    /// write with the given attributes.
+    ///
+    /// A cached query is evicted when:
+    /// - It had **no filter** on a dimension (could match anything), OR
+    /// - Its filter **matches** the written memory's attribute on that dimension.
+    ///
+    /// Entries whose filters *definitely exclude* the written memory are kept.
+    ///
+    /// The hot cache is always cleared because it is ordered by access count
+    /// and any write could shift rankings.
+    pub(super) fn invalidate_cache_selective(
+        &self,
+        event_type: Option<&str>,
+        project: Option<&str>,
+        session_id: Option<&str>,
+    ) {
+        if let Ok(mut cache) = self.query_cache.lock() {
+            // Collect keys to evict (cannot mutate while iterating the LRU).
+            let keys_to_evict: Vec<u64> = cache
+                .iter()
+                .filter_map(|(&key, entry)| {
+                    if Self::cache_entry_could_be_affected(entry, event_type, project, session_id) {
+                        Some(key)
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            for key in keys_to_evict {
+                cache.pop(&key);
+            }
+        }
+
+        // Hot cache is ranked by access_count; any write can shift rankings.
+        if let Some(hot_cache) = &self.hot_cache {
+            hot_cache.clear();
+        }
+    }
+
+    /// Returns `true` when a cached entry *could* contain results affected by
+    /// a write with the given attributes.
+    fn cache_entry_could_be_affected(
+        entry: &CachedQuery,
+        written_event_type: Option<&str>,
+        written_project: Option<&str>,
+        written_session_id: Option<&str>,
+    ) -> bool {
+        // For each dimension: if the cached query had no filter, the write
+        // could affect its results. If it had a filter, it's only affected
+        // when the filter matches the written value.
+        let event_type_affected = match (&entry.event_type_filter, written_event_type) {
+            (None, _) => true, // unfiltered query — any type could match
+            (_, None) => true, // written memory has no type — could appear in any query
+            (Some(f), Some(w)) => f == w,
+        };
+        let project_affected = match (&entry.project_filter, written_project) {
+            (None, _) => true,
+            (_, None) => true,
+            (Some(f), Some(w)) => f == w,
+        };
+        let session_affected = match (&entry.session_id_filter, written_session_id) {
+            (None, _) => true,
+            (_, None) => true,
+            (Some(f), Some(w)) => f == w,
+        };
+
+        event_type_affected && project_affected && session_affected
     }
 
     pub(super) async fn refresh_hot_cache(&self) -> Result<()> {
@@ -558,7 +651,7 @@ impl SqliteStorage {
 
         let pool = Arc::clone(&self.pool);
 
-        tokio::task::spawn_blocking(move || {
+        let counts = tokio::task::spawn_blocking(move || {
             let conn = pool.writer()?;
 
             let tx = conn
@@ -692,7 +785,12 @@ impl SqliteStorage {
             Ok::<_, anyhow::Error>((mem_count, rel_count))
         })
         .await
-        .context("spawn_blocking join error")?
+        .context("spawn_blocking join error")?;
+
+        // Bulk mutation — full cache clear.
+        self.invalidate_query_cache();
+
+        counts
     }
 
     #[cfg(test)]

--- a/src/memory_core/storage/sqlite/tests.rs
+++ b/src/memory_core/storage/sqlite/tests.rs
@@ -6152,3 +6152,358 @@ async fn hot_cache_refresh_task_releases_pool_on_drop() {
 
     assert!(weak_pool.upgrade().is_none());
 }
+
+// ── selective cache invalidation tests ────────────────────────────────
+
+#[tokio::test]
+async fn selective_invalidation_preserves_unrelated_cache_entries() {
+    let storage = SqliteStorage::new_in_memory().unwrap();
+
+    // Store two memories in different projects.
+    storage
+        .store(
+            "proj-a-1",
+            "alpha project memory about databases",
+            &MemoryInput {
+                content: "alpha project memory about databases".to_string(),
+                project: Some("alpha".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+    storage
+        .store(
+            "proj-b-1",
+            "beta project memory about networking",
+            &MemoryInput {
+                content: "beta project memory about networking".to_string(),
+                project: Some("beta".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    // Populate cache with a project-filtered query for "beta".
+    let beta_opts = SearchOptions {
+        project: Some("beta".to_string()),
+        ..Default::default()
+    };
+    let results_before =
+        <SqliteStorage as AdvancedSearcher>::advanced_search(&storage, "networking", 5, &beta_opts)
+            .await
+            .unwrap();
+    assert!(!results_before.is_empty());
+
+    // Store a new memory in project "alpha" — should NOT invalidate the "beta" cache.
+    storage
+        .store(
+            "proj-a-2",
+            "another alpha project memory about servers",
+            &MemoryInput {
+                content: "another alpha project memory about servers".to_string(),
+                project: Some("alpha".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    // The "beta" cache entry should still be present (not evicted).
+    let cache_key = super::helpers::query_cache_key("networking", 5, &beta_opts);
+    let cache_hit = storage
+        .query_cache
+        .lock()
+        .ok()
+        .and_then(|mut cache| cache.get(&cache_key).cloned());
+    assert!(
+        cache_hit.is_some(),
+        "beta project cache entry should survive alpha-project write"
+    );
+}
+
+#[tokio::test]
+async fn selective_invalidation_evicts_matching_project_entry() {
+    let storage = SqliteStorage::new_in_memory().unwrap();
+
+    storage
+        .store(
+            "proj-x-1",
+            "project x memory about databases",
+            &MemoryInput {
+                content: "project x memory about databases".to_string(),
+                project: Some("x".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    // Populate cache with a project-filtered query for "x".
+    let x_opts = SearchOptions {
+        project: Some("x".to_string()),
+        ..Default::default()
+    };
+    let _results =
+        <SqliteStorage as AdvancedSearcher>::advanced_search(&storage, "databases", 5, &x_opts)
+            .await
+            .unwrap();
+
+    // Store another memory in the SAME project "x" — should invalidate matching cache entry.
+    storage
+        .store(
+            "proj-x-2",
+            "project x memory about indexing strategies",
+            &MemoryInput {
+                content: "project x memory about indexing strategies".to_string(),
+                project: Some("x".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    let cache_key = super::helpers::query_cache_key("databases", 5, &x_opts);
+    let cache_hit = storage
+        .query_cache
+        .lock()
+        .ok()
+        .and_then(|mut cache| cache.get(&cache_key).cloned());
+    assert!(
+        cache_hit.is_none(),
+        "project x cache entry should be evicted by project x write"
+    );
+}
+
+#[tokio::test]
+async fn selective_invalidation_evicts_unfiltered_queries() {
+    let storage = SqliteStorage::new_in_memory().unwrap();
+
+    storage
+        .store(
+            "unf-1",
+            "unfiltered memory about caching strategies",
+            &MemoryInput {
+                content: "unfiltered memory about caching strategies".to_string(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    // Populate cache with an unfiltered query (no project/session/type filter).
+    let opts = SearchOptions::default();
+    let _results =
+        <SqliteStorage as AdvancedSearcher>::advanced_search(&storage, "caching", 5, &opts)
+            .await
+            .unwrap();
+
+    // Store a memory with specific project — unfiltered entries must be evicted.
+    storage
+        .store(
+            "unf-2",
+            "another memory about caching with project scope",
+            &MemoryInput {
+                content: "another memory about caching with project scope".to_string(),
+                project: Some("myproject".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    let cache_key = super::helpers::query_cache_key("caching", 5, &opts);
+    let cache_hit = storage
+        .query_cache
+        .lock()
+        .ok()
+        .and_then(|mut cache| cache.get(&cache_key).cloned());
+    assert!(
+        cache_hit.is_none(),
+        "unfiltered cache entry should be evicted by any write"
+    );
+}
+
+#[tokio::test]
+async fn import_invalidates_cache() {
+    let storage = SqliteStorage::new_in_memory().unwrap();
+
+    storage
+        .store(
+            "import-cache-1",
+            "memory before import for cache test",
+            &MemoryInput {
+                content: "memory before import for cache test".to_string(),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    // Populate cache.
+    let opts = SearchOptions::default();
+    let _results =
+        <SqliteStorage as AdvancedSearcher>::advanced_search(&storage, "before import", 5, &opts)
+            .await
+            .unwrap();
+
+    // Verify cache is populated.
+    let cache_key = super::helpers::query_cache_key("before import", 5, &opts);
+    let populated = storage
+        .query_cache
+        .lock()
+        .ok()
+        .and_then(|mut cache| cache.get(&cache_key).cloned());
+    assert!(
+        populated.is_some(),
+        "cache should be populated before import"
+    );
+
+    // Import data.
+    let export = storage.export_all().await.unwrap();
+    storage.import_all(&export).await.unwrap();
+
+    // Cache should be fully cleared after import.
+    let after_import = storage
+        .query_cache
+        .lock()
+        .ok()
+        .map(|cache| cache.len())
+        .unwrap_or(0);
+    assert_eq!(after_import, 0, "cache should be empty after import");
+}
+
+#[tokio::test]
+async fn sweep_expired_invalidates_cache() {
+    use crate::memory_core::ExpirationSweeper;
+
+    let storage = SqliteStorage::new_in_memory().unwrap();
+
+    // Store a memory with a 1-second TTL.
+    storage
+        .store(
+            "sweep-cache-1",
+            "ephemeral memory for sweep cache test",
+            &MemoryInput {
+                content: "ephemeral memory for sweep cache test".to_string(),
+                ttl_seconds: Some(1),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+    // Populate cache.
+    let opts = SearchOptions::default();
+    let _results =
+        <SqliteStorage as AdvancedSearcher>::advanced_search(&storage, "ephemeral", 5, &opts)
+            .await
+            .unwrap();
+
+    // Force the memory to be expired by backdating created_at.
+    {
+        let conn = storage.test_conn().unwrap();
+        conn.execute(
+            "UPDATE memories SET created_at = datetime('now', '-10 seconds') WHERE id = 'sweep-cache-1'",
+            [],
+        )
+        .unwrap();
+    }
+
+    // Run sweep.
+    let swept = storage.sweep_expired().await.unwrap();
+    assert_eq!(swept, 1, "should have swept 1 expired memory");
+
+    // Cache should be cleared.
+    let after_sweep = storage
+        .query_cache
+        .lock()
+        .ok()
+        .map(|cache| cache.len())
+        .unwrap_or(0);
+    assert_eq!(after_sweep, 0, "cache should be empty after sweep");
+}
+
+#[test]
+fn cache_entry_affected_check_logic() {
+    use std::time::Instant;
+
+    // Entry with project="alpha" filter.
+    let entry = CachedQuery {
+        inserted_at: Instant::now(),
+        results: Vec::new(),
+        event_type_filter: None,
+        project_filter: Some("alpha".to_string()),
+        session_id_filter: None,
+    };
+
+    // Write to project "alpha" — affected.
+    assert!(SqliteStorage::cache_entry_could_be_affected(
+        &entry,
+        None,
+        Some("alpha"),
+        None
+    ));
+
+    // Write to project "beta" — NOT affected.
+    assert!(!SqliteStorage::cache_entry_could_be_affected(
+        &entry,
+        None,
+        Some("beta"),
+        None
+    ));
+
+    // Write with no project — affected (could match unfiltered project dimension).
+    assert!(SqliteStorage::cache_entry_could_be_affected(
+        &entry, None, None, None
+    ));
+
+    // Entry with all filters set.
+    let strict_entry = CachedQuery {
+        inserted_at: Instant::now(),
+        results: Vec::new(),
+        event_type_filter: Some("decision".to_string()),
+        project_filter: Some("alpha".to_string()),
+        session_id_filter: Some("sess-1".to_string()),
+    };
+
+    // Write matches all three dimensions.
+    assert!(SqliteStorage::cache_entry_could_be_affected(
+        &strict_entry,
+        Some("decision"),
+        Some("alpha"),
+        Some("sess-1"),
+    ));
+
+    // Write matches event_type and project, but different session — NOT affected.
+    assert!(!SqliteStorage::cache_entry_could_be_affected(
+        &strict_entry,
+        Some("decision"),
+        Some("alpha"),
+        Some("sess-2"),
+    ));
+
+    // Write with different event_type — NOT affected.
+    assert!(!SqliteStorage::cache_entry_could_be_affected(
+        &strict_entry,
+        Some("observation"),
+        Some("alpha"),
+        Some("sess-1"),
+    ));
+
+    // Unfiltered entry — always affected.
+    let unfiltered = CachedQuery {
+        inserted_at: Instant::now(),
+        results: Vec::new(),
+        event_type_filter: None,
+        project_filter: None,
+        session_id_filter: None,
+    };
+    assert!(SqliteStorage::cache_entry_could_be_affected(
+        &unfiltered,
+        Some("anything"),
+        Some("any_project"),
+        Some("any_session"),
+    ));
+}


### PR DESCRIPTION
## Summary

### Bug Fixes (6 missing invalidation sites)
- `import_all()` — was missing cache invalidation entirely after bulk import
- `sweep_expired()` — was missing cache invalidation after deleting expired memories
- `clear_session()` — was missing cache invalidation after session deletion
- `consolidate()`, `compact()`, `auto_compact()` — were missing cache invalidation after mutations

### Selective Cache Invalidation
- New `CachedQuery` struct wraps cached results with filter metadata (event_type, project, session_id)
- `store()` now uses selective invalidation: only evicts cache entries whose filters could match the written memory
- Cached queries with non-overlapping filters are preserved (e.g., writing to project "alpha" keeps project "beta" cache)
- All other write operations use full clear (safe default)

### Strategy
| Operation | Strategy | Reason |
|-----------|----------|--------|
| `store()` | Selective | Attributes available, most frequent path |
| `update/delete` | Full clear | Attributes not cheaply available |
| `import/sweep/consolidate/compact` | Full clear | Bulk mutations |

## Test plan
- [x] `cargo test --all-features` (6 new tests, all pass)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] Selective invalidation preserves unrelated cache entries (tested)
- [x] Import/sweep now properly invalidate (tested)

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed cache inconsistencies after maintenance operations including consolidation, compaction, and session clearing.
  * Cache now properly invalidates after expired memory cleanup.

* **Performance**
  * Implemented selective cache invalidation to preserve unrelated query results, reducing unnecessary cache clears.
  * Cache now tracks metadata to enable granular invalidation based on applied filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->