### PR TITLE
feat(bench): add E2E word-overlap scoring mode (closes #38)

### DIFF
--- a/benches/locomo/display.rs
+++ b/benches/locomo/display.rs
@@ -40,6 +40,7 @@ pub(crate) fn print_results(summary: &LoCoMoSummary) {
     let score_col = match summary.scoring_mode.as_str() {
         "word-overlap" => "WdOvlp",
         "llm-f1" => "LlmF1",
+        "e2e-word-overlap" => "E2eWO",
         "substring" => "TokF1",
         _ => "TokF1",
     };
@@ -94,6 +95,7 @@ pub(crate) fn print_results(summary: &LoCoMoSummary) {
     let score_label = match summary.scoring_mode.as_str() {
         "word-overlap" => "WORD OVERLAP",
         "llm-f1" => "MEAN LLM F1",
+        "e2e-word-overlap" => "E2E WORD OVERLAP",
         _ => "MEAN TOKEN F1",
     };
 

--- a/benches/locomo/main.rs
+++ b/benches/locomo/main.rs
@@ -25,6 +25,8 @@ enum ScoringMode {
     WordOverlap,
     /// LLM-generated answer scored via token F1 (requires --llm-judge or --local).
     LlmF1,
+    /// E2E: LLM-generated answer scored via word-overlap recall (requires --llm-judge or --local).
+    E2eWordOverlap,
 }
 
 #[path = "../bench_utils/mod.rs"]
@@ -88,10 +90,13 @@ struct Args {
     /// Requires OPENAI_API_KEY in environment or .env.local file.
     #[arg(long)]
     openai_embeddings: bool,
-    /// Scoring mode: substring, word-overlap, or llm-f1.
+    /// Scoring mode: substring, word-overlap, llm-f1, or e2e-word-overlap.
     /// If omitted, defaults to substring unless --llm-judge/--local implies llm-f1.
     #[arg(long, value_enum)]
     scoring_mode: Option<ScoringMode>,
+    /// Shorthand for --scoring-mode e2e-word-overlap (requires --llm-judge or --local).
+    #[arg(long)]
+    e2e: bool,
 }
 
 // ── Main ────────────────────────────────────────────────────────────────
@@ -105,16 +110,20 @@ fn main() -> Result<()> {
         bail!("--dataset-path cannot be combined with --force-refresh or --temp-dataset");
     }
 
-    // Resolve effective scoring mode: explicit --scoring-mode wins.
-    // Otherwise, --llm-judge/--local implies llm-f1; fallback default is substring.
+    // Resolve effective scoring mode: --e2e shorthand wins over implicit default,
+    // explicit --scoring-mode always wins.
     let scoring_mode = match args.scoring_mode {
         Some(mode) => mode,
+        None if args.e2e => ScoringMode::E2eWordOverlap,
         None if args.llm_judge || args.local => ScoringMode::LlmF1,
         None => ScoringMode::Substring,
     };
 
     if scoring_mode == ScoringMode::LlmF1 && !(args.llm_judge || args.local) {
         bail!("--scoring-mode llm-f1 requires --llm-judge or --local");
+    }
+    if scoring_mode == ScoringMode::E2eWordOverlap && !(args.llm_judge || args.local) {
+        bail!("--e2e / --scoring-mode e2e-word-overlap requires --llm-judge or --local");
     }
     if scoring_mode == ScoringMode::WordOverlap && (args.llm_judge || args.local) {
         bail!("--scoring-mode word-overlap is incompatible with --llm-judge / --local");
@@ -144,7 +153,10 @@ fn main() -> Result<()> {
     let metadata = benchmarking::benchmark_metadata("locomo", &dataset);
 
     // Initialize LLM if needed.
-    let use_llm = scoring_mode == ScoringMode::LlmF1;
+    let use_llm = matches!(
+        scoring_mode,
+        ScoringMode::LlmF1 | ScoringMode::E2eWordOverlap
+    );
     if use_llm {
         let model = args.llm_model.as_deref().unwrap_or(if args.local {
             DEFAULT_LOCAL_MODEL
@@ -256,6 +268,32 @@ fn main() -> Result<()> {
                     };
                     (score, String::new())
                 }
+                ScoringMode::E2eWordOverlap if !expected_answer.is_empty() => {
+                    // E2E: generate LLM answer, then score with word-overlap recall.
+                    match runtime.block_on(llm::generate_answer(&qa.question, &hits)) {
+                        Ok(generated) => {
+                            if is_adversarial {
+                                let score = if scoring::adversarial_check(&generated) {
+                                    1.0
+                                } else {
+                                    0.0
+                                };
+                                (score, generated)
+                            } else {
+                                let score =
+                                    scoring::word_overlap_on_text(&generated, expected_answer);
+                                (score, generated)
+                            }
+                        }
+                        Err(err) => {
+                            eprintln!(
+                                "warning: LLM generation failed, falling back to retrieval word-overlap: {err}"
+                            );
+                            let score = scoring::word_overlap_score(&hits, expected_answer);
+                            (score, String::new())
+                        }
+                    }
+                }
                 ScoringMode::LlmF1 if !expected_answer.is_empty() => {
                     match runtime.block_on(llm::generate_answer(&qa.question, &hits)) {
                         Ok(generated) => {
@@ -285,8 +323,8 @@ fn main() -> Result<()> {
                         }
                     }
                 }
-                ScoringMode::Substring | ScoringMode::LlmF1 => {
-                    // Substring mode, or LlmF1 fallback when expected is empty.
+                ScoringMode::Substring | ScoringMode::LlmF1 | ScoringMode::E2eWordOverlap => {
+                    // Substring mode, or LlmF1/E2eWordOverlap fallback when expected is empty.
                     let concat = hits
                         .iter()
                         .map(|h| h.content.as_str())
@@ -373,6 +411,7 @@ fn main() -> Result<()> {
         ScoringMode::Substring => "substring",
         ScoringMode::WordOverlap => "word-overlap",
         ScoringMode::LlmF1 => "llm-f1",
+        ScoringMode::E2eWordOverlap => "e2e-word-overlap",
     };
 
     let summary = types::LoCoMoSummary {

--- a/benches/locomo/scoring.rs
+++ b/benches/locomo/scoring.rs
@@ -183,6 +183,27 @@ pub(crate) fn word_overlap_score(hits: &[RetrievalHit], expected: &str) -> f64 {
     }
 }
 
+// ── Word-overlap on text (for E2E scoring) ───────────────────────────────
+
+/// Compute word-overlap recall between LLM-generated text and expected answer.
+/// Reuses `normalize_tokens()` for consistency with retrieval word-overlap.
+pub(crate) fn word_overlap_on_text(generated: &str, expected: &str) -> f64 {
+    if expected.is_empty() {
+        return 0.0;
+    }
+    let expected_tokens = normalize_tokens(expected);
+    if expected_tokens.is_empty() {
+        return 0.0;
+    }
+    let generated_tokens = normalize_tokens(generated);
+    #[allow(clippy::cast_precision_loss)]
+    let overlap = expected_tokens.intersection(&generated_tokens).count() as f64;
+    #[allow(clippy::cast_precision_loss)]
+    {
+        overlap / expected_tokens.len() as f64
+    }
+}
+
 // ── Adversarial detection ────────────────────────────────────────────────
 
 /// Phrases that indicate the LLM correctly identified information as absent.
@@ -513,5 +534,59 @@ mod tests {
         // Hit 1 has "pari", hit 2 has "tuesday" — full recall
         let score = word_overlap_score(&hits, "Paris Tuesday");
         assert!((score - 1.0).abs() < 1e-9, "expected 1.0, got {score}");
+    }
+
+    // ── word_overlap_on_text tests ─────────────────────────────────────
+
+    #[test]
+    fn test_word_overlap_on_text_exact_match() {
+        let score = word_overlap_on_text("Alice went to Paris", "Alice went to Paris");
+        assert!((score - 1.0).abs() < 1e-9, "expected 1.0, got {score}");
+    }
+
+    #[test]
+    fn test_word_overlap_on_text_partial_match() {
+        // Expected: "Paris on Tuesday" => tokens {pari, tuesday}
+        // Generated: "Alice visited Paris" => tokens {alic, visit, pari}
+        // Overlap: {pari} => 1/2 = 0.5
+        let score = word_overlap_on_text("Alice visited Paris", "Paris on Tuesday");
+        assert!((score - 0.5).abs() < 0.01, "expected ~0.5, got {score}");
+    }
+
+    #[test]
+    fn test_word_overlap_on_text_no_match() {
+        let score = word_overlap_on_text("something completely different", "Paris Tuesday");
+        assert!(score < 0.01, "expected ~0.0, got {score}");
+    }
+
+    #[test]
+    fn test_word_overlap_on_text_empty_expected() {
+        let score = word_overlap_on_text("some generated text", "");
+        assert!(score.abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_word_overlap_on_text_empty_generated() {
+        let score = word_overlap_on_text("", "Paris Tuesday");
+        assert!(score.abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_word_overlap_on_text_both_empty() {
+        let score = word_overlap_on_text("", "");
+        assert!(score.abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_word_overlap_on_text_case_insensitive() {
+        let score = word_overlap_on_text("PARIS TUESDAY", "paris tuesday");
+        assert!((score - 1.0).abs() < 1e-9, "expected 1.0, got {score}");
+    }
+
+    #[test]
+    fn test_word_overlap_on_text_stopwords_only_expected() {
+        // "the a an" are all stopwords, so expected_tokens is empty → returns 0.0
+        let score = word_overlap_on_text("the a an is are", "the a an");
+        assert!(score.abs() < 1e-9);
     }
 }

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -141,6 +141,34 @@ AutoMem numbers are from the [LoCoMo paper](https://arxiv.org/abs/2402.18180) Ta
 
 This is a retrieval-oriented benchmark, not a full generative evaluation. The README describes it that way intentionally.
 
+### E2E LLM Evaluation Mode
+
+The E2E (end-to-end) word-overlap mode combines LLM answer generation with word-overlap recall scoring. This mirrors AutoMem's evaluation pipeline: retrieve context, generate an LLM answer, then score the generated answer against the expected answer using word-overlap recall.
+
+This gives a more realistic evaluation than retrieval-only word-overlap (which scores raw retrieved text) or LLM F1 (which uses token-level F1). Adversarial questions are scored via phrase-based detection (same as `llm-f1` mode).
+
+Command:
+
+```bash
+# E2E word-overlap with OpenAI (requires OPENAI_API_KEY)
+cargo run --release --bin locomo_bench -- --e2e --llm-judge --samples 2
+# E2E word-overlap with local LM Studio
+cargo run --release --bin locomo_bench -- --e2e --local --samples 2
+# Equivalent explicit form
+cargo run --release --bin locomo_bench -- --scoring-mode e2e-word-overlap --llm-judge --samples 2
+```
+
+Results will be populated after the first benchmark run with this mode.
+
+| Category | MAG (E2E) | AutoMem |
+| --- | ---: | ---: |
+| Single-Hop QA | _TBD_ | `79.8%` |
+| Temporal Reasoning | _TBD_ | `85.1%` |
+| Multi-Hop QA | _TBD_ | `50.0%` |
+| Open-Domain | _TBD_ | `95.8%` |
+| Adversarial | _TBD_ | `100.0%` |
+| **Overall** | _TBD_ | **`90.5%`** |
+
 ## Scale Benchmark
 
 Command:


### PR DESCRIPTION
## Summary
- Add `E2eWordOverlap` scoring mode that generates LLM answers and scores them with word-overlap recall, matching AutoMem's evaluation pipeline
- Add `--e2e` CLI shorthand flag (requires `--llm-judge` or `--local`)
- Add `word_overlap_on_text()` function in scoring.rs with 8 unit tests
- Update display labels and docs/benchmarks.md with E2E section

## Test plan
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all-features` passes (all 500+ tests)
- [x] New `word_overlap_on_text` unit tests cover: exact match, partial match, no match, empty inputs, case insensitivity, stopwords-only
- [ ] Manual: `cargo run --release --bin locomo_bench -- --e2e --llm-judge --samples 2` (requires OPENAI_API_KEY)
- [ ] Manual: `cargo run --release --bin locomo_bench -- --e2e --local --samples 2` (requires local LM Studio)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced E2E Word Overlap scoring mode for comprehensive end-to-end LLM evaluation, combining generation and word-overlap recall scoring.
  * Added `--e2e` flag for quick enablement of the new scoring mode.
  * Full support for OpenAI and local LM Studio implementations.

* **Documentation**
  * Added detailed E2E LLM Evaluation Mode guide with workflow instructions, supported commands, and performance benchmarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->