### PR TITLE
feat(search): add entity expansion during recall

### DIFF
--- a/src/memory_core/scoring.rs
+++ b/src/memory_core/scoring.rs
@@ -182,6 +182,12 @@ pub const ABSTENTION_MIN_TEXT: f64 = 0.15;
 /// surface related memories in production without dominating rankings.
 pub const GRAPH_NEIGHBOR_FACTOR: f64 = 0.1;
 pub const GRAPH_MIN_EDGE_WEIGHT: f64 = 0.3;
+
+/// Multiplicative boost for memories found via entity tag expansion.
+/// Applied on top of the standard scoring pipeline. AutoMem uses +0.15 additive;
+/// we use a multiplicative 1.15 to integrate with the existing RRF-based scoring.
+pub const ENTITY_EXPANSION_BOOST: f64 = 1.15;
+
 /// Weighted RRF fusion — equal weight for vector and FTS (grid search optimal).
 /// Previous bias (1.5 vec / 1.0 fts) was suboptimal on LongMemEval.
 pub const RRF_WEIGHT_VEC: f64 = 1.0;
@@ -1161,6 +1167,11 @@ mod tests {
     }
 
     // ── abstention threshold tests ────────────────────────────────────
+
+    #[test]
+    fn test_entity_expansion_boost_value() {
+        assert!((ENTITY_EXPANSION_BOOST - 1.15).abs() < 1e-9);
+    }
 
     #[test]
     fn test_abstention_threshold_lowered() {

--- a/src/memory_core/storage/sqlite/advanced.rs
+++ b/src/memory_core/storage/sqlite/advanced.rs
@@ -1,7 +1,7 @@
 use super::helpers::{
     IntentProfile, QueryIntent, classify_query_intent, content_fingerprint,
-    detect_dynamic_limit_mult, extract_query_entities, extract_topic_keywords,
-    generate_sub_queries,
+    detect_dynamic_limit_mult, extract_entities_from_tags, extract_query_entities,
+    extract_topic_keywords, generate_sub_queries,
 };
 use super::*;
 use crate::memory_core::scoring::query_coverage_boost;
@@ -803,6 +803,204 @@ fn fuse_refine_and_output(
             }
         }
     }
