### PR TITLE
feat(search): add query decomposition for multi-hop queries

### DIFF
--- a/src/memory_core/storage/sqlite/advanced.rs
+++ b/src/memory_core/storage/sqlite/advanced.rs
@@ -1,5 +1,7 @@
 use super::helpers::{
-    IntentProfile, QueryIntent, classify_query_intent, detect_dynamic_limit_mult,
+    IntentProfile, QueryIntent, classify_query_intent, content_fingerprint,
+    detect_dynamic_limit_mult, extract_query_entities, extract_topic_keywords,
+    generate_sub_queries,
 };
 use super::*;
 use crate::memory_core::scoring::query_coverage_boost;
@@ -939,6 +941,129 @@ fn merge_semantic_metadata(existing: &mut serde_json::Value, incoming: serde_jso
     }
 }
 
+/// Run the core search pipeline for a single query: embed -> vector+FTS -> fuse -> refine.
+///
+/// Used by query decomposition to run each sub-query through the full pipeline.
+#[allow(clippy::too_many_arguments)]
+async fn run_single_query_pipeline(
+    pool: &Arc<ConnPool>,
+    embedder: &Arc<dyn Embedder>,
+    query: &str,
+    candidate_limit: usize,
+    limit: usize,
+    opts: &SearchOptions,
+    scoring_params: &ScoringParams,
+    include_superseded: bool,
+    explain_enabled: bool,
+) -> Result<Vec<SemanticResult>> {
+    let intent = classify_query_intent(query);
+    let keyword_only = intent == QueryIntent::Keyword;
+
+    let query_embedding = if keyword_only || query.is_empty() {
+        Vec::new()
+    } else {
+        let embedder = Arc::clone(embedder);
+        let q = query.to_string();
+        tokio::task::spawn_blocking(move || embedder.embed(&q))
+            .await
+            .context("spawn_blocking join error")??
+    };
+
+    let (vector_candidates, fts_candidates) = if keyword_only {
+        let pool = Arc::clone(pool);
+        let q = query.to_string();
+        let o = opts.clone();
+        let sp = scoring_params.clone();
+        let fts_result = tokio::task::spawn_blocking(move || {
+            let conn = pool.reader()?;
+            collect_fts_candidates(&conn, &q, candidate_limit, &o, include_superseded, &sp)
+        })
+        .await
+        .context("spawn_blocking join error")??;
+        (Vec::new(), fts_result)
+    } else if pool.has_readers() {
+        let (vec_result, fts_result) = tokio::try_join!(
+            tokio::task::spawn_blocking({
+                let pool = Arc::clone(pool);
+                let emb = query_embedding.clone();
+                let o = opts.clone();
+                let sp = scoring_params.clone();
+                move || {
+                    let conn = pool.reader()?;
+                    collect_vector_candidates(
+                        &conn,
+                        &emb,
+                        candidate_limit,
+                        include_superseded,
+                        &o,
+                        &sp,
+                    )
+                }
+            }),
+            tokio::task::spawn_blocking({
+                let pool = Arc::clone(pool);
+                let q = query.to_string();
+                let o = opts.clone();
+                let sp = scoring_params.clone();
+                move || {
+                    let conn = pool.reader()?;
+                    collect_fts_candidates(&conn, &q, candidate_limit, &o, include_superseded, &sp)
+                }
+            }),
+        )
+        .context("parallel search join error")?;
+        (vec_result?, fts_result?)
+    } else {
+        let pool = Arc::clone(pool);
+        let emb = query_embedding.clone();
+        let q = query.to_string();
+        let o = opts.clone();
+        let sp = scoring_params.clone();
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.reader()?;
+            let vec_c = collect_vector_candidates(
+                &conn,
+                &emb,
+                candidate_limit,
+                include_superseded,
+                &o,
+                &sp,
+            )?;
+            let fts_c =
+                collect_fts_candidates(&conn, &q, candidate_limit, &o, include_superseded, &sp)?;
+            Ok::<_, anyhow::Error>((vec_c, fts_c))
+        })
+        .await
+        .context("spawn_blocking join error")??
+    };
+
+    let ce_scores: Option<HashMap<String, f32>> = None;
+
+    let pool_for_fuse = Arc::clone(pool);
+    let q = query.to_string();
+    let emb = query_embedding;
+    let o = opts.clone();
+    let sp = scoring_params.clone();
+    tokio::task::spawn_blocking(move || {
+        let conn = pool_for_fuse.reader()?;
+        fuse_refine_and_output(
+            &conn,
+            vector_candidates,
+            fts_candidates,
+            &q,
+            &emb,
+            &o,
+            limit,
+            include_superseded,
+            explain_enabled,
+            &sp,
+            ce_scores.as_ref(),
+        )
+    })
+    .await
+    .context("spawn_blocking join error")?
+}
+
 #[async_trait]
 impl AdvancedSearcher for SqliteStorage {
     async fn advanced_search(
@@ -954,6 +1079,7 @@ impl AdvancedSearcher for SqliteStorage {
         let today = chrono::Local::now().date_naive();
         let temporal = expand_temporal_query(query, &today);
         let query = temporal.cleaned_query;
+        let query_for_decomp = query.clone();
         let mut opts = opts.clone();
         if opts.event_after.is_none()
             && let Some(after) = temporal.event_after
@@ -1166,6 +1292,65 @@ impl AdvancedSearcher for SqliteStorage {
         })
         .await
         .context("spawn_blocking join error")??;
+
+        // ── Query decomposition: enrich results for multi-entity queries ──
+        let decomp_entities = extract_query_entities(&query_for_decomp);
+        let results = if decomp_entities.len() >= 2 {
+            let topics = extract_topic_keywords(&query_for_decomp, &decomp_entities);
+            let sub_queries = generate_sub_queries(&query_for_decomp, &decomp_entities, &topics);
+
+            if !topics.is_empty() && sub_queries.len() > 1 {
+                let mut all_results = results;
+                let mut seen_ids: HashSet<String> =
+                    all_results.iter().map(|r| r.id.clone()).collect();
+
+                let decomp_pool = Arc::clone(&self.pool);
+                let decomp_embedder = Arc::clone(&self.embedder);
+                let decomp_sp = self.scoring_params.clone();
+                let decomp_opts = SearchOptions::default();
+                for sub_query in sub_queries.iter().skip(1) {
+                    let sub_results = run_single_query_pipeline(
+                        &decomp_pool,
+                        &decomp_embedder,
+                        sub_query,
+                        candidate_limit,
+                        limit,
+                        &decomp_opts,
+                        &decomp_sp,
+                        include_superseded,
+                        explain_enabled,
+                    )
+                    .await?;
+
+                    for result in sub_results {
+                        if seen_ids.insert(result.id.clone()) {
+                            all_results.push(result);
+                        } else if let Some(existing) =
+                            all_results.iter_mut().find(|r| r.id == result.id)
+                            && result.score > existing.score
+                        {
+                            existing.score = result.score;
+                        }
+                    }
+                }
+
+                let mut deduped: Vec<SemanticResult> = Vec::new();
+                let mut fingerprints: HashSet<String> = HashSet::new();
+                all_results.sort_by(|a, b| b.score.total_cmp(&a.score));
+                for result in all_results {
+                    let fp = content_fingerprint(&result.content);
+                    if fingerprints.insert(fp) {
+                        deduped.push(result);
+                    }
+                }
+                deduped.truncate(limit);
+                deduped
+            } else {
+                results
+            }
+        } else {
+            results
+        };
 
         let results = if hot_has_confident_match {
             merge_hot_cache_results(hot_results, results, limit)

--- a/src/memory_core/storage/sqlite/helpers.rs
+++ b/src/memory_core/storage/sqlite/helpers.rs
@@ -1645,6 +1645,475 @@ fn compute_ago(now: &chrono::NaiveDate, n: i64, unit: &str) -> Option<(String, S
     ))
 }
 
+/// Stopwords for entity extraction from queries — words that appear capitalized
+/// but are not entities (question words, auxiliaries, months, etc.)
+const ENTITY_STOPWORDS: &[&str] = &[
+    "What",
+    "How",
+    "Why",
+    "When",
+    "Where",
+    "Which",
+    "Who",
+    "Whose",
+    "Whom",
+    "Is",
+    "Are",
+    "Was",
+    "Were",
+    "Do",
+    "Does",
+    "Did",
+    "Has",
+    "Have",
+    "Had",
+    "Will",
+    "Would",
+    "Could",
+    "Should",
+    "Can",
+    "May",
+    "Might",
+    "Must",
+    "Being",
+    "Been",
+    "Having",
+    "The",
+    "This",
+    "That",
+    "These",
+    "Those",
+    "It",
+    "Its",
+    "Yes",
+    "No",
+    "Not",
+    "Very",
+    "Also",
+    "Just",
+    "Even",
+    "Still",
+    "January",
+    "February",
+    "March",
+    "April",
+    "June",
+    "July",
+    "August",
+    "September",
+    "October",
+    "November",
+    "December",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+    "Sunday",
+    "National",
+    "American",
+    "European",
+    "Asian",
+    "African",
+    "International",
+    "Global",
+    "Local",
+    "Regional",
+    "Western",
+    "Eastern",
+    "Northern",
+    "Southern",
+    "Answer",
+    "Based",
+    "According",
+    "Since",
+    "Because",
+    "Although",
+    "However",
+    "Therefore",
+    "Furthermore",
+    "Moreover",
+    "Nevertheless",
+    "Likely",
+    "Probably",
+    "Certainly",
+    "Actually",
+    "Recently",
+    "Today",
+    "Yesterday",
+    "Tomorrow",
+];
+
+/// Extract capitalized proper nouns (entity names) from a query string.
+///
+/// Skips sentence-initial words, stopwords, and words < 2 chars.
+/// Also extracts possessives (e.g., "John's" -> "John").
+pub(super) fn extract_query_entities(query: &str) -> Vec<String> {
+    let mut entities = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    let stopwords: std::collections::HashSet<&str> = ENTITY_STOPWORDS.iter().copied().collect();
+
+    let words: Vec<&str> = query.split_whitespace().collect();
+
+    for (i, word) in words.iter().enumerate() {
+        let clean: String = word.chars().filter(|c| c.is_alphanumeric()).collect();
+
+        if clean.len() < 2 {
+            continue;
+        }
+        if stopwords.contains(clean.as_str()) {
+            continue;
+        }
+        if i == 0 {
+            continue;
+        }
+        if i > 0 {
+            let prev = words[i - 1];
+            if prev.ends_with('.') || prev.ends_with('?') || prev.ends_with('!') {
+                continue;
+            }
+        }
+        if clean.len() > 1
+            && clean.chars().next().is_some_and(|c| c.is_uppercase())
+            && clean.chars().skip(1).all(|c| c.is_lowercase())
+            && seen.insert(clean.clone())
+        {
+            entities.push(clean);
+        }
+    }
+
+    // Extract possessives: "Name's" -> "Name"
+    for word in &words {
+        if let Some(pos) = word.find("'s") {
+            let name = &word[..pos];
+            if name.len() >= 2
+                && name.chars().next().is_some_and(|c| c.is_uppercase())
+                && name.chars().skip(1).all(|c| c.is_lowercase())
+                && !stopwords.contains(name)
+                && seen.insert(name.to_string())
+            {
+                entities.push(name.to_string());
+            }
+        }
+    }
+
+    entities
+}
+
+/// Extract semantic topic keywords from a query, excluding entities and common words.
+///
+/// Returns up to 5 unique topic words that are 4+ chars and not in the skip list.
+pub(super) fn extract_topic_keywords(query: &str, exclude_entities: &[String]) -> Vec<String> {
+    let exclude_lower: std::collections::HashSet<String> =
+        exclude_entities.iter().map(|e| e.to_lowercase()).collect();
+
+    let skip_words: std::collections::HashSet<&str> = [
+        "what",
+        "when",
+        "where",
+        "which",
+        "who",
+        "whom",
+        "whose",
+        "how",
+        "why",
+        "that",
+        "this",
+        "these",
+        "those",
+        "there",
+        "here",
+        "then",
+        "than",
+        "been",
+        "being",
+        "have",
+        "having",
+        "does",
+        "doing",
+        "done",
+        "will",
+        "would",
+        "could",
+        "should",
+        "shall",
+        "might",
+        "must",
+        "about",
+        "after",
+        "also",
+        "another",
+        "away",
+        "back",
+        "because",
+        "before",
+        "between",
+        "both",
+        "came",
+        "come",
+        "coming",
+        "each",
+        "even",
+        "every",
+        "first",
+        "from",
+        "gets",
+        "give",
+        "given",
+        "goes",
+        "going",
+        "gone",
+        "good",
+        "great",
+        "into",
+        "just",
+        "keep",
+        "kind",
+        "know",
+        "known",
+        "last",
+        "left",
+        "like",
+        "liked",
+        "likely",
+        "long",
+        "look",
+        "made",
+        "make",
+        "making",
+        "many",
+        "more",
+        "most",
+        "much",
+        "need",
+        "never",
+        "next",
+        "once",
+        "only",
+        "other",
+        "over",
+        "part",
+        "past",
+        "people",
+        "perhaps",
+        "place",
+        "point",
+        "probably",
+        "pursue",
+        "quite",
+        "rather",
+        "really",
+        "right",
+        "said",
+        "same",
+        "seem",
+        "show",
+        "side",
+        "since",
+        "some",
+        "something",
+        "sometimes",
+        "still",
+        "such",
+        "sure",
+        "take",
+        "tell",
+        "them",
+        "they",
+        "thing",
+        "things",
+        "think",
+        "time",
+        "told",
+        "took",
+        "turn",
+        "under",
+        "upon",
+        "used",
+        "using",
+        "very",
+        "want",
+        "well",
+        "went",
+        "were",
+        "while",
+        "with",
+        "within",
+        "without",
+        "work",
+        "year",
+        "years",
+        "your",
+        "able",
+        "already",
+        "always",
+        "around",
+        "away",
+        "called",
+        "certain",
+        "during",
+        "either",
+        "else",
+        "enough",
+        "ever",
+        "fact",
+        "find",
+        "found",
+        "gets",
+        "hard",
+        "help",
+        "high",
+        "hold",
+        "home",
+        "however",
+        "important",
+        "include",
+        "indeed",
+        "inside",
+        "instead",
+        "itself",
+        "large",
+        "later",
+        "least",
+        "less",
+        "life",
+        "line",
+        "little",
+        "live",
+        "lived",
+        "lives",
+        "living",
+        "longer",
+        "mean",
+        "means",
+        "mention",
+        "mentioned",
+        "name",
+        "near",
+        "number",
+        "often",
+        "open",
+        "order",
+        "others",
+        "outside",
+        "particular",
+        "play",
+        "possible",
+        "prefer",
+        "pretty",
+        "provide",
+        "real",
+        "reason",
+        "regarding",
+        "remember",
+        "result",
+        "seems",
+        "sense",
+        "several",
+        "simply",
+        "small",
+        "sort",
+        "speak",
+        "start",
+        "state",
+        "talk",
+        "together",
+        "true",
+        "type",
+        "types",
+        "usually",
+        "various",
+        "ways",
+    ]
+    .iter()
+    .copied()
+    .collect();
+
+    let lower = query.to_lowercase();
+
+    let mut topics = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+
+    let mut current_word = String::new();
+    for ch in lower.chars() {
+        if ch.is_ascii_lowercase() {
+            current_word.push(ch);
+        } else {
+            if current_word.len() >= 4
+                && !skip_words.contains(current_word.as_str())
+                && !exclude_lower.contains(&current_word)
+                && seen.insert(current_word.clone())
+            {
+                topics.push(current_word.clone());
+                if topics.len() >= 5 {
+                    return topics;
+                }
+            }
+            current_word.clear();
+        }
+    }
+    if current_word.len() >= 4
+        && !skip_words.contains(current_word.as_str())
+        && !exclude_lower.contains(&current_word)
+        && seen.insert(current_word.clone())
+    {
+        topics.push(current_word);
+    }
+
+    topics
+}
+
+/// Generate decomposed sub-queries from extracted entities and topics.
+///
+/// Returns the original query first, then entity-based and topic-based variations.
+/// Max 2 entities, max 3 topics per entity.
+pub(super) fn generate_sub_queries(
+    query: &str,
+    entities: &[String],
+    topics: &[String],
+) -> Vec<String> {
+    let mut queries = vec![query.to_string()];
+
+    for entity in entities.iter().take(2) {
+        queries.push(entity.clone());
+        for topic in topics.iter().take(3) {
+            queries.push(format!("{entity} {topic}"));
+        }
+        if topics.iter().any(|t| {
+            matches!(
+                t.as_str(),
+                "career" | "jobs" | "work" | "occupation" | "employment"
+            )
+        }) {
+            queries.push(format!("{entity} interests goals plans"));
+        }
+    }
+
+    if entities.is_empty() && !topics.is_empty() {
+        for topic in topics.iter().take(3) {
+            queries.push(topic.clone());
+        }
+    }
+
+    queries
+}
+
+/// Content fingerprint for dedup: first 320 chars, normalized, lowered, ASCII-only.
+pub(super) fn content_fingerprint(content: &str) -> String {
+    let cleaned: String = content
+        .to_lowercase()
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric() || c.is_ascii_whitespace())
+        .collect();
+    let collapsed = cleaned.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.len() > 320 {
+        collapsed[..320].to_string()
+    } else {
+        collapsed
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2302,5 +2771,72 @@ mod tests {
         assert!((p.suggested_limit_mult - 1.3).abs() < 1e-9);
         let p = IntentProfile::for_intent(QueryIntent::General);
         assert!((p.suggested_limit_mult - 1.0).abs() < 1e-9);
+    }
+
+    // ── extract_query_entities tests ───────────────────────────────────
+
+    #[test]
+    fn test_extract_query_entities() {
+        let entities = extract_query_entities("Would Caroline pursue writing?");
+        assert!(
+            entities.contains(&"Caroline".to_string()),
+            "expected Caroline in {entities:?}"
+        );
+        assert!(
+            !entities.contains(&"Would".to_string()),
+            "should skip question word Would"
+        );
+    }
+
+    #[test]
+    fn test_extract_query_entities_possessive() {
+        let entities = extract_query_entities("What is Amanda's sister's career?");
+        assert!(
+            entities.contains(&"Amanda".to_string()),
+            "expected Amanda in {entities:?}"
+        );
+    }
+
+    // ── extract_topic_keywords tests ───────────────────────────────────
+
+    #[test]
+    fn test_extract_topic_keywords() {
+        let topics = extract_topic_keywords(
+            "Would Caroline pursue writing as a career?",
+            &["Caroline".to_string()],
+        );
+        assert!(
+            topics.contains(&"writing".to_string()),
+            "expected 'writing' in {topics:?}"
+        );
+        assert!(
+            topics.contains(&"career".to_string()),
+            "expected 'career' in {topics:?}"
+        );
+        assert!(
+            !topics.contains(&"caroline".to_string()),
+            "should exclude entity 'caroline'"
+        );
+    }
+
+    // ── generate_sub_queries tests ─────────────────────────────────────
+
+    #[test]
+    fn test_generate_sub_queries() {
+        let queries = generate_sub_queries(
+            "Would Caroline pursue writing?",
+            &["Caroline".to_string()],
+            &["writing".to_string()],
+        );
+        assert_eq!(queries[0], "Would Caroline pursue writing?");
+        assert!(queries.contains(&"Caroline".to_string()));
+        assert!(queries.contains(&"Caroline writing".to_string()));
+    }
+
+    #[test]
+    fn test_generate_sub_queries_no_entities() {
+        let queries = generate_sub_queries("Tell me about writing", &[], &["writing".to_string()]);
+        assert_eq!(queries[0], "Tell me about writing");
+        assert!(queries.contains(&"writing".to_string()));
     }
 }


### PR DESCRIPTION
## Summary
- Adds `extract_query_entities()` to pull proper nouns from queries (skips sentence-initial words, stopwords, possessives)
- Adds `extract_topic_keywords()` to extract semantic topics (4+ char words, filtered)
- Adds `generate_sub_queries()` to create entity+topic sub-query combinations
- Adds `run_single_query_pipeline()` to execute the full search pipeline for a single sub-query
- Restructures `advanced_search()` to run sub-queries through pipeline and merge results when 2+ entities detected
- Content fingerprint deduplication (first 320 chars, normalized)

Conservative activation threshold: decomposition only fires for queries with 2+ proper noun entities, which targets true multi-hop queries while leaving single-entity and non-entity queries on the standard path.

Part of the AutoMem scoring features implementation (Unit 3/5).

## Test plan
- [x] 5 unit tests for entity extraction, topic extraction, sub-query generation
- [x] `cargo test --all-features` passes (373/374, 1 pre-existing failure)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] LoCoMo benchmark: decomposition path does not fire for benchmark queries (conservative threshold)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Decomposes queries into enriched sub-queries (entities & topics) and runs each through the retrieval+fusion pipeline for broader, more relevant results.

* **Bug Fixes / Behavior**
  * Merges sub-query results with ID and content-fingerprint deduplication, updating scores for duplicates and preserving final result limits.

* **Performance**
  * Collects additional full-text and vector candidates per sub-query before ranking to improve relevance.

* **Tests**
  * Added unit tests covering entity/topic extraction, sub-query generation, and deduplication behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->