### PR TITLE
feat(memory): expand supersession to UserFact and Reminder with entity scoping (closes #37)

### DIFF
--- a/src/memory_core/mod.rs
+++ b/src/memory_core/mod.rs
@@ -175,6 +175,7 @@ impl EventType {
             EventType::TaskCompletion => Some(0.85),
             EventType::Decision => Some(0.80),
             EventType::LessonLearned => Some(0.85),
+            EventType::UserFact => Some(0.85),
             _ => None,
         }
     }
@@ -183,7 +184,11 @@ impl EventType {
     pub fn is_supersession_type(&self) -> bool {
         matches!(
             self,
-            EventType::Decision | EventType::LessonLearned | EventType::UserPreference
+            EventType::Decision
+                | EventType::LessonLearned
+                | EventType::UserPreference
+                | EventType::UserFact
+                | EventType::Reminder
         )
     }
 
@@ -201,6 +206,7 @@ impl EventType {
             EventType::TaskCompletion,
             EventType::Decision,
             EventType::LessonLearned,
+            EventType::UserFact,
         ]
     }
 }

--- a/src/memory_core/storage/sqlite/crud.rs
+++ b/src/memory_core/storage/sqlite/crud.rs
@@ -148,37 +148,55 @@ impl Storage for SqliteStorage {
             if let Some(ref event_type_value) = event_type
                 && event_type_enum.as_ref().is_some_and(|et| et.is_supersession_type())
             {
+                // Build supersession query with optional entity_id narrowing
+                let entity_narrowing = if entity_id.is_some() {
+                    " AND entity_id = ?3"
+                } else {
+                    ""
+                };
+                let sup_sql = format!(
+                    "SELECT id, content, embedding FROM memories
+                     WHERE event_type = ?1
+                       AND id != ?2
+                       AND superseded_by_id IS NULL
+                       AND (ttl_seconds IS NULL OR datetime(created_at, '+' || ttl_seconds || ' seconds') > datetime('now'))
+                       {entity_narrowing}
+                     ORDER BY created_at DESC LIMIT 10"
+                );
                 let mut sup_stmt = tx
-                    .prepare(
-                        "SELECT id, content, embedding FROM memories
-                         WHERE event_type = ?1
-                           AND id != ?2
-                           AND superseded_by_id IS NULL
-                           AND (ttl_seconds IS NULL OR datetime(created_at, '+' || ttl_seconds || ' seconds') > datetime('now'))
-                         ORDER BY created_at DESC LIMIT 10",
-                    )
+                    .prepare(&sup_sql)
                     .context("failed to prepare supersession query")?;
 
-                let sup_rows = sup_stmt
-                    .query_map(params![event_type_value, &id_for_store], |row| {
-                        Ok((
-                            row.get::<_, String>(0)?,
-                            row.get::<_, String>(1)?,
-                            row.get::<_, Option<Vec<u8>>>(2).ok().flatten(),
-                        ))
-                    })
-                    .context("failed to execute supersession query")?;
+                let row_mapper = |row: &rusqlite::Row<'_>| {
+                    Ok((
+                        row.get::<_, String>(0)?,
+                        row.get::<_, String>(1)?,
+                        row.get::<_, Option<Vec<u8>>>(2).ok().flatten(),
+                    ))
+                };
+                let sup_candidates: Vec<(String, String, Option<Vec<u8>>)> =
+                    if let Some(ref eid) = entity_id {
+                        sup_stmt
+                            .query_map(params![event_type_value, &id_for_store, eid], row_mapper)
+                            .context("failed to execute supersession query")?
+                            .collect::<Result<Vec<_>, _>>()
+                            .context("failed to decode supersession rows")?
+                    } else {
+                        sup_stmt
+                            .query_map(params![event_type_value, &id_for_store], row_mapper)
+                            .context("failed to execute supersession query")?
+                            .collect::<Result<Vec<_>, _>>()
+                            .context("failed to decode supersession rows")?
+                    };
 
                 let emb_data = &embedding_vec;
-                for row in sup_rows {
-                    let (candidate_id, candidate_content, candidate_emb) =
-                        row.context("failed to decode supersession row")?;
+                for (candidate_id, candidate_content, candidate_emb) in &sup_candidates {
 
                     // Primary signal: cosine similarity (catches semantic overlap
                     // even when wording changes significantly)
                     let cosine_ok = if let Some(emb_blob) = candidate_emb
                         && let Ok(candidate_embedding) =
-                            decode_embedding(&emb_blob)
+                            decode_embedding(emb_blob)
                     {
                         let cosine = cosine_similarity(emb_data, &candidate_embedding);
                         cosine >= SUPERSESSION_COSINE_THRESHOLD
@@ -191,12 +209,12 @@ impl Storage for SqliteStorage {
 
                     // Secondary signal: Jaccard word overlap (prevents cross-topic
                     // false matches from cosine alone)
-                    let jaccard = jaccard_similarity(&data, &candidate_content, 3);
+                    let jaccard = jaccard_similarity(&data, candidate_content, 3);
                     if jaccard < SUPERSESSION_JACCARD_THRESHOLD {
                         continue;
                     }
 
-                    superseded_ids.push(candidate_id);
+                    superseded_ids.push(candidate_id.clone());
                 }
                 drop(sup_stmt);
             }

--- a/src/memory_core/storage/sqlite/schema.rs
+++ b/src/memory_core/storage/sqlite/schema.rs
@@ -109,6 +109,7 @@ pub(super) fn initialize_schema(conn: &Connection, embedding_dim: usize) -> Resu
         "CREATE INDEX IF NOT EXISTS idx_memories_project_created_active ON memories(project, created_at DESC) WHERE superseded_by_id IS NULL",
         "CREATE INDEX IF NOT EXISTS idx_memories_session_created_active ON memories(session_id, created_at DESC) WHERE superseded_by_id IS NULL",
         "CREATE INDEX IF NOT EXISTS idx_memories_event_created_active ON memories(event_type, created_at DESC) WHERE superseded_by_id IS NULL",
+        "CREATE INDEX IF NOT EXISTS idx_memories_entity_id ON memories(entity_id)",
         "CREATE INDEX IF NOT EXISTS idx_memories_canonical ON memories(canonical_hash)",
         "CREATE INDEX IF NOT EXISTS idx_memories_version_chain ON memories(version_chain_id)",
         "CREATE INDEX IF NOT EXISTS idx_memories_superseded ON memories(superseded_by_id)",

--- a/src/memory_core/storage/sqlite/tests.rs
+++ b/src/memory_core/storage/sqlite/tests.rs
@@ -7075,3 +7075,171 @@ async fn test_search_cache_hit_returns_same_results() {
         );
     }
 }
+
+#[tokio::test]
+async fn test_user_fact_supersession_same_entity() {
+    let storage = SqliteStorage::new_in_memory_with_embedder(Arc::new(KeywordEmbedder)).unwrap();
+
+    <SqliteStorage as Storage>::store(
+        &storage,
+        "uf-a",
+        "alpha Jim is in France",
+        &MemoryInput {
+            event_type: Some(EventType::UserFact),
+            entity_id: Some("jim".to_string()),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    <SqliteStorage as Storage>::store(
+        &storage,
+        "uf-b",
+        "alpha Jim is in Germany",
+        &MemoryInput {
+            event_type: Some(EventType::UserFact),
+            entity_id: Some("jim".to_string()),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let (superseded_by, _) = storage.debug_get_versioning_fields("uf-a").unwrap();
+    assert_eq!(
+        superseded_by.as_deref(),
+        Some("uf-b"),
+        "first UserFact should be superseded by second with same entity_id"
+    );
+}
+
+#[tokio::test]
+async fn test_user_fact_no_cross_entity_supersession() {
+    let storage = SqliteStorage::new_in_memory_with_embedder(Arc::new(KeywordEmbedder)).unwrap();
+
+    <SqliteStorage as Storage>::store(
+        &storage,
+        "uf-jim",
+        "alpha Jim is in France",
+        &MemoryInput {
+            event_type: Some(EventType::UserFact),
+            entity_id: Some("jim".to_string()),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    <SqliteStorage as Storage>::store(
+        &storage,
+        "uf-alice",
+        "alpha Alice is 30 years old",
+        &MemoryInput {
+            event_type: Some(EventType::UserFact),
+            entity_id: Some("alice".to_string()),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let (superseded_by, _) = storage.debug_get_versioning_fields("uf-jim").unwrap();
+    assert!(
+        superseded_by.is_none(),
+        "UserFact with different entity_id should NOT be superseded"
+    );
+}
+
+#[tokio::test]
+async fn test_reminder_supersession() {
+    let storage = SqliteStorage::new_in_memory_with_embedder(Arc::new(KeywordEmbedder)).unwrap();
+
+    <SqliteStorage as Storage>::store(
+        &storage,
+        "rem-a",
+        "alpha reminder: team standup at 9am",
+        &MemoryInput {
+            event_type: Some(EventType::Reminder),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    <SqliteStorage as Storage>::store(
+        &storage,
+        "rem-b",
+        "alpha reminder: team standup moved to 10am",
+        &MemoryInput {
+            event_type: Some(EventType::Reminder),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let (superseded_by, _) = storage.debug_get_versioning_fields("rem-a").unwrap();
+    assert_eq!(
+        superseded_by.as_deref(),
+        Some("rem-b"),
+        "first Reminder should be superseded by second"
+    );
+}
+
+#[tokio::test]
+async fn test_entity_scoped_decision_supersession() {
+    let storage = SqliteStorage::new_in_memory_with_embedder(Arc::new(KeywordEmbedder)).unwrap();
+
+    <SqliteStorage as Storage>::store(
+        &storage,
+        "dec-a",
+        "alpha decided to use React for frontend",
+        &MemoryInput {
+            event_type: Some(EventType::Decision),
+            entity_id: Some("frontend".to_string()),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    <SqliteStorage as Storage>::store(
+        &storage,
+        "dec-b",
+        "alpha decided to use Vue for frontend",
+        &MemoryInput {
+            event_type: Some(EventType::Decision),
+            entity_id: Some("frontend".to_string()),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    <SqliteStorage as Storage>::store(
+        &storage,
+        "dec-c",
+        "alpha decided to use Postgres for database",
+        &MemoryInput {
+            event_type: Some(EventType::Decision),
+            entity_id: Some("database".to_string()),
+            ..Default::default()
+        },
+    )
+    .await
+    .unwrap();
+
+    let (superseded_by_a, _) = storage.debug_get_versioning_fields("dec-a").unwrap();
+    assert_eq!(
+        superseded_by_a.as_deref(),
+        Some("dec-b"),
+        "first Decision should be superseded by second with same entity_id"
+    );
+
+    let (superseded_by_c, _) = storage.debug_get_versioning_fields("dec-c").unwrap();
+    assert!(
+        superseded_by_c.is_none(),
+        "Decision with different entity_id should NOT be superseded"
+    );
+}


### PR DESCRIPTION
## Summary
- Expand `is_supersession_type()` to include `UserFact` and `Reminder` event types, enabling temporal fact reconciliation (e.g. "Jim is in France" superseded by "Jim is in Germany")
- Add entity_id-based narrowing to the supersession query so that facts about different entities never supersede each other
- Add `UserFact` to `dedup_threshold()` (0.85) and `types_with_dedup_threshold()`
- Add `idx_memories_entity_id` index for efficient entity-scoped queries
- LoCoMo benchmark unaffected: benchmark memories have no `event_type` set

## Changes
- `src/memory_core/mod.rs`: Expand `is_supersession_type()`, `dedup_threshold()`, `types_with_dedup_threshold()`
- `src/memory_core/storage/sqlite/crud.rs`: Dynamic supersession query with optional `AND entity_id = ?3` clause
- `src/memory_core/storage/sqlite/schema.rs`: Add `idx_memories_entity_id` index
- `src/memory_core/storage/sqlite/tests.rs`: 4 new tests covering same-entity supersession, cross-entity isolation, reminder supersession, and entity-scoped decision supersession

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] All 6 supersession tests pass (2 existing + 4 new)
- [x] 355/356 tests pass (1 pre-existing flaky test unrelated to this change)
- [ ] Verify LoCoMo benchmark shows no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced deduplication and supersession logic for UserFact and Reminder events, preventing outdated information from persisting.
  * Improved entity-scoped memory handling to prevent cross-entity interference.

* **Performance**
  * Added database optimization for faster entity-based memory lookups.

* **Tests**
  * Expanded test coverage for memory consistency across event types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->