+    // ── Phase 5b: Entity expansion — find memories tagged with entities from seed results ──
+    {
+        use crate::memory_core::scoring::ENTITY_EXPANSION_BOOST;
+
+        // Collect entity tags from the top-k seed results
+        let mut seed_list_for_expansion: Vec<(String, f64, Vec<String>)> = ranked
+            .iter()
+            .map(|(id, c)| (id.clone(), c.score, c.result.tags.clone()))
+            .collect();
+        seed_list_for_expansion.sort_by(|a, b| b.1.total_cmp(&a.1));
+        seed_list_for_expansion.truncate(limit.min(20));
+
+        let mut entity_tags_to_search: Vec<String> = Vec::new();
+        let mut seen_entity_tags = HashSet::new();
+        for (_id, _score, tags) in &seed_list_for_expansion {
+            for tag in extract_entities_from_tags(tags) {
+                if seen_entity_tags.insert(tag.clone()) {
+                    entity_tags_to_search.push(tag);
+                }
+            }
+        }
+        entity_tags_to_search.truncate(5);
+
+        if !entity_tags_to_search.is_empty() {
+            let expansion_limit = 25usize;
+            let mut expanded_count = 0usize;
+            let existing_ids: HashSet<String> = ranked.keys().cloned().collect();
+
+            // For each entity tag, find memories with that tag
+            for entity_tag in &entity_tags_to_search {
+                if expanded_count >= expansion_limit {
+                    break;
+                }
+
+                // Query for memories with this entity tag using json_each
+                let tag_sql = if include_superseded {
+                    "SELECT id, content, tags, importance, metadata, event_type, session_id, \
+                     project, priority, created_at, entity_id, agent_type, event_at \
+                     FROM memories \
+                     WHERE json_valid(tags) AND EXISTS ( \
+                         SELECT 1 FROM json_each(tags) WHERE value = ?1 \
+                     ) \
+                     ORDER BY created_at DESC LIMIT ?2"
+                } else {
+                    "SELECT id, content, tags, importance, metadata, event_type, session_id, \
+                     project, priority, created_at, entity_id, agent_type, event_at \
+                     FROM memories \
+                     WHERE json_valid(tags) AND EXISTS ( \
+                         SELECT 1 FROM json_each(tags) WHERE value = ?1 \
+                     ) \
+                     AND superseded_by_id IS NULL \
+                     ORDER BY created_at DESC LIMIT ?2"
+                };
+
+                let per_entity_limit = 5i64;
+                if let Ok(mut stmt) = conn.prepare(tag_sql)
+                    && let Ok(rows) = stmt.query_map(params![entity_tag, per_entity_limit], |row| {
+                        Ok((
+                            row.get::<_, String>(0)?,
+                            row.get::<_, String>(1)?,
+                            row.get::<_, String>(2)?,
+                            row.get::<_, f64>(3)?,
+                            row.get::<_, String>(4)?,
+                            row.get::<_, Option<String>>(5).ok().flatten(),
+                            row.get::<_, Option<String>>(6).ok().flatten(),
+                            row.get::<_, Option<String>>(7).ok().flatten(),
+                            row.get::<_, Option<i64>>(8).ok().flatten(),
+                            row.get::<_, String>(9)
+                                .unwrap_or_else(|_| EPOCH_FALLBACK.to_string()),
+                            row.get::<_, Option<String>>(10).ok().flatten(),
+                            row.get::<_, Option<String>>(11).ok().flatten(),
+                            row.get::<_, String>(12)
+                                .unwrap_or_else(|_| EPOCH_FALLBACK.to_string()),
+                        ))
+                    })
+                {
+                    for row_res in rows {
+                        if expanded_count >= expansion_limit {
+                            break;
+                        }
+                        let row = match row_res {
+                            Ok(r) => r,
+                            Err(e) => {
+                                tracing::warn!("failed to decode entity expansion row: {e}");
+                                continue;
+                            }
+                        };
+                        let (
+                            id,
+                            content,
+                            raw_tags,
+                            importance,
+                            raw_metadata,
+                            event_type_str,
+                            session_id,
+                            project,
+                            priority,
+                            created_at,
+                            entity_id,
+                            agent_type,
+                            event_at,
+                        ) = row;
+
+                        if existing_ids.contains(&id) {
+                            continue; // Already in results
+                        }
+
+                        let tags = parse_tags_from_db(&raw_tags);
+                        let metadata = parse_metadata_from_db(&raw_metadata);
+                        let et = event_type_from_sql(event_type_str);
+                        let et_ref = et.as_ref().unwrap_or(&EventType::Memory);
+                        let priority_value = if let Some(p) = priority
+                            && (1..=5).contains(&p)
+                        {
+                            u8::try_from(p).unwrap_or(3)
+                        } else {
+                            let dp = et_ref.default_priority();
+                            if dp == 0 {
+                                3
+                            } else {
+                                u8::try_from(dp).unwrap_or(3)
+                            }
+                        };
+
+                        // Score: type_weight x priority x importance x ENTITY_EXPANSION_BOOST
+                        let base_score = type_weight_et(et_ref)
+                            * priority_factor(priority_value, scoring_params);
+                        let importance_factor_val = scoring_params.importance_floor
+                            + importance * scoring_params.importance_scale;
+                        let with_tags_text = if tags.is_empty() {
+                            content.clone()
+                        } else {
+                            format!("{} {}", content, tags.join(" "))
+                        };
+                        let overlap =
+                            word_overlap_pre(&query_tokens, &token_set(&with_tags_text, 3));
+                        let td = time_decay_et(&created_at, et_ref, scoring_params);
+
+                        let expanded_score = base_score
+                            * importance_factor_val
+                            * (1.0 + overlap * scoring_params.word_overlap_weight)
+                            * td
+                            * ENTITY_EXPANSION_BOOST;
+
+                        // Use a fraction of the max seed score as a baseline
+                        let max_seed_score = seed_list_for_expansion
+                            .first()
+                            .map(|(_, s, _)| *s)
+                            .unwrap_or(1.0);
+                        let final_score = expanded_score.min(max_seed_score * 0.8);
+
+                        let explain_data = if explain_enabled {
+                            Some(serde_json::json!({
+                                "entity_expansion": true,
+                                "expanded_from_tag": entity_tag,
+                                "entity_boost": ENTITY_EXPANSION_BOOST,
+                                "word_overlap": overlap,
+                                "importance_factor": importance_factor_val,
+                                "time_decay": td,
+                            }))
+                        } else {
+                            None
+                        };
+
+                        ranked.insert(
+                            id.clone(),
+                            RankedSemanticCandidate {
+                                result: SemanticResult {
+                                    id,
+                                    content,
+                                    tags,
+                                    importance,
+                                    metadata,
+                                    event_type: et,
+                                    session_id,
+                                    project,
+                                    entity_id: entity_id.clone(),
+                                    agent_type: agent_type.clone(),
+                                    score: 0.0,
+                                },
+                                created_at,
+                                event_at,
+                                score: final_score,
+                                priority_value,
+                                vec_sim: None,
+                                text_overlap: overlap,
+                                entity_id,
+                                agent_type,
+                                explain: explain_data,
+                            },
+                        );
+                        expanded_count += 1;
+                    }
+                }
+            }
+        }
+    }
+
     // ── Phase 6: Collection-level abstention + dedup ─────────────
     let mut deduped = Vec::new();
     let mut seen = HashSet::new();

