### PR TITLE
feat(bench): add voyage-4-nano ONNX + timing metrics

### DIFF
--- a/benches/bench_utils/mod.rs
+++ b/benches/bench_utils/mod.rs
@@ -1,3 +1,4 @@
 pub mod formatting;
 pub mod metrics;
 pub mod openai_types;
+pub mod timing_embedder;

--- a/benches/bench_utils/timing_embedder.rs
+++ b/benches/bench_utils/timing_embedder.rs
@@ -1,0 +1,80 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Instant;
+
+use anyhow::Result;
+use mag::memory_core::embedder::Embedder;
+
+/// Wraps an inner `Embedder`, recording timing and call counts atomically.
+#[allow(dead_code)]
+pub struct TimingEmbedder {
+    inner: Arc<dyn Embedder>,
+    calls: AtomicU64,
+    total_us: AtomicU64,
+}
+
+impl std::fmt::Debug for TimingEmbedder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TimingEmbedder")
+            .field("calls", &self.calls.load(Ordering::Relaxed))
+            .field("total_us", &self.total_us.load(Ordering::Relaxed))
+            .finish()
+    }
+}
+
+#[allow(dead_code)]
+impl TimingEmbedder {
+    pub fn new(inner: Arc<dyn Embedder>) -> Self {
+        Self {
+            inner,
+            calls: AtomicU64::new(0),
+            total_us: AtomicU64::new(0),
+        }
+    }
+
+    pub fn total_calls(&self) -> u64 {
+        self.calls.load(Ordering::Relaxed)
+    }
+
+    /// Total embed time in milliseconds.
+    pub fn total_embed_ms(&self) -> u64 {
+        self.total_us.load(Ordering::Relaxed) / 1000
+    }
+
+    /// Average embed time per call in milliseconds.
+    #[allow(clippy::cast_precision_loss)]
+    pub fn avg_embed_ms(&self) -> f64 {
+        let calls = self.calls.load(Ordering::Relaxed);
+        if calls == 0 {
+            0.0
+        } else {
+            self.total_us.load(Ordering::Relaxed) as f64 / calls as f64 / 1000.0
+        }
+    }
+}
+
+impl Embedder for TimingEmbedder {
+    fn dimension(&self) -> usize {
+        self.inner.dimension()
+    }
+
+    fn embed(&self, text: &str) -> Result<Vec<f32>> {
+        let t = Instant::now();
+        let r = self.inner.embed(text)?;
+        #[allow(clippy::cast_possible_truncation)]
+        self.total_us
+            .fetch_add(t.elapsed().as_micros() as u64, Ordering::Relaxed);
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        Ok(r)
+    }
+
+    fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+        let t = Instant::now();
+        let r = self.inner.embed_batch(texts)?;
+        #[allow(clippy::cast_possible_truncation)]
+        self.total_us
+            .fetch_add(t.elapsed().as_micros() as u64, Ordering::Relaxed);
+        self.calls.fetch_add(texts.len() as u64, Ordering::Relaxed);
+        Ok(r)
+    }
+}

--- a/benches/locomo/display.rs
+++ b/benches/locomo/display.rs
@@ -62,6 +62,15 @@ pub(crate) fn print_results(summary: &LoCoMoSummary) {
         summary.total_memories_ingested, summary.total_duration_seconds, summary.avg_query_ms
     );
     println!("  Peak RSS: {} KB", summary.peak_rss_kb);
+    println!("  Embedder: {}", summary.embedder_name);
+    {
+        #[allow(clippy::cast_precision_loss)]
+        let seed_time_s = summary.total_seed_ms as f64 / 1000.0;
+        println!(
+            "  Embed calls: {}  Avg embed: {:.1}ms  Seed time: {:.1}s",
+            summary.total_embed_calls, summary.avg_embed_ms, seed_time_s
+        );
+    }
     println!();
 
     // Header.

--- a/benches/locomo/main.rs
+++ b/benches/locomo/main.rs
@@ -5,6 +5,7 @@ static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 use std::collections::BTreeMap;
 use std::io::Write;
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::{Result, bail};
@@ -48,6 +49,7 @@ mod openai_embedder;
 mod scoring;
 mod seeding;
 mod types;
+mod voyage_embedder;
 
 use bench_utils::formatting::{pct, truncate};
 use bench_utils::metrics::PeakRss;
@@ -100,6 +102,21 @@ struct Args {
     /// Requires OPENAI_API_KEY in environment or .env.local file.
     #[arg(long)]
     openai_embeddings: bool,
+    /// Use voyage-4-nano ONNX (onnx-community, 2048-dim native, use --voyage-quant for variant).
+    #[arg(long)]
+    voyage_onnx: bool,
+    /// Use Voyage AI API embeddings (requires VOYAGE_API_KEY env var or .env.local).
+    #[arg(long)]
+    voyage_api: bool,
+    /// Voyage AI model name (default: voyage-4-lite).
+    #[arg(long)]
+    voyage_model: Option<String>,
+    /// Embedding dimension override for Matryoshka variants (256/512/1024/2048).
+    #[arg(long)]
+    embedder_dim: Option<usize>,
+    /// Voyage ONNX quantization variant: fp32, fp16, q4, int8 (default: int8).
+    #[arg(long, default_value = "int8")]
+    voyage_quant: String,
     /// Scoring mode: substring, word-overlap, llm-f1, or e2e-word-overlap.
     /// If omitted, defaults to substring unless --llm-judge/--local implies llm-f1.
     #[arg(long, value_enum)]
@@ -127,6 +144,13 @@ fn main() -> Result<()> {
     }
     if args.dataset_path.is_some() && (args.force_refresh || args.temp_dataset) {
         bail!("--dataset-path cannot be combined with --force-refresh or --temp-dataset");
+    }
+    let embedder_flags = [args.openai_embeddings, args.voyage_onnx, args.voyage_api]
+        .iter()
+        .filter(|&&b| b)
+        .count();
+    if embedder_flags > 1 {
+        bail!("only one of --openai-embeddings, --voyage-onnx, --voyage-api may be specified");
     }
 
     // Resolve effective scoring mode: --e2e shorthand wins over implicit default,
@@ -201,7 +225,7 @@ fn main() -> Result<()> {
         eprintln!("Scoring mode: {scoring_mode:?}");
     }
 
-    let embedder: std::sync::Arc<dyn Embedder> = if args.openai_embeddings {
+    let (inner_embedder, embedder_name): (Arc<dyn Embedder>, String) = if args.openai_embeddings {
         llm::load_api_key_from_dotenv();
         let api_key = std::env::var("OPENAI_API_KEY").map_err(|_| {
             anyhow::anyhow!(
@@ -211,13 +235,70 @@ fn main() -> Result<()> {
         if !args.json {
             eprintln!("Embedder: OpenAI text-embedding-3-large (3072-dim)");
         }
-        std::sync::Arc::new(openai_embedder::OpenAiEmbedder::new(api_key)?)
+        (
+            Arc::new(openai_embedder::OpenAiEmbedder::new(api_key)?),
+            "text-embedding-3-large (openai api, 3072-dim)".to_string(),
+        )
+    } else if args.voyage_onnx {
+        let dim = args.embedder_dim.unwrap_or(2048);
+        let quant = args.voyage_quant.as_str();
+        let (model_file, model_label) = match quant {
+            "fp32" => ("onnx/model.onnx", "FP32"),
+            "fp16" => ("onnx/model_fp16.onnx", "FP16"),
+            "q4" => ("onnx/model_q4.onnx", "Q4"),
+            _ => ("onnx/model_quantized.onnx", "INT8"), // default
+        };
+        let base = "https://huggingface.co/onnx-community/voyage-4-nano-ONNX/resolve/main";
+        let model_url = format!("{base}/{model_file}");
+        let tokenizer_url = format!("{base}/tokenizer.json");
+        if !args.json {
+            eprintln!("Embedder: voyage-4-nano {model_label} ONNX ({dim}-dim)");
+        }
+        (
+            Arc::new(OnnxEmbedder::with_model(
+                "voyage-4-nano-onnx-community",
+                &model_url,
+                &tokenizer_url,
+                dim,
+                "pooler_output",
+            )?),
+            format!("voyage-4-nano {model_label} onnx ({dim}-dim)"),
+        )
+    } else if args.voyage_api {
+        llm::load_api_key_from_dotenv();
+        let api_key = std::env::var("VOYAGE_API_KEY").map_err(|_| {
+            anyhow::anyhow!("--voyage-api requires VOYAGE_API_KEY (env var or .env.local file)")
+        })?;
+        let model = args
+            .voyage_model
+            .clone()
+            .unwrap_or_else(|| "voyage-4-lite".to_string());
+        let dim = args.embedder_dim.unwrap_or(1024);
+        if !args.json {
+            eprintln!("Embedder: Voyage API {model} ({dim}-dim)");
+        }
+        (
+            Arc::new(voyage_embedder::VoyageApiEmbedder::new(
+                api_key,
+                model.clone(),
+                dim,
+            )?),
+            format!("{model} (voyage api, {dim}-dim)"),
+        )
     } else {
         if !args.json {
             eprintln!("Embedder: ONNX bge-small-en-v1.5 (384-dim)");
         }
-        std::sync::Arc::new(OnnxEmbedder::new()?)
+        (
+            Arc::new(OnnxEmbedder::new()?),
+            "bge-small-en-v1.5 (onnx, 384-dim)".to_string(),
+        )
     };
+
+    let timing = Arc::new(bench_utils::timing_embedder::TimingEmbedder::new(
+        inner_embedder,
+    ));
+    let embedder: Arc<dyn Embedder> = timing.clone();
     let top_k = args.top_k.unwrap_or(50);
     let start = Instant::now();
     let mut rss = PeakRss::default();
@@ -226,6 +307,7 @@ fn main() -> Result<()> {
     let mut total_memories = 0usize;
     let mut total_queries = 0usize;
     let mut total_query_ms = 0u128;
+    let mut total_seed_ms = 0u128;
     let mut total_correct = 0usize;
     let mut total_f1_sum = 0.0f64;
     let mut total_evidence_recall_sum = 0.0f64;
@@ -253,8 +335,10 @@ fn main() -> Result<()> {
             storage.set_scoring_params(params);
         }
 
+        let seed_start = Instant::now();
         let seeded =
             runtime.block_on(seeding::seed_sample(&storage, sample, !args.no_entity_tags))?;
+        total_seed_ms += seed_start.elapsed().as_millis();
         total_memories += seeded;
         samples_evaluated += 1;
         rss.sample();
@@ -483,6 +567,11 @@ fn main() -> Result<()> {
         ScoringMode::E2eWordOverlap => "e2e-word-overlap",
     };
 
+    let total_embed_calls = timing.total_calls();
+    let avg_embed_ms = timing.avg_embed_ms();
+    #[allow(clippy::cast_possible_truncation)]
+    let total_seed_ms_u64 = total_seed_ms as u64;
+
     let summary = types::LoCoMoSummary {
         metadata,
         dataset: "LoCoMo10".to_string(),
@@ -498,6 +587,10 @@ fn main() -> Result<()> {
         mean_f1,
         mean_evidence_recall,
         categories,
+        embedder_name,
+        total_seed_ms: total_seed_ms_u64,
+        total_embed_calls,
+        avg_embed_ms,
     };
 
     if args.json {

--- a/benches/locomo/types.rs
+++ b/benches/locomo/types.rs
@@ -150,4 +150,8 @@ pub(crate) struct LoCoMoSummary {
     pub mean_f1: f64,
     pub mean_evidence_recall: f64,
     pub categories: BTreeMap<String, CategoryResult>,
+    pub embedder_name: String,
+    pub total_seed_ms: u64,
+    pub total_embed_calls: u64,
+    pub avg_embed_ms: f64,
 }

--- a/benches/locomo/voyage_embedder.rs
+++ b/benches/locomo/voyage_embedder.rs
@@ -1,0 +1,227 @@
+use std::sync::Mutex;
+use std::time::Duration;
+
+use anyhow::{Context, Result, anyhow};
+use mag::memory_core::embedder::Embedder;
+use sha2::{Digest, Sha256};
+
+/// Maximum number of texts per Voyage AI embeddings API call.
+const BATCH_SIZE: usize = 128;
+
+const EMBEDDING_URL: &str = "https://api.voyageai.com/v1/embeddings";
+
+/// Voyage AI embedder.
+///
+/// Uses the Voyage AI embeddings API via reqwest. The sync `embed()` trait method
+/// bridges to async via a dedicated single-threaded tokio runtime (safe from
+/// within `spawn_blocking` contexts where `block_in_place` would panic).
+pub(crate) struct VoyageApiEmbedder {
+    api_key: String,
+    model: String,
+    dimension: usize,
+    client: reqwest::Client,
+    /// Dedicated runtime for bridging sync -> async HTTP calls.
+    runtime: tokio::runtime::Runtime,
+    /// LRU cache keyed by SHA-256 of input text.
+    cache: Mutex<lru::LruCache<[u8; 32], Vec<f32>>>,
+}
+
+impl VoyageApiEmbedder {
+    pub fn new(api_key: String, model: String, dimension: usize) -> Result<Self> {
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(120))
+            .connect_timeout(Duration::from_secs(30))
+            .build()
+            .context("failed to build HTTP client for Voyage AI embeddings")?;
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .context("failed to create tokio runtime for Voyage AI embedder")?;
+        let cache_capacity = std::num::NonZeroUsize::new(4096)
+            .ok_or_else(|| anyhow!("cache capacity must be non-zero"))?;
+        Ok(Self {
+            api_key,
+            model,
+            dimension,
+            client,
+            runtime,
+            cache: Mutex::new(lru::LruCache::new(cache_capacity)),
+        })
+    }
+
+    /// Call Voyage AI embeddings API for a batch of texts, returning one vector per text.
+    fn call_api(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+        let model = self.model.clone();
+        let dimension = self.dimension;
+        self.runtime.block_on(async {
+            let mut body = serde_json::json!({
+                "model": model,
+                "input": texts,
+            });
+            // Only include output_dimension if it differs from the default (1024).
+            if dimension != 1024 {
+                body["output_dimension"] = serde_json::json!(dimension);
+            }
+
+            let response = self
+                .client
+                .post(EMBEDDING_URL)
+                .bearer_auth(&self.api_key)
+                .json(&body)
+                .send()
+                .await
+                .context("Voyage AI embeddings request failed")?;
+
+            if !response.status().is_success() {
+                let status = response.status();
+                let body_text = response
+                    .text()
+                    .await
+                    .unwrap_or_else(|_| "<unreadable>".to_string());
+                return Err(anyhow!(
+                    "Voyage AI embeddings API returned {status}: {body_text}"
+                ));
+            }
+
+            let parsed: VoyageEmbeddingResponse = response
+                .json()
+                .await
+                .context("failed to parse Voyage AI embeddings response")?;
+
+            // The API returns embeddings in order of the input index, but we
+            // sort by index to be safe.
+            let mut items = parsed.data;
+            items.sort_by_key(|item| item.index);
+
+            if items.len() != texts.len() {
+                return Err(anyhow!(
+                    "Voyage AI returned {} embeddings for {} inputs",
+                    items.len(),
+                    texts.len()
+                ));
+            }
+
+            Ok(items.into_iter().map(|item| item.embedding).collect())
+        })
+    }
+
+    fn cache_key(text: &str) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        hasher.update(text.as_bytes());
+        hasher.finalize().into()
+    }
+}
+
+impl std::fmt::Debug for VoyageApiEmbedder {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VoyageApiEmbedder")
+            .field("model", &self.model)
+            .field("dimension", &self.dimension)
+            .finish()
+    }
+}
+
+impl Embedder for VoyageApiEmbedder {
+    fn dimension(&self) -> usize {
+        self.dimension
+    }
+
+    fn embed(&self, text: &str) -> Result<Vec<f32>> {
+        let key = Self::cache_key(text);
+        if let Ok(mut cache) = self.cache.lock()
+            && let Some(cached) = cache.get(&key)
+        {
+            return Ok(cached.clone());
+        }
+
+        let mut results = self.call_api(&[text])?;
+        let embedding = results
+            .pop()
+            .ok_or_else(|| anyhow!("empty response from Voyage AI embeddings API"))?;
+
+        if let Ok(mut cache) = self.cache.lock() {
+            cache.put(key, embedding.clone());
+        }
+        Ok(embedding)
+    }
+
+    fn embed_batch(&self, texts: &[&str]) -> Result<Vec<Vec<f32>>> {
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
+        if texts.len() == 1 {
+            return Ok(vec![self.embed(texts[0])?]);
+        }
+
+        // --- Cache probe: split hits from misses ---
+        let keys: Vec<[u8; 32]> = texts.iter().map(|t| Self::cache_key(t)).collect();
+        let mut results: Vec<Option<Vec<f32>>> = vec![None; texts.len()];
+        let mut miss_indices: Vec<usize> = Vec::new();
+
+        if let Ok(mut cache) = self.cache.lock() {
+            for (i, key) in keys.iter().enumerate() {
+                if let Some(cached) = cache.get(key) {
+                    results[i] = Some(cached.clone());
+                } else {
+                    miss_indices.push(i);
+                }
+            }
+        } else {
+            miss_indices.extend(0..texts.len());
+        }
+
+        if miss_indices.is_empty() {
+            return results
+                .into_iter()
+                .map(|opt| opt.ok_or_else(|| anyhow!("unexpected None in cache-hit path")))
+                .collect();
+        }
+
+        // --- Batched API calls for cache misses ---
+        let miss_texts: Vec<&str> = miss_indices.iter().map(|&i| texts[i]).collect();
+        let mut all_computed: Vec<Vec<f32>> = Vec::with_capacity(miss_texts.len());
+
+        for chunk in miss_texts.chunks(BATCH_SIZE) {
+            let batch_result = self.call_api(chunk)?;
+            all_computed.extend(batch_result);
+        }
+
+        if all_computed.len() != miss_indices.len() {
+            return Err(anyhow!(
+                "Voyage AI returned {} embeddings for {} miss texts",
+                all_computed.len(),
+                miss_indices.len()
+            ));
+        }
+
+        // --- Populate cache and assemble results ---
+        if let Ok(mut cache) = self.cache.lock() {
+            for (embedding, &orig_idx) in all_computed.iter().zip(miss_indices.iter()) {
+                cache.put(keys[orig_idx], embedding.clone());
+                results[orig_idx] = Some(embedding.clone());
+            }
+        } else {
+            for (embedding, &orig_idx) in all_computed.into_iter().zip(miss_indices.iter()) {
+                results[orig_idx] = Some(embedding);
+            }
+        }
+
+        results
+            .into_iter()
+            .map(|opt| opt.ok_or_else(|| anyhow!("unexpected None in batch result")))
+            .collect()
+    }
+}
+
+// ── Voyage AI Embeddings API response types ──────────────────────────────
+
+#[derive(Debug, serde::Deserialize)]
+struct VoyageEmbeddingResponse {
+    data: Vec<VoyageEmbeddingItem>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct VoyageEmbeddingItem {
+    embedding: Vec<f32>,
+    index: usize,
+}

--- a/src/memory_core/embedder.rs
+++ b/src/memory_core/embedder.rs
@@ -73,6 +73,10 @@ const IDLE_TIMEOUT_SECS: u64 = 600; // 10 minutes
 #[derive(Debug)]
 pub struct OnnxEmbedder {
     model_dir: PathBuf,
+    model_url: String,
+    tokenizer_url: String,
+    dimension: usize,
+    output_tensor_name: String,
     runtime: std::sync::Mutex<Option<OnnxRuntime>>,
     last_used: std::sync::atomic::AtomicU64,
     cache: std::sync::Mutex<lru::LruCache<[u8; 32], Vec<f32>>>,
@@ -96,8 +100,29 @@ struct ModelFiles {
 #[cfg(feature = "real-embeddings")]
 impl OnnxEmbedder {
     pub fn new() -> Result<Self> {
+        Self::with_model(
+            "bge-small-en-v1.5",
+            MODEL_URL,
+            TOKENIZER_URL,
+            384,
+            "last_hidden_state",
+        )
+    }
+
+    pub fn with_model(
+        name: &str,
+        model_url: &str,
+        tokenizer_url: &str,
+        dimension: usize,
+        output_tensor_name: &str,
+    ) -> Result<Self> {
+        let model_dir = app_paths::resolve_app_paths()?.model_root.join(name);
         Ok(Self {
-            model_dir: default_model_dir()?,
+            model_dir,
+            model_url: model_url.to_string(),
+            tokenizer_url: tokenizer_url.to_string(),
+            dimension,
+            output_tensor_name: output_tensor_name.to_string(),
             runtime: std::sync::Mutex::new(None),
             last_used: std::sync::atomic::AtomicU64::new(0),
             cache: std::sync::Mutex::new(lru::LruCache::new(EMBEDDING_CACHE_CAPACITY)),
@@ -177,7 +202,11 @@ impl OnnxEmbedder {
     }
 
     fn init_runtime(&self) -> Result<OnnxRuntime> {
-        let files = ensure_model_files_blocking(self.model_dir.clone())?;
+        let files = ensure_model_files_blocking(
+            self.model_dir.clone(),
+            &self.model_url,
+            &self.tokenizer_url,
+        )?;
         // Force CPU-only execution (skip CoreML/Metal which leak memory on
         // long-running macOS processes) and disable the CPU memory arena to
         // reduce RSS by ~50 MB.
@@ -213,7 +242,7 @@ impl OnnxEmbedder {
 #[cfg(feature = "real-embeddings")]
 impl Embedder for OnnxEmbedder {
     fn dimension(&self) -> usize {
-        384
+        self.dimension
     }
 
     fn embed(&self, text: &str) -> Result<Vec<f32>> {
@@ -284,52 +313,75 @@ impl Embedder for OnnxEmbedder {
                 ])
                 .context("ONNX inference failed")?;
             let first_output = outputs
-                .get("last_hidden_state")
-                .ok_or_else(|| anyhow!("missing ONNX output tensor 'last_hidden_state'"))?;
+                .get(self.output_tensor_name.as_str())
+                .ok_or_else(|| {
+                    anyhow!("missing ONNX output tensor '{}'", self.output_tensor_name)
+                })?;
             let (shape, output) = first_output
                 .try_extract_tensor::<f32>()
                 .context("failed to extract ONNX output tensor")?;
 
-            if shape.len() != 3 || shape[0] != 1 {
+            // Support both 2D pre-pooled tensors (shape [1, hidden]) and
+            // 3D token-level tensors (shape [1, seq_len, hidden]) that need mean-pooling.
+            let mut pooled = if shape.len() == 2 {
+                // Pre-pooled output (e.g. onnx-community/voyage-4-nano-ONNX `pooler_output`).
+                // Shape: [1, hidden_size] — already mean-pooled and L2-normalised by the model.
+                if shape[0] != 1 {
+                    return Err(anyhow!("unexpected ONNX output shape: {shape:?}"));
+                }
+                let hidden_size =
+                    usize::try_from(shape[1]).context("invalid output hidden size")?;
+                if hidden_size < self.dimension {
+                    return Err(anyhow!(
+                        "ONNX output dim {hidden_size} is smaller than requested dim {}",
+                        self.dimension
+                    ));
+                }
+                // Matryoshka truncation: slice to requested dimension then re-normalise.
+                output[..self.dimension].to_vec()
+            } else if shape.len() == 3 {
+                // Token-level output — apply mean pooling with attention mask.
+                if shape[0] != 1 {
+                    return Err(anyhow!("unexpected ONNX output shape: {shape:?}"));
+                }
+                let output_seq_len =
+                    usize::try_from(shape[1]).context("invalid output sequence length")?;
+                let hidden_size =
+                    usize::try_from(shape[2]).context("invalid output hidden size")?;
+                if hidden_size < self.dimension {
+                    return Err(anyhow!(
+                        "ONNX output dim {hidden_size} smaller than requested dim {}",
+                        self.dimension
+                    ));
+                }
+                if output_seq_len == 0 {
+                    return Err(anyhow!("ONNX output sequence length is zero"));
+                }
+                let effective_len = output_seq_len.min(seq_len);
+                let mut pooled = vec![0.0f32; self.dimension];
+                let mut mask_sum = 0.0f32;
+                for token_idx in 0..effective_len {
+                    #[allow(clippy::cast_precision_loss)]
+                    let mask_value = encoding.get_attention_mask()[token_idx] as f32;
+                    if mask_value <= 0.0 {
+                        continue;
+                    }
+                    mask_sum += mask_value;
+                    for (d, pooled_value) in pooled.iter_mut().enumerate() {
+                        let flat_index = token_idx * hidden_size + d;
+                        *pooled_value += output[flat_index] * mask_value;
+                    }
+                }
+                if mask_sum <= 0.0 {
+                    return Err(anyhow!("attention mask sum is zero during mean pooling"));
+                }
+                for value in &mut pooled {
+                    *value /= mask_sum;
+                }
+                pooled
+            } else {
                 return Err(anyhow!("unexpected ONNX output shape: {shape:?}"));
-            }
-            let output_seq_len =
-                usize::try_from(shape[1]).context("invalid output sequence length")?;
-            let hidden_size = usize::try_from(shape[2]).context("invalid output hidden size")?;
-            if hidden_size != self.dimension() {
-                return Err(anyhow!(
-                    "unexpected embedding dimension: got {hidden_size}, expected {}",
-                    self.dimension()
-                ));
-            }
-            if output_seq_len == 0 {
-                return Err(anyhow!("ONNX output sequence length is zero"));
-            }
-
-            let effective_len = output_seq_len.min(seq_len);
-            let mut pooled = vec![0.0f32; hidden_size];
-            let mut mask_sum = 0.0f32;
-
-            for token_idx in 0..effective_len {
-                // Attention mask values are 0 or 1, so cast to f32 is lossless.
-                #[allow(clippy::cast_precision_loss)]
-                let mask_value = encoding.get_attention_mask()[token_idx] as f32;
-                if mask_value <= 0.0 {
-                    continue;
-                }
-                mask_sum += mask_value;
-                for (dim, pooled_value) in pooled.iter_mut().enumerate() {
-                    let flat_index = token_idx * hidden_size + dim;
-                    *pooled_value += output[flat_index] * mask_value;
-                }
-            }
-
-            if mask_sum <= 0.0 {
-                return Err(anyhow!("attention mask sum is zero during mean pooling"));
-            }
-            for value in &mut pooled {
-                *value /= mask_sum;
-            }
+            };
             normalize_embedding(&mut pooled);
             pooled
         };
@@ -475,66 +527,96 @@ impl Embedder for OnnxEmbedder {
                 ])
                 .context("batched ONNX inference failed")?;
             let first_output = outputs
-                .get("last_hidden_state")
-                .ok_or_else(|| anyhow!("missing ONNX output tensor 'last_hidden_state'"))?;
+                .get(self.output_tensor_name.as_str())
+                .ok_or_else(|| {
+                    anyhow!("missing ONNX output tensor '{}'", self.output_tensor_name)
+                })?;
             let (shape, output) = first_output
                 .try_extract_tensor::<f32>()
                 .context("failed to extract batched ONNX output tensor")?;
 
-            if shape.len() != 3 {
-                return Err(anyhow!("unexpected batched ONNX output shape: {shape:?}"));
-            }
-            let out_batch = usize::try_from(shape[0]).context("invalid output batch dimension")?;
-            let out_seq_len =
-                usize::try_from(shape[1]).context("invalid output sequence length")?;
-            let hidden_size = usize::try_from(shape[2]).context("invalid output hidden size")?;
-            if out_batch != batch_size {
-                return Err(anyhow!(
-                    "output batch size mismatch: got {out_batch}, expected {batch_size}"
-                ));
-            }
-            if hidden_size != self.dimension() {
-                return Err(anyhow!(
-                    "unexpected embedding dimension: got {hidden_size}, expected {}",
-                    self.dimension()
-                ));
-            }
-            if out_seq_len == 0 {
-                return Err(anyhow!("ONNX output sequence length is zero"));
-            }
-
-            // Mean-pool each item in the batch using its own attention mask.
+            // Support both 2D pre-pooled tensors (shape [batch, hidden]) and
+            // 3D token-level tensors (shape [batch, seq_len, hidden]).
             let mut batch_embeddings: Vec<Vec<f32>> = Vec::with_capacity(batch_size);
-            for (b, enc) in encodings.iter().enumerate() {
-                let seq_len = enc.get_ids().len();
-                let effective_len = out_seq_len.min(seq_len);
-                let mut pooled = vec![0.0f32; hidden_size];
-                let mut mask_sum = 0.0f32;
-
-                for token_idx in 0..effective_len {
-                    // Attention mask values are 0 or 1, so cast to f32 is lossless.
-                    #[allow(clippy::cast_precision_loss)]
-                    let mask_value = enc.get_attention_mask()[token_idx] as f32;
-                    if mask_value <= 0.0 {
-                        continue;
-                    }
-                    mask_sum += mask_value;
-                    let row_offset = b * out_seq_len * hidden_size + token_idx * hidden_size;
-                    for (dim, pooled_value) in pooled.iter_mut().enumerate() {
-                        *pooled_value += output[row_offset + dim] * mask_value;
-                    }
-                }
-
-                if mask_sum <= 0.0 {
+            if shape.len() == 2 {
+                // Pre-pooled output — shape [batch, hidden_size].
+                let out_batch =
+                    usize::try_from(shape[0]).context("invalid output batch dimension")?;
+                let hidden_size =
+                    usize::try_from(shape[1]).context("invalid output hidden size")?;
+                if out_batch != batch_size {
                     return Err(anyhow!(
-                        "attention mask sum is zero during mean pooling for batch item {b}"
+                        "output batch size mismatch: got {out_batch}, expected {batch_size}"
                     ));
                 }
-                for value in &mut pooled {
-                    *value /= mask_sum;
+                if hidden_size < self.dimension {
+                    return Err(anyhow!(
+                        "ONNX output dim {hidden_size} is smaller than requested dim {}",
+                        self.dimension
+                    ));
                 }
-                normalize_embedding(&mut pooled);
-                batch_embeddings.push(pooled);
+                for b in 0..batch_size {
+                    let row_start = b * hidden_size;
+                    // Matryoshka truncation + re-normalise.
+                    let mut pooled = output[row_start..row_start + self.dimension].to_vec();
+                    normalize_embedding(&mut pooled);
+                    batch_embeddings.push(pooled);
+                }
+            } else if shape.len() == 3 {
+                let out_batch =
+                    usize::try_from(shape[0]).context("invalid output batch dimension")?;
+                let out_seq_len =
+                    usize::try_from(shape[1]).context("invalid output sequence length")?;
+                let hidden_size =
+                    usize::try_from(shape[2]).context("invalid output hidden size")?;
+                if out_batch != batch_size {
+                    return Err(anyhow!(
+                        "output batch size mismatch: got {out_batch}, expected {batch_size}"
+                    ));
+                }
+                if hidden_size < self.dimension {
+                    return Err(anyhow!(
+                        "unexpected embedding dimension: got {hidden_size}, expected >= {}",
+                        self.dimension
+                    ));
+                }
+                if out_seq_len == 0 {
+                    return Err(anyhow!("ONNX output sequence length is zero"));
+                }
+                // Mean-pool each item in the batch using its own attention mask.
+                for (b, enc) in encodings.iter().enumerate() {
+                    let seq_len = enc.get_ids().len();
+                    let effective_len = out_seq_len.min(seq_len);
+                    let mut pooled = vec![0.0f32; self.dimension];
+                    let mut mask_sum = 0.0f32;
+
+                    for token_idx in 0..effective_len {
+                        // Attention mask values are 0 or 1, so cast to f32 is lossless.
+                        #[allow(clippy::cast_precision_loss)]
+                        let mask_value = enc.get_attention_mask()[token_idx] as f32;
+                        if mask_value <= 0.0 {
+                            continue;
+                        }
+                        mask_sum += mask_value;
+                        let row_offset = b * out_seq_len * hidden_size + token_idx * hidden_size;
+                        for (d, pooled_value) in pooled.iter_mut().enumerate() {
+                            *pooled_value += output[row_offset + d] * mask_value;
+                        }
+                    }
+
+                    if mask_sum <= 0.0 {
+                        return Err(anyhow!(
+                            "attention mask sum is zero during mean pooling for batch item {b}"
+                        ));
+                    }
+                    for value in &mut pooled {
+                        *value /= mask_sum;
+                    }
+                    normalize_embedding(&mut pooled);
+                    batch_embeddings.push(pooled);
+                }
+            } else {
+                return Err(anyhow!("unexpected batched ONNX output shape: {shape:?}"));
             }
             batch_embeddings
         };
@@ -566,7 +648,7 @@ impl Embedder for OnnxEmbedder {
 #[cfg(feature = "real-embeddings")]
 pub async fn download_bge_small_model() -> Result<PathBuf> {
     let model_dir = default_model_dir()?;
-    let files = ensure_model_files_async(model_dir).await?;
+    let files = ensure_model_files_async(model_dir, MODEL_URL, TOKENIZER_URL).await?;
     Ok(files.directory)
 }
 
@@ -576,7 +658,11 @@ fn default_model_dir() -> Result<PathBuf> {
 }
 
 #[cfg(feature = "real-embeddings")]
-fn ensure_model_files_blocking(model_dir: PathBuf) -> Result<ModelFiles> {
+fn ensure_model_files_blocking(
+    model_dir: PathBuf,
+    model_url: &str,
+    tokenizer_url: &str,
+) -> Result<ModelFiles> {
     if model_files_exist(&model_dir) {
         return Ok(model_files_for_dir(model_dir));
     }
@@ -589,11 +675,19 @@ fn ensure_model_files_blocking(model_dir: PathBuf) -> Result<ModelFiles> {
         .enable_all()
         .build()
         .context("failed to create temporary tokio runtime for model download")?;
-    runtime.block_on(ensure_model_files_async(model_dir))
+    runtime.block_on(ensure_model_files_async(
+        model_dir,
+        model_url,
+        tokenizer_url,
+    ))
 }
 
 #[cfg(feature = "real-embeddings")]
-async fn ensure_model_files_async(model_dir: PathBuf) -> Result<ModelFiles> {
+async fn ensure_model_files_async(
+    model_dir: PathBuf,
+    model_url: &str,
+    tokenizer_url: &str,
+) -> Result<ModelFiles> {
     let files = model_files_for_dir(model_dir);
     if model_files_exist(&files.directory) {
         return Ok(files);
@@ -612,13 +706,13 @@ async fn ensure_model_files_async(model_dir: PathBuf) -> Result<ModelFiles> {
         .await
         .context("failed to check model.onnx path")?
     {
-        download_file(MODEL_URL, &files.model_path).await?;
+        download_file(model_url, &files.model_path).await?;
     }
     if !tokio::fs::try_exists(&files.tokenizer_path)
         .await
         .context("failed to check tokenizer.json path")?
     {
-        download_file(TOKENIZER_URL, &files.tokenizer_path).await?;
+        download_file(tokenizer_url, &files.tokenizer_path).await?;
     }
 
     Ok(files)


### PR DESCRIPTION
## Summary

- Add voyage-4-nano ONNX support to the LoCoMo benchmark via --voyage-onnx flag
- Support all quantization variants (FP32, FP16, Q4, INT8) via --voyage-quant
- Support Matryoshka dimension variants (256/512/1024/2048) via --embedder-dim
- Add TimingEmbedder wrapper to track embed call count + latency across all embedders
- Add Voyage API embedder (--voyage-api) for API-based model comparison
- Surface timing stats in benchmark output: total_seed_ms, total_embed_calls, avg_embed_ms, embedder_name

## Implementation details

- OnnxEmbedder is now configurable via with_model() constructor
- Handles both 2D pre-pooled tensors (pooler_output from voyage-nano) and 3D token-level tensors (last_hidden_state from bge-small)
- Matryoshka truncation: slice to target dim then renormalize (L2)
- Default model unchanged: bge-small-en-v1.5 with last_hidden_state, dim=384

## Test plan

- cargo build --features real-embeddings --bin locomo_bench compiles without warnings
- ./locomo_bench --voyage-onnx runs with voyage-4-nano INT8
- ./locomo_bench --voyage-onnx --voyage-quant fp32 --embedder-dim 1024 runs with correct dim
- ./locomo_bench (no flags) still uses bge-small-en-v1.5

Generated with Claude Code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple embedder backends: Voyage ONNX, Voyage API, and OpenAI.
  * Added configurable embedder model selection via command-line options.
  * Enhanced benchmark output with performance metrics: embedder name, total embedding calls, average embedding latency, and seeding time.
  * Implemented result caching for API-based embeddings.

* **Chores**
  * Added internal performance measurement utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->