### PR TITLE
refactor(bench): extract shared utilities to bench_utils module

### DIFF
--- a/benches/bench_utils/formatting.rs
+++ b/benches/bench_utils/formatting.rs
@@ -1,0 +1,74 @@
+/// Truncate a string to at most `max_chars` characters.
+pub fn truncate(value: &str, max_chars: usize) -> String {
+    value.chars().take(max_chars).collect()
+}
+
+/// Compute a percentage from correct/total counts.
+pub fn pct(correct: usize, total: usize) -> f64 {
+    if total == 0 {
+        0.0
+    } else {
+        #[allow(clippy::cast_precision_loss)]
+        {
+            correct as f64 / total as f64 * 100.0
+        }
+    }
+}
+
+/// Map a percentage to a letter grade.
+pub fn grade(percentage: f64) -> &'static str {
+    if percentage >= 90.0 {
+        "A"
+    } else if percentage >= 75.0 {
+        "B"
+    } else if percentage >= 60.0 {
+        "C"
+    } else if percentage >= 40.0 {
+        "D"
+    } else {
+        "F"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_truncate_short() {
+        assert_eq!(truncate("hello", 10), "hello");
+    }
+
+    #[test]
+    fn test_truncate_exact() {
+        assert_eq!(truncate("hello", 5), "hello");
+    }
+
+    #[test]
+    fn test_truncate_long() {
+        assert_eq!(truncate("hello world", 5), "hello");
+    }
+
+    #[test]
+    fn test_pct_normal() {
+        assert!((pct(3, 4) - 75.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_pct_zero_total() {
+        assert!((pct(0, 0)).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_grade_boundaries() {
+        assert_eq!(grade(95.0), "A");
+        assert_eq!(grade(90.0), "A");
+        assert_eq!(grade(80.0), "B");
+        assert_eq!(grade(75.0), "B");
+        assert_eq!(grade(65.0), "C");
+        assert_eq!(grade(60.0), "C");
+        assert_eq!(grade(45.0), "D");
+        assert_eq!(grade(40.0), "D");
+        assert_eq!(grade(30.0), "F");
+    }
+}

--- a/benches/bench_utils/metrics.rs
+++ b/benches/bench_utils/metrics.rs
@@ -1,0 +1,45 @@
+use anyhow::Result;
+
+// ── Peak RSS tracking ─────────────────────────────────────────────────────
+
+#[derive(Debug, Default)]
+pub struct PeakRss {
+    pub peak_kb: u64,
+}
+
+impl PeakRss {
+    pub fn sample(&mut self) {
+        if let Ok(kb) = current_rss_kb()
+            && kb > self.peak_kb
+        {
+            self.peak_kb = kb;
+        }
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn current_rss_kb() -> Result<u64> {
+    let pid = std::process::id();
+    let output = std::process::Command::new("ps")
+        .args(["-o", "rss=", "-p", &pid.to_string()])
+        .output()?;
+    let text = String::from_utf8_lossy(&output.stdout);
+    Ok(text.trim().parse()?)
+}
+
+#[cfg(target_os = "linux")]
+fn current_rss_kb() -> Result<u64> {
+    let status = std::fs::read_to_string("/proc/self/status")?;
+    for line in status.lines() {
+        if let Some(value) = line.strip_prefix("VmRSS:") {
+            let kb: u64 = value.trim().trim_end_matches(" kB").trim().parse()?;
+            return Ok(kb);
+        }
+    }
+    Ok(0)
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux")))]
+fn current_rss_kb() -> Result<u64> {
+    Ok(0)
+}

--- a/benches/bench_utils/mod.rs
+++ b/benches/bench_utils/mod.rs
@@ -1,0 +1,3 @@
+pub mod formatting;
+pub mod metrics;
+pub mod openai_types;

--- a/benches/bench_utils/openai_types.rs
+++ b/benches/bench_utils/openai_types.rs
@@ -1,0 +1,43 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize)]
+pub struct OpenAiChatRequest {
+    pub model: String,
+    pub temperature: f32,
+    pub max_tokens: u16,
+    pub messages: Vec<OpenAiMessage>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct OpenAiMessage {
+    pub role: String,
+    pub content: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OpenAiChatResponse {
+    pub choices: Vec<OpenAiChoice>,
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub usage: Option<OpenAiUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OpenAiUsage {
+    #[allow(dead_code)]
+    pub prompt_tokens: u64,
+    #[allow(dead_code)]
+    pub completion_tokens: u64,
+    #[allow(dead_code)]
+    pub total_tokens: u64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OpenAiChoice {
+    pub message: OpenAiResponseMessage,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct OpenAiResponseMessage {
+    pub content: String,
+}

--- a/benches/locomo/display.rs
+++ b/benches/locomo/display.rs
@@ -1,17 +1,7 @@
 use std::collections::BTreeMap;
 
+use crate::bench_utils::formatting::{grade, pct};
 use crate::types::{CategoryResult, LoCoMoSummary};
-
-pub(crate) fn pct(correct: usize, total: usize) -> f64 {
-    if total == 0 {
-        0.0
-    } else {
-        #[allow(clippy::cast_precision_loss)]
-        {
-            correct as f64 / total as f64 * 100.0
-        }
-    }
-}
 
 fn avg_f1(cat: &CategoryResult) -> f64 {
     if cat.total == 0 {
@@ -32,20 +22,6 @@ fn avg_evidence(cat: &CategoryResult) -> f64 {
         {
             cat.evidence_recall_sum / cat.total as f64 * 100.0
         }
-    }
-}
-
-fn grade(percentage: f64) -> &'static str {
-    if percentage >= 90.0 {
-        "A"
-    } else if percentage >= 75.0 {
-        "B"
-    } else if percentage >= 60.0 {
-        "C"
-    } else if percentage >= 40.0 {
-        "D"
-    } else {
-        "F"
     }
 }
 

--- a/benches/locomo/main.rs
+++ b/benches/locomo/main.rs
@@ -27,6 +27,8 @@ enum ScoringMode {
     LlmF1,
 }
 
+#[path = "../bench_utils/mod.rs"]
+mod bench_utils;
 mod dataset;
 mod display;
 mod llm;
@@ -34,6 +36,9 @@ mod openai_embedder;
 mod scoring;
 mod seeding;
 mod types;
+
+use bench_utils::formatting::{pct, truncate};
+use bench_utils::metrics::PeakRss;
 
 const DEFAULT_LLM_MODEL: &str = "gpt-4o-mini";
 const DEFAULT_LOCAL_MODEL: &str = "qwen3.5-9b-optiq";
@@ -87,56 +92,6 @@ struct Args {
     /// If omitted, defaults to substring unless --llm-judge/--local implies llm-f1.
     #[arg(long, value_enum)]
     scoring_mode: Option<ScoringMode>,
-}
-
-// ── Peak RSS tracking ───────────────────────────────────────────────────
-
-#[derive(Debug, Default)]
-struct PeakRss {
-    peak_kb: u64,
-}
-
-impl PeakRss {
-    fn sample(&mut self) {
-        if let Ok(kb) = current_rss_kb()
-            && kb > self.peak_kb
-        {
-            self.peak_kb = kb;
-        }
-    }
-}
-
-#[cfg(target_os = "macos")]
-fn current_rss_kb() -> Result<u64> {
-    let pid = std::process::id();
-    let output = std::process::Command::new("ps")
-        .args(["-o", "rss=", "-p", &pid.to_string()])
-        .output()?;
-    let text = String::from_utf8_lossy(&output.stdout);
-    Ok(text.trim().parse()?)
-}
-
-#[cfg(target_os = "linux")]
-fn current_rss_kb() -> Result<u64> {
-    let status = std::fs::read_to_string("/proc/self/status")?;
-    for line in status.lines() {
-        if let Some(value) = line.strip_prefix("VmRSS:") {
-            let kb: u64 = value.trim().trim_end_matches(" kB").trim().parse()?;
-            return Ok(kb);
-        }
-    }
-    Ok(0)
-}
-
-#[cfg(not(any(target_os = "macos", target_os = "linux")))]
-fn current_rss_kb() -> Result<u64> {
-    Ok(0)
-}
-
-// ── Helpers ─────────────────────────────────────────────────────────────
-
-fn truncate(value: &str, max_chars: usize) -> String {
-    value.chars().take(max_chars).collect()
 }
 
 // ── Main ────────────────────────────────────────────────────────────────
@@ -431,7 +386,7 @@ fn main() -> Result<()> {
         avg_query_ms,
         peak_rss_kb: rss.peak_kb,
         raw_correct: total_correct,
-        raw_percentage: display::pct(total_correct, total_queries),
+        raw_percentage: pct(total_correct, total_queries),
         mean_f1,
         mean_evidence_recall,
         categories,

--- a/benches/locomo/types.rs
+++ b/benches/locomo/types.rs
@@ -2,6 +2,10 @@ use std::collections::BTreeMap;
 
 use serde::{Deserialize, Serialize};
 
+pub(crate) use crate::bench_utils::openai_types::{
+    OpenAiChatRequest, OpenAiChatResponse, OpenAiMessage,
+};
+
 // ── LoCoMo dataset types ────────────────────────────────────────────────
 
 #[derive(Debug, Deserialize)]
@@ -112,48 +116,4 @@ pub(crate) struct LoCoMoSummary {
     pub mean_f1: f64,
     pub mean_evidence_recall: f64,
     pub categories: BTreeMap<String, CategoryResult>,
-}
-
-// ── OpenAI types ────────────────────────────────────────────────────────
-
-#[derive(Debug, Serialize)]
-pub(crate) struct OpenAiChatRequest {
-    pub model: String,
-    pub temperature: f32,
-    pub max_tokens: u16,
-    pub messages: Vec<OpenAiMessage>,
-}
-
-#[derive(Debug, Serialize)]
-pub(crate) struct OpenAiMessage {
-    pub role: String,
-    pub content: String,
-}
-
-#[derive(Debug, Deserialize)]
-pub(crate) struct OpenAiChatResponse {
-    pub choices: Vec<OpenAiChoice>,
-    #[serde(default)]
-    #[allow(dead_code)]
-    pub usage: Option<OpenAiUsage>,
-}
-
-#[derive(Debug, Deserialize)]
-pub(crate) struct OpenAiUsage {
-    #[allow(dead_code)]
-    pub prompt_tokens: u64,
-    #[allow(dead_code)]
-    pub completion_tokens: u64,
-    #[allow(dead_code)]
-    pub total_tokens: u64,
-}
-
-#[derive(Debug, Deserialize)]
-pub(crate) struct OpenAiChoice {
-    pub message: OpenAiResponseMessage,
-}
-
-#[derive(Debug, Deserialize)]
-pub(crate) struct OpenAiResponseMessage {
-    pub content: String,
 }

--- a/benches/longmemeval/helpers.rs
+++ b/benches/longmemeval/helpers.rs
@@ -1,52 +1,15 @@
 use std::collections::BTreeMap;
 use std::sync::{Mutex, OnceLock};
 
-use anyhow::Result;
-
 use crate::types::{CategoryResult, Hit, QuestionEvaluation};
 
-// ── Peak RSS tracking ─────────────────────────────────────────────────────
-
-#[derive(Debug, Default)]
-pub(crate) struct PeakRss {
-    pub peak_kb: u64,
-}
-
-impl PeakRss {
-    pub fn sample(&mut self) {
-        if let Ok(kb) = current_rss_kb()
-            && kb > self.peak_kb
-        {
-            self.peak_kb = kb;
-        }
-    }
-}
-
-#[cfg(target_os = "macos")]
-fn current_rss_kb() -> Result<u64> {
-    use std::process::Command;
-    let pid = std::process::id();
-    let output = Command::new("ps")
-        .args(["-o", "rss=", "-p", &pid.to_string()])
-        .output()?;
-    let text = String::from_utf8_lossy(&output.stdout);
-    let kb: u64 = text.trim().parse()?;
-    Ok(kb)
-}
-
-#[cfg(not(target_os = "macos"))]
-fn current_rss_kb() -> Result<u64> {
-    Ok(0)
-}
+pub(crate) use crate::bench_utils::formatting::{grade, pct, truncate};
+pub(crate) use crate::bench_utils::metrics::PeakRss;
 
 // ── Formatting helpers ────────────────────────────────────────────────────
 
 pub(crate) fn iso(ts: chrono::DateTime<chrono::Utc>) -> String {
     ts.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
-}
-
-pub(crate) fn truncate(value: &str, max_chars: usize) -> String {
-    value.chars().take(max_chars).collect()
 }
 
 pub(crate) fn substring_match(hits: &[Hit], expected_substring: &str) -> bool {
@@ -65,30 +28,6 @@ pub(crate) fn categories() -> Vec<(&'static str, &'static str)> {
         ("knowledge_update", "Knowledge Update"),
         ("abstention", "Abstention"),
     ]
-}
-
-pub(crate) fn grade(percentage: f64) -> &'static str {
-    if percentage >= 90.0 {
-        "A"
-    } else if percentage >= 75.0 {
-        "B"
-    } else if percentage >= 60.0 {
-        "C"
-    } else if percentage >= 40.0 {
-        "D"
-    } else {
-        "F"
-    }
-}
-
-pub(crate) fn pct(correct: usize, total: usize) -> f64 {
-    if total == 0 {
-        return 0.0;
-    }
-    #[allow(clippy::cast_precision_loss)]
-    {
-        correct as f64 / total as f64 * 100.0
-    }
 }
 
 pub(crate) fn summarize_totals(

--- a/benches/longmemeval/main.rs
+++ b/benches/longmemeval/main.rs
@@ -13,6 +13,8 @@ use mag::benchmarking::{self, DatasetKind};
 use mag::memory_core::storage::sqlite::SqliteStorage;
 use mag::memory_core::{ABSTENTION_MIN_TEXT, OnnxEmbedder};
 
+#[path = "../bench_utils/mod.rs"]
+mod bench_utils;
 mod display;
 mod grid_search;
 mod helpers;
@@ -84,7 +86,7 @@ fn main() -> Result<()> {
     {
         bail!("--dataset-path/--force-refresh/--temp-dataset/--questions require --official");
     }
-    let mut rss = helpers::PeakRss::default();
+    let mut rss = bench_utils::metrics::PeakRss::default();
     rss.sample();
 
     let runtime = tokio::runtime::Runtime::new()?;

--- a/benches/longmemeval/types.rs
+++ b/benches/longmemeval/types.rs
@@ -4,6 +4,10 @@ use mag::benchmarking::BenchmarkMetadata;
 use mag::memory_core::ScoringParams;
 use serde::{Deserialize, Serialize};
 
+pub(crate) use crate::bench_utils::openai_types::{
+    OpenAiChatRequest, OpenAiChatResponse, OpenAiMessage,
+};
+
 // ── Official LongMemEval_S dataset types ──────────────────────────────────
 
 #[derive(Debug, Deserialize)]
@@ -137,46 +141,4 @@ pub(crate) struct GridSearchSummary {
 pub(crate) struct Hit {
     pub content: String,
     pub score: f32,
-}
-
-// ── OpenAI types ──────────────────────────────────────────────────────────
-
-#[derive(Debug, Serialize)]
-pub(crate) struct OpenAiChatRequest {
-    pub model: String,
-    pub temperature: f32,
-    pub max_tokens: u16,
-    pub messages: Vec<OpenAiMessage>,
-}
-
-#[derive(Debug, Serialize)]
-pub(crate) struct OpenAiMessage {
-    pub role: String,
-    pub content: String,
-}
-
-#[derive(Debug, Deserialize)]
-pub(crate) struct OpenAiChatResponse {
-    pub choices: Vec<OpenAiChoice>,
-    #[serde(default)]
-    pub usage: Option<OpenAiUsage>,
-}
-
-#[derive(Debug, Deserialize)]
-pub(crate) struct OpenAiUsage {
-    pub prompt_tokens: u64,
-    #[allow(dead_code)]
-    pub completion_tokens: u64,
-    #[allow(dead_code)]
-    pub total_tokens: u64,
-}
-
-#[derive(Debug, Deserialize)]
-pub(crate) struct OpenAiChoice {
-    pub message: OpenAiResponseMessage,
-}
-
-#[derive(Debug, Deserialize)]
-pub(crate) struct OpenAiResponseMessage {
-    pub content: String,
 }


### PR DESCRIPTION
## Summary
Extracts duplicated code from `benches/locomo/` and `benches/longmemeval/` into shared `benches/bench_utils/` module.

### New files
- `bench_utils/mod.rs` — re-exports
- `bench_utils/metrics.rs` — `PeakRss` + `current_rss_kb()` (macOS + Linux unified)
- `bench_utils/formatting.rs` — `pct()`, `grade()`, `truncate()` + unit tests
- `bench_utils/openai_types.rs` — 6 OpenAI chat API types

### Deduplication
- Removed identical `PeakRss`, `truncate`, `pct`, `grade` from both benches
- Removed identical OpenAI types from both `types.rs` files
- Both binaries include via `#[path = "../bench_utils/mod.rs"]` (no Cargo.toml changes)
- Net: -226 lines removed, +185 added (41 lines saved)

## Test plan
- [x] `cargo test --all-features` (all pass)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] Both bench binaries compile: `locomo_bench`, `longmemeval_bench`

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized benchmark utilities into a dedicated bench utils area and replaced local helpers with shared exports.
  * Moved OpenAI request/response types to a single shared location and re-exported them for crate-wide use.
* **New Features**
  * Added shared formatting helpers and a cross-platform memory-usage tracker for benchmarks.
* **Tests**
  * Added unit tests covering formatting helper behavior (truncation, percentage, grade boundaries).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->