--- a/src/memory_core/storage/sqlite/helpers.rs
+++ b/src/memory_core/storage/sqlite/helpers.rs
@@ -507,6 +507,17 @@ pub(super) fn content_hash(content: &str) -> String {
     format!("{:x}", hasher.finalize())
 }
 
+/// Extract entity slugs from tags matching the `entity:*` prefix pattern.
+///
+/// Given tags like `["entity:people:alice", "entity:tools:react", "locomo-test"]`,
+/// returns `["entity:people:alice", "entity:tools:react"]`.
+pub(super) fn extract_entities_from_tags(tags: &[String]) -> Vec<String> {
+    tags.iter()
+        .filter(|tag| tag.starts_with("entity:"))
+        .cloned()
+        .collect()
+}
+
 pub(super) fn parse_tags_from_db(raw: &str) -> Vec<String> {
     serde_json::from_str(raw).unwrap_or_default()
 }
@@ -2726,6 +2737,27 @@ mod tests {
             q.contains("\"automobile\""),
             "missing synonym 'automobile': {q}"
         );
+    }
+
+    #[test]
+    fn test_extract_entities_from_tags() {
+        let tags = vec![
+            "entity:people:alice".to_string(),
+            "entity:tools:react".to_string(),
+            "locomo-test".to_string(),
+            "session:1".to_string(),
+        ];
+        let entities = extract_entities_from_tags(&tags);
+        assert_eq!(entities.len(), 2);
+        assert!(entities.contains(&"entity:people:alice".to_string()));
+        assert!(entities.contains(&"entity:tools:react".to_string()));
+    }
+
+    #[test]
+    fn test_extract_entities_from_tags_empty() {
+        let tags: Vec<String> = vec!["locomo-test".to_string()];
+        let entities = extract_entities_from_tags(&tags);
+        assert!(entities.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Adds Phase 5b entity expansion after graph enrichment in `advanced_search()`
- Extracts entity tags from seed results, queries for additional memories with those tags
- Applies 1.15x multiplicative boost (ENTITY_EXPANSION_BOOST) to expanded results
- Limits to 5 entity tags, 5 results per tag, 25 total expanded

Part of the AutoMem scoring features implementation (Unit 4/5).

## Test plan
- [x] Unit tests for `extract_entities_from_tags()`
- [x] Test for ENTITY_EXPANSION_BOOST constant
- [x] `cargo test --all-features` passes (358 pass, 1 pre-existing failure)
- [x] LoCoMo benchmark shows no regression (75.3% word overlap, 77.7% ev. recall)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Entity expansion: top results are used to discover related entity-tagged memories and include additional expanded matches in ranked results, with safeguards on per-entity and overall expansion limits and a slight relevance boost for expanded items.
* **Tests**
  * Added unit tests covering entity tag extraction and the expansion scoring behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->