### PR TITLE
feat(memory): entity extraction and auto-tagging at ingest

### DIFF
--- a/src/memory_core/entity.rs
+++ b/src/memory_core/entity.rs
@@ -51,8 +51,15 @@ fn extract_person_names(content: &str, tags: &mut BTreeSet<String>) {
         }
 
         // Pattern 3: Possessive "'s" — "Caroline's" → entity:person:caroline
+        // Strips the trailing "'s" suffix rather than splitting on apostrophe,
+        // so names like "O'Connor's" correctly extract "O'Connor" not "O".
         if word.ends_with("'s") || word.ends_with("\u{2019}s") {
-            let name_part = word.split(['\'', '\u{2019}']).next().unwrap_or("");
+            let name_part = if word.ends_with("'s") {
+                &word[..word.len() - 2]
+            } else {
+                // '\u{2019}' is 3 bytes in UTF-8
+                &word[..word.len() - 4]
+            };
             let name_clean = name_part.trim_matches(|c: char| !c.is_alphanumeric());
             if name_clean.len() >= 2
                 && name_clean.chars().next().is_some_and(|c| c.is_uppercase())
@@ -83,7 +90,7 @@ fn is_common_non_name(word: &str) -> bool {
         "it" | "he" | "she" | "they" | "we" | "you"
         // Days and months
         | "monday" | "tuesday" | "wednesday" | "thursday" | "friday" | "saturday" | "sunday"
-        | "january" | "february" | "march" | "april" | "june"
+        | "january" | "february" | "march" | "april" | "may" | "june"
         | "july" | "august" | "september" | "october" | "november" | "december"
         // Interjections and fillers
         | "oh" | "ah" | "hmm" | "huh" | "wow" | "ooh"
@@ -126,6 +133,17 @@ mod tests {
         let tags = extract_entity_tags("I visited Caroline's house yesterday");
         assert!(
             tags.iter().any(|t| t == "entity:person:caroline"),
+            "tags: {:?}",
+            tags
+        );
+    }
+
+    #[test]
+    fn test_extract_possessive_oconnor() {
+        // O'Connor's should extract "O'Connor", not just "O"
+        let tags = extract_entity_tags("I went to O'Connor's pub last night");
+        assert!(
+            tags.iter().any(|t| t == "entity:person:o'connor"),
             "tags: {:?}",
             tags
         );

--- a/src/memory_core/entity.rs
+++ b/src/memory_core/entity.rs
@@ -1,12 +1,12 @@
-use std::collections::HashSet;
+use std::collections::BTreeSet;
 
 /// Extracts entity tags from memory content using lightweight regex patterns.
-/// Returns tags in the format `entity:person:name`.
+/// Returns tags in the format `entity:person:name`, sorted for deterministic output.
 ///
 /// This is additive-only — if extraction produces no results, the caller's
 /// tags remain unchanged.
 pub fn extract_entity_tags(content: &str) -> Vec<String> {
-    let mut tags = HashSet::new();
+    let mut tags = BTreeSet::new();
 
     // Extract person names: capitalized words that appear after speaker patterns
     // like "Speaker:", "with Name", "from Name", "'s" possessives
@@ -15,13 +15,13 @@ pub fn extract_entity_tags(content: &str) -> Vec<String> {
     tags.into_iter().collect()
 }
 
-fn extract_person_names(content: &str, tags: &mut HashSet<String>) {
+fn extract_person_names(content: &str, tags: &mut BTreeSet<String>) {
     let words: Vec<&str> = content.split_whitespace().collect();
 
     for (i, word) in words.iter().enumerate() {
         // Skip very short words and common non-name capitalized words
         let clean = word.trim_matches(|c: char| !c.is_alphanumeric());
-        if clean.len() < 2 || !clean.chars().next().map_or(false, |c| c.is_uppercase()) {
+        if clean.len() < 2 || !clean.chars().next().is_some_and(|c| c.is_uppercase()) {
             continue;
         }
         if is_common_non_name(clean) {
@@ -29,11 +29,10 @@ fn extract_person_names(content: &str, tags: &mut HashSet<String>) {
         }
 
         // Pattern 1: "Speaker: text" — word before colon is likely a person name
-        if word.ends_with(':') && clean.len() >= 2 {
+        // (is_common_non_name already checked above, no need to re-check)
+        if word.ends_with(':') {
             let name = clean.to_lowercase();
-            if !is_common_non_name(clean) {
-                tags.insert(format!("entity:person:{name}"));
-            }
+            tags.insert(format!("entity:person:{name}"));
             continue;
         }
 
@@ -53,164 +52,58 @@ fn extract_person_names(content: &str, tags: &mut HashSet<String>) {
 
         // Pattern 3: Possessive "'s" — "Caroline's" → entity:person:caroline
         if word.ends_with("'s") || word.ends_with("\u{2019}s") {
-            let name_part = word
-                .split(|c| c == '\'' || c == '\u{2019}')
-                .next()
-                .unwrap_or("");
+            let name_part = word.split(['\'', '\u{2019}']).next().unwrap_or("");
             let name_clean = name_part.trim_matches(|c: char| !c.is_alphanumeric());
             if name_clean.len() >= 2
-                && name_clean
-                    .chars()
-                    .next()
-                    .map_or(false, |c| c.is_uppercase())
+                && name_clean.chars().next().is_some_and(|c| c.is_uppercase())
                 && !is_common_non_name(name_clean)
             {
                 tags.insert(format!("entity:person:{}", name_clean.to_lowercase()));
             }
         }
-
     }
 }
 
 /// Common words that are capitalized but are NOT person names.
+///
+/// Delegates to the canonical `is_stopword()` in `scoring.rs` for the base set,
+/// then adds entity-extraction-specific extras (interjections, greetings, pronouns,
+/// days/months, filler words) that aren't needed for BM25 scoring but cause false
+/// positives in name extraction.
 fn is_common_non_name(word: &str) -> bool {
     let lower = word.to_lowercase();
+    // Base stopwords shared with BM25/token_set
+    if crate::memory_core::scoring::is_stopword(&lower) {
+        return true;
+    }
+    // Entity-extraction-specific extras
     matches!(
         lower.as_str(),
-        "the"
-            | "this"
-            | "that"
-            | "these"
-            | "those"
-            | "what"
-            | "when"
-            | "where"
-            | "which"
-            | "who"
-            | "how"
-            | "why"
-            | "and"
-            | "but"
-            | "for"
-            | "not"
-            | "with"
-            | "from"
-            | "into"
-            | "have"
-            | "has"
-            | "had"
-            | "will"
-            | "would"
-            | "could"
-            | "should"
-            | "was"
-            | "were"
-            | "been"
-            | "being"
-            | "are"
-            | "can"
-            | "may"
-            | "might"
-            | "must"
-            | "shall"
-            | "also"
-            | "just"
-            | "even"
-            | "still"
-            | "already"
-            | "very"
-            | "really"
-            | "quite"
-            | "rather"
-            | "much"
-            | "some"
-            | "any"
-            | "all"
-            | "each"
-            | "every"
-            | "both"
-            | "about"
-            | "after"
-            | "before"
-            | "between"
-            | "during"
-            | "until"
-            | "here"
-            | "there"
-            | "then"
-            | "now"
-            | "today"
-            | "yesterday"
-            | "tomorrow"
-            | "monday"
-            | "tuesday"
-            | "wednesday"
-            | "thursday"
-            | "friday"
-            | "saturday"
-            | "sunday"
-            | "january"
-            | "february"
-            | "march"
-            | "april"
-            | "june"
-            | "july"
-            | "august"
-            | "september"
-            | "october"
-            | "november"
-            | "december"
-            | "new"
-            | "old"
-            | "first"
-            | "last"
-            | "next"
-            | "other"
-            | "yes"
-            | "yeah"
-            | "yep"
-            | "sure"
-            | "okay"
-            | "well"
-            | "right"
-            | "hey"
-            | "hello"
-            | "bye"
-            | "thanks"
-            | "thank"
-            | "please"
-            | "sorry"
-            | "great"
-            | "good"
-            | "nice"
-            | "cool"
-            | "awesome"
-            | "actually"
-            | "basically"
-            | "literally"
-            | "definitely"
-            | "absolutely"
-            | "maybe"
-            | "probably"
-            | "perhaps"
-            | "certainly"
-            | "honestly"
-            | "it"
-            | "he"
-            | "she"
-            | "they"
-            | "we"
-            | "you"
-            | "speaker"
-            | "user"
-            | "assistant"
-            | "system"
-            | "oh"
-            | "ah"
-            | "hmm"
-            | "huh"
-            | "wow"
-            | "ooh"
+        // Pronouns (short, caught by is_stopword len filter but capitalized in text)
+        "it" | "he" | "she" | "they" | "we" | "you"
+        // Days and months
+        | "monday" | "tuesday" | "wednesday" | "thursday" | "friday" | "saturday" | "sunday"
+        | "january" | "february" | "march" | "april" | "june"
+        | "july" | "august" | "september" | "october" | "november" | "december"
+        // Interjections and fillers
+        | "oh" | "ah" | "hmm" | "huh" | "wow" | "ooh"
+        | "yes" | "yeah" | "yep" | "sure" | "okay" | "well" | "right"
+        | "hey" | "hello" | "bye" | "thanks" | "thank" | "please" | "sorry"
+        | "great" | "good" | "nice" | "cool" | "awesome"
+        // Adverbs/hedges
+        | "actually" | "basically" | "literally" | "definitely" | "absolutely"
+        | "maybe" | "probably" | "perhaps" | "certainly" | "honestly"
+        | "really" | "quite" | "rather" | "very" | "much"
+        // Adjectives/determiners
+        | "new" | "old" | "first" | "last" | "next" | "other"
+        | "some" | "any" | "each" | "every" | "both"
+        // Misc common words
+        | "being" | "been" | "shall" | "must" | "might" | "could" | "should" | "would"
+        | "also" | "just" | "even" | "still" | "already"
+        | "about" | "after" | "before" | "between" | "during" | "until"
+        | "here" | "there" | "then" | "now" | "today" | "yesterday" | "tomorrow"
+        // Domain terms
+        | "speaker" | "user" | "assistant" | "system"
     )
 }
 

--- a/src/memory_core/entity.rs
+++ b/src/memory_core/entity.rs
@@ -1,0 +1,298 @@
+use std::collections::HashSet;
+
+/// Extracts entity tags from memory content using lightweight regex patterns.
+/// Returns tags in the format `entity:person:name`.
+///
+/// This is additive-only — if extraction produces no results, the caller's
+/// tags remain unchanged.
+pub fn extract_entity_tags(content: &str) -> Vec<String> {
+    let mut tags = HashSet::new();
+
+    // Extract person names: capitalized words that appear after speaker patterns
+    // like "Speaker:", "with Name", "from Name", "'s" possessives
+    extract_person_names(content, &mut tags);
+
+    tags.into_iter().collect()
+}
+
+fn extract_person_names(content: &str, tags: &mut HashSet<String>) {
+    let words: Vec<&str> = content.split_whitespace().collect();
+
+    for (i, word) in words.iter().enumerate() {
+        // Skip very short words and common non-name capitalized words
+        let clean = word.trim_matches(|c: char| !c.is_alphanumeric());
+        if clean.len() < 2 || !clean.chars().next().map_or(false, |c| c.is_uppercase()) {
+            continue;
+        }
+        if is_common_non_name(clean) {
+            continue;
+        }
+
+        // Pattern 1: "Speaker: text" — word before colon is likely a person name
+        if word.ends_with(':') && clean.len() >= 2 {
+            let name = clean.to_lowercase();
+            if !is_common_non_name(clean) {
+                tags.insert(format!("entity:person:{name}"));
+            }
+            continue;
+        }
+
+        // Pattern 2: After "with", "from", "and" + capitalized word = likely person name
+        if i > 0 {
+            let prev = words[i - 1].to_lowercase();
+            let prev_clean = prev.trim_matches(|c: char| !c.is_alphanumeric());
+            if matches!(
+                prev_clean,
+                "with" | "from" | "and" | "told" | "asked" | "said" | "called" | "named" | "met"
+            ) {
+                let name = clean.to_lowercase();
+                tags.insert(format!("entity:person:{name}"));
+                continue;
+            }
+        }
+
+        // Pattern 3: Possessive "'s" — "Caroline's" → entity:person:caroline
+        if word.ends_with("'s") || word.ends_with("\u{2019}s") {
+            let name_part = word
+                .split(|c| c == '\'' || c == '\u{2019}')
+                .next()
+                .unwrap_or("");
+            let name_clean = name_part.trim_matches(|c: char| !c.is_alphanumeric());
+            if name_clean.len() >= 2
+                && name_clean
+                    .chars()
+                    .next()
+                    .map_or(false, |c| c.is_uppercase())
+                && !is_common_non_name(name_clean)
+            {
+                tags.insert(format!("entity:person:{}", name_clean.to_lowercase()));
+            }
+        }
+
+    }
+}
+
+/// Common words that are capitalized but are NOT person names.
+fn is_common_non_name(word: &str) -> bool {
+    let lower = word.to_lowercase();
+    matches!(
+        lower.as_str(),
+        "the"
+            | "this"
+            | "that"
+            | "these"
+            | "those"
+            | "what"
+            | "when"
+            | "where"
+            | "which"
+            | "who"
+            | "how"
+            | "why"
+            | "and"
+            | "but"
+            | "for"
+            | "not"
+            | "with"
+            | "from"
+            | "into"
+            | "have"
+            | "has"
+            | "had"
+            | "will"
+            | "would"
+            | "could"
+            | "should"
+            | "was"
+            | "were"
+            | "been"
+            | "being"
+            | "are"
+            | "can"
+            | "may"
+            | "might"
+            | "must"
+            | "shall"
+            | "also"
+            | "just"
+            | "even"
+            | "still"
+            | "already"
+            | "very"
+            | "really"
+            | "quite"
+            | "rather"
+            | "much"
+            | "some"
+            | "any"
+            | "all"
+            | "each"
+            | "every"
+            | "both"
+            | "about"
+            | "after"
+            | "before"
+            | "between"
+            | "during"
+            | "until"
+            | "here"
+            | "there"
+            | "then"
+            | "now"
+            | "today"
+            | "yesterday"
+            | "tomorrow"
+            | "monday"
+            | "tuesday"
+            | "wednesday"
+            | "thursday"
+            | "friday"
+            | "saturday"
+            | "sunday"
+            | "january"
+            | "february"
+            | "march"
+            | "april"
+            | "june"
+            | "july"
+            | "august"
+            | "september"
+            | "october"
+            | "november"
+            | "december"
+            | "new"
+            | "old"
+            | "first"
+            | "last"
+            | "next"
+            | "other"
+            | "yes"
+            | "yeah"
+            | "yep"
+            | "sure"
+            | "okay"
+            | "well"
+            | "right"
+            | "hey"
+            | "hello"
+            | "bye"
+            | "thanks"
+            | "thank"
+            | "please"
+            | "sorry"
+            | "great"
+            | "good"
+            | "nice"
+            | "cool"
+            | "awesome"
+            | "actually"
+            | "basically"
+            | "literally"
+            | "definitely"
+            | "absolutely"
+            | "maybe"
+            | "probably"
+            | "perhaps"
+            | "certainly"
+            | "honestly"
+            | "it"
+            | "he"
+            | "she"
+            | "they"
+            | "we"
+            | "you"
+            | "speaker"
+            | "user"
+            | "assistant"
+            | "system"
+            | "oh"
+            | "ah"
+            | "hmm"
+            | "huh"
+            | "wow"
+            | "ooh"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_speaker_pattern() {
+        let tags = extract_entity_tags("Caroline: I went to the store today");
+        assert!(
+            tags.iter().any(|t| t == "entity:person:caroline"),
+            "tags: {:?}",
+            tags
+        );
+    }
+
+    #[test]
+    fn test_extract_possessive_pattern() {
+        let tags = extract_entity_tags("I visited Caroline's house yesterday");
+        assert!(
+            tags.iter().any(|t| t == "entity:person:caroline"),
+            "tags: {:?}",
+            tags
+        );
+    }
+
+    #[test]
+    fn test_extract_with_pattern() {
+        let tags = extract_entity_tags("I went shopping with Alice and Bob");
+        assert!(
+            tags.iter().any(|t| t == "entity:person:alice"),
+            "tags: {:?}",
+            tags
+        );
+        assert!(
+            tags.iter().any(|t| t == "entity:person:bob"),
+            "tags: {:?}",
+            tags
+        );
+    }
+
+    #[test]
+    fn test_extract_from_pattern() {
+        let tags = extract_entity_tags("Got a call from David about the project");
+        assert!(
+            tags.iter().any(|t| t == "entity:person:david"),
+            "tags: {:?}",
+            tags
+        );
+    }
+
+    #[test]
+    fn test_no_false_positives_on_common_words() {
+        let tags = extract_entity_tags("The weather was really nice today");
+        assert!(
+            tags.is_empty(),
+            "should not extract common words, got: {:?}",
+            tags
+        );
+    }
+
+    #[test]
+    fn test_empty_input() {
+        let tags = extract_entity_tags("");
+        assert!(tags.is_empty());
+    }
+
+    #[test]
+    fn test_date_prefixed_speaker() {
+        let tags = extract_entity_tags("[2023-05-15] Alice: We should plan the trip");
+        assert!(
+            tags.iter().any(|t| t == "entity:person:alice"),
+            "tags: {:?}",
+            tags
+        );
+    }
+
+    #[test]
+    fn test_graceful_no_entities() {
+        // All lowercase, no names
+        let tags = extract_entity_tags("went to the store and bought groceries");
+        assert!(tags.is_empty());
+    }
+}

--- a/src/memory_core/mod.rs
+++ b/src/memory_core/mod.rs
@@ -8,6 +8,7 @@ use tracing::info;
 use uuid::Uuid;
 
 pub mod embedder;
+pub mod entity;
 pub mod reranker;
 pub mod scoring;
 pub mod storage;

--- a/src/memory_core/storage/sqlite/crud.rs
+++ b/src/memory_core/storage/sqlite/crud.rs
@@ -3,8 +3,11 @@ use super::*;
 #[async_trait]
 impl Storage for SqliteStorage {
     async fn store(&self, id: &str, data: &str, input: &MemoryInput) -> Result<()> {
+        let mut tags = input.tags.clone();
+        let entity_tags = crate::memory_core::entity::extract_entity_tags(data);
+        tags.extend(entity_tags);
         let tags_json =
-            serde_json::to_string(&input.tags).context("failed to serialize tags to JSON")?;
+            serde_json::to_string(&tags).context("failed to serialize tags to JSON")?;
         let metadata_json = serde_json::to_string(&input.metadata)
             .context("failed to serialize metadata to JSON")?;
 

--- a/src/memory_core/storage/sqlite/crud.rs
+++ b/src/memory_core/storage/sqlite/crud.rs
@@ -3,11 +3,14 @@ use super::*;
 #[async_trait]
 impl Storage for SqliteStorage {
     async fn store(&self, id: &str, data: &str, input: &MemoryInput) -> Result<()> {
-        let mut tags = input.tags.clone();
         let entity_tags = crate::memory_core::entity::extract_entity_tags(data);
-        tags.extend(entity_tags);
-        let tags_json =
-            serde_json::to_string(&tags).context("failed to serialize tags to JSON")?;
+        let tags_json = if entity_tags.is_empty() {
+            serde_json::to_string(&input.tags).context("failed to serialize tags to JSON")?
+        } else {
+            let mut tags = input.tags.clone();
+            tags.extend(entity_tags);
+            serde_json::to_string(&tags).context("failed to serialize tags to JSON")?
+        };
         let metadata_json = serde_json::to_string(&input.metadata)
             .context("failed to serialize metadata to JSON")?;
 


### PR DESCRIPTION
## Summary
- Add `entity.rs` module with regex-based entity extraction (person names from speaker patterns, possessives, "with/from" patterns)
- Integrate entity extraction in `store()` — automatically adds `entity:person:name` tags
- Additive-only: if extraction produces no results, tags are unchanged
- No external dependencies — pure regex/string operations
- Fixes for CodeRabbit findings: removed dead Pattern 4 code, added pronoun stop-list, tightened possessive matching to `ends_with`

## Test plan
- [x] `prek run` passes (fmt + clippy + tests)
- [x] `cargo test --all-features -- entity` passes (8 entity tests)
- [x] `cargo run --release --bin locomo_bench -- --samples 2 --scoring-mode word-overlap` = 75.3% (meets threshold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic entity tag extraction: person names detected in content are added to tags, merged with your existing tags, deduplicated, and returned in a stable order. Possessives, speaker-like patterns, and common-word filtering improve accuracy; if no entities are found, original tags are preserved.
* **Tests**
  * Unit tests added to validate detection patterns and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->