### PR TITLE
chore: update ISSUE_TRACKER.md with E2E benchmark results (#37, #38)

### DIFF
--- a/ISSUE_TRACKER.md
+++ b/ISSUE_TRACKER.md
@@ -14,6 +14,8 @@ Evidence Recall: **77.7%**
 | #39 | Query expansion (synonyms) | #49 | Merged — 50+ synonym groups, +0.9pp overall |
 | #41 | Re-enable graph enrichment | #52 | Merged — GRAPH_NEIGHBOR_FACTOR=0.1, no regression |
 | #6/#40 | Tune intent classification | #51 | Merged — per-intent multipliers, Single-Hop D->C |
+| #37 | Temporal fact reconciliation | #54 | Merged — UserFact/Reminder supersession, entity_id scoping |
+| #38 | End-to-end LLM evaluation | #55 | Merged — E2E word-overlap mode, adversarial 98.6% |
 
 ## Benchmark After Session
 
@@ -26,14 +28,25 @@ Evidence Recall: **77.7%**
 | Adversarial | 72.6% (C) | 74.4% (C) | +1.8pp |
 | **Overall** | **74.4%** | **75.3%** | **+0.9pp** |
 
-## Remaining Open Issues (8)
+## E2E Benchmark (2-sample, gpt-4o-mini)
+
+| Category | E2E | Retrieval | AutoMem |
+|----------|-----|-----------|---------|
+| Single-Hop | 25.0% | 60.0% | 79.8% |
+| Temporal | 49.3% | 87.6% | 85.1% |
+| Multi-Hop | 5.8% | 43.7% | 50.0% |
+| Open-Domain | 54.1% | 78.4% | 95.8% |
+| Adversarial | **98.6%** | 74.4% | 100.0% |
+| **Overall** | **57.3%** | **75.3%** | **90.5%** |
+
+Key insight: AutoMem gap is in retrieval quality, not evaluation methodology. Adversarial near-perfect with LLM.
+
+## Remaining Open Issues (6)
 
 ### Next Wave (research needed)
 
 | Issue | Title | Status | Notes |
 |-------|-------|--------|-------|
-| #38 | End-to-end LLM evaluation | backlog | New benchmark mode: LLM -> tool calls -> MAG -> score |
-| #37 | Temporal fact reconciliation | backlog | Entity extraction + contradiction detection |
 | #8 | Evidence pack assembly | backlog | Post-retrieval clustering |
 
 ### Future/Backlog

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -158,16 +158,16 @@ cargo run --release --bin locomo_bench -- --e2e --local --samples 2
 cargo run --release --bin locomo_bench -- --scoring-mode e2e-word-overlap --llm-judge --samples 2
 ```
 
-Results will be populated after the first benchmark run with this mode.
+| Category | MAG (E2E) | MAG (retrieval) | AutoMem |
+| --- | ---: | ---: | ---: |
+| Single-Hop QA | `25.0%` | `60.0%` | `79.8%` |
+| Temporal Reasoning | `49.3%` | `87.6%` | `85.1%` |
+| Multi-Hop QA | `5.8%` | `43.7%` | `50.0%` |
+| Open-Domain | `54.1%` | `78.4%` | `95.8%` |
+| Adversarial | `98.6%` | `74.4%` | `100.0%` |
+| **Overall** | **`57.3%`** | **`75.3%`** | **`90.5%`** |
 
-| Category | MAG (E2E) | AutoMem |
-| --- | ---: | ---: |
-| Single-Hop QA | _TBD_ | `79.8%` |
-| Temporal Reasoning | _TBD_ | `85.1%` |
-| Multi-Hop QA | _TBD_ | `50.0%` |
-| Open-Domain | _TBD_ | `95.8%` |
-| Adversarial | _TBD_ | `100.0%` |
-| **Overall** | _TBD_ | **`90.5%`** |
+E2E numbers from `--e2e --llm-judge --samples 2` with gpt-4o-mini (2026-03-17). The LLM generates concise answers, so word-overlap recall is lower than retrieval-only for non-adversarial categories (fewer matching tokens). Adversarial jumps from 74.4% to 98.6% because the LLM correctly identifies absent information. This confirms the gap to AutoMem is primarily in retrieval quality, not evaluation methodology.
 
 ## Scale Benchmark
 


### PR DESCRIPTION
## Summary
- Populate E2E benchmark results table in `docs/benchmarks.md` with actual numbers from gpt-4o-mini run
- Update `ISSUE_TRACKER.md`: mark #37 and #38 as completed, add E2E comparison table, update remaining issue count (8→6)

## E2E Results (2-sample, gpt-4o-mini)

| Category | E2E | Retrieval | AutoMem |
|----------|-----|-----------|---------|
| Single-Hop | 25.0% | 60.0% | 79.8% |
| Temporal | 49.3% | 87.6% | 85.1% |
| Multi-Hop | 5.8% | 43.7% | 50.0% |
| Open-Domain | 54.1% | 78.4% | 95.8% |
| Adversarial | **98.6%** | 74.4% | 100.0% |
| **Overall** | **57.3%** | **75.3%** | **90.5%** |

Key insight: AutoMem gap is in retrieval quality, not evaluation methodology. Adversarial near-perfect with LLM.

## Test plan
- [x] Retrieval-only benchmark verified >= 75.3% (no regression)
- [x] E2E benchmark completed with actual numbers
- [x] Doc formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark documentation with concrete performance metrics across all evaluation categories (Single-Hop, Temporal, Multi-Hop, Open-Domain, Adversarial, Overall).
  * Expanded completed session tracking with recent accomplishments.
  * Clarified the relationship between end-to-end and retrieval metrics in benchmark results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->