### PR TITLE
feat(bench): standardized benchmark runner + CSV log

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,16 @@ cargo run --release --bin longmemeval_bench -- --grid-search  # parameter optimi
 cargo run --release --bin locomo_bench -- --samples 2                                # substring baseline
 cargo run --release --bin locomo_bench -- --samples 2 --scoring-mode word-overlap    # AutoMem-comparable
 cargo run --release --bin locomo_bench -- --llm-judge --samples 2                    # LLM judge (needs OPENAI_API_KEY)
+
+# Standardized benchmark runner (logs to docs/benchmark_log.csv, prints comparison table)
+./scripts/bench.sh                                 # bge-small, 2 samples, word-overlap
+./scripts/bench.sh --model voyage-nano-int8        # voyage-4-nano INT8 @ 1024-dim
+./scripts/bench.sh --model bge-small --samples 10  # full validation run
+./scripts/bench.sh --model voyage-nano-fp32 --notes "after scoring tweak"  # with notes
+
+# README update checker (suggests edits, does not modify files)
+./scripts/check-readme.sh                          # analyze last 3 commits vs README
+./scripts/check-readme.sh "new model, score improved to 91%"  # with context hint
 ```
 
 ## Architecture

--- a/benchmarks/LATEST.md
+++ b/benchmarks/LATEST.md
@@ -1,0 +1,5 @@
+# MAG Benchmark Results
+
+Latest benchmark runs. Updated automatically by `./scripts/bench.sh`.
+
+See `docs/benchmark_log.csv` for full history.

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# bench.sh — Standardized LoCoMo benchmark runner
+#
+# Usage:
+#   ./scripts/bench.sh
+#   ./scripts/bench.sh --model voyage-nano-int8
+#   ./scripts/bench.sh --model bge-small --samples 10
+#   ./scripts/bench.sh --model voyage-nano-fp32 --dim 512 --scoring-mode word-overlap
+#
+# Appends a row to docs/benchmark_log.csv and prints a comparison table of all
+# runs with the same scoring-mode.  Also writes benchmarks/LATEST.md.
+#
+# CSV format (16 columns):
+#   date,commit,branch,issue_or_pr,scoring_mode,samples,embedding_model,
+#   overall_score,single_hop,temporal,multi_hop,open_domain,adversarial,
+#   evidence_recall,avg_query_ms,notes
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RESULTS_CSV="${REPO_DIR}/docs/benchmark_log.csv"
+LATEST_MD="${REPO_DIR}/benchmarks/LATEST.md"
+
+CSV_HEADER="date,commit,branch,issue_or_pr,scoring_mode,samples,embedding_model,overall_score,single_hop,temporal,multi_hop,open_domain,adversarial,evidence_recall,avg_query_ms,notes"
+
+# ── Defaults ─────────────────────────────────────────────────────────────────
+MODEL="bge-small"
+DIM=""            # empty = use model default
+SAMPLES=2
+SCORING_MODE="word-overlap"
+NOTES=""
+
+# ── Parse flags ───────────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --model)        MODEL="$2";        shift 2 ;;
+        --dim)          DIM="$2";          shift 2 ;;
+        --samples)      SAMPLES="$2";      shift 2 ;;
+        --scoring-mode) SCORING_MODE="$2"; shift 2 ;;
+        --notes)        NOTES="$2";        shift 2 ;;
+        *) echo "Unknown flag: $1" >&2; exit 1 ;;
+    esac
+done
+
+# ── Model → default dim + cargo flags ────────────────────────────────────────
+case "$MODEL" in
+    bge-small)
+        DEFAULT_DIM=384
+        EMBEDDING_MODEL="onnx-bge-small"
+        CARGO_FLAGS=(--release --bin locomo_bench -- --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
+        ;;
+    voyage-nano-int8)
+        DEFAULT_DIM=1024
+        EMBEDDING_MODEL="voyage-nano-int8"
+        DIM_ARG="${DIM:-1024}"
+        CARGO_FLAGS=(--release --bin locomo_bench -- --voyage-onnx --voyage-quant int8 --embedder-dim "${DIM_ARG}" --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
+        ;;
+    voyage-nano-fp16)
+        DEFAULT_DIM=1024
+        EMBEDDING_MODEL="voyage-nano-fp16"
+        DIM_ARG="${DIM:-1024}"
+        CARGO_FLAGS=(--release --bin locomo_bench -- --voyage-onnx --voyage-quant fp16 --embedder-dim "${DIM_ARG}" --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
+        ;;
+    voyage-nano-fp32)
+        DEFAULT_DIM=1024
+        EMBEDDING_MODEL="voyage-nano-fp32"
+        DIM_ARG="${DIM:-1024}"
+        CARGO_FLAGS=(--release --bin locomo_bench -- --voyage-onnx --voyage-quant fp32 --embedder-dim "${DIM_ARG}" --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
+        ;;
+    voyage-nano-q4)
+        DEFAULT_DIM=1024
+        EMBEDDING_MODEL="voyage-nano-q4"
+        DIM_ARG="${DIM:-1024}"
+        CARGO_FLAGS=(--release --bin locomo_bench -- --voyage-onnx --voyage-quant q4 --embedder-dim "${DIM_ARG}" --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
+        ;;
+    *)
+        echo "Unknown model: ${MODEL}" >&2
+        echo "Valid models: bge-small, voyage-nano-int8, voyage-nano-fp16, voyage-nano-fp32, voyage-nano-q4" >&2
+        exit 1
+        ;;
+esac
+
+# ── Ensure CSV exists ─────────────────────────────────────────────────────────
+if [[ ! -f "${RESULTS_CSV}" ]]; then
+    echo "${CSV_HEADER}" > "${RESULTS_CSV}"
+    echo "Created ${RESULTS_CSV}"
+fi
+
+# ── Run benchmark, capture output ────────────────────────────────────────────
+cd "${REPO_DIR}"
+echo "Running: cargo ${CARGO_FLAGS[*]}"
+echo "──────────────────────────────────────────────────────────────────────────"
+
+RAW_OUTPUT="$(cargo "${CARGO_FLAGS[@]}" 2>&1)"
+EXIT_CODE=$?
+echo "${RAW_OUTPUT}"
+echo "──────────────────────────────────────────────────────────────────────────"
+
+if [[ $EXIT_CODE -ne 0 ]]; then
+    echo "Benchmark run failed (exit ${EXIT_CODE})" >&2
+    exit "${EXIT_CODE}"
+fi
+
+# ── Parse output ─────────────────────────────────────────────────────────────
+
+# Primary score: word overlap / mean score line
+overall_score=$(echo "${RAW_OUTPUT}" | grep -E "WORD OVERLAP|E2E WORD OVERLAP|MEAN TOKEN F1|MEAN LLM F1" | grep -oE '[0-9]+\.[0-9]+' | head -1)
+overall_score="${overall_score:-0}"
+
+# Evidence recall
+evidence_recall=$(echo "${RAW_OUTPUT}" | grep "MEAN EV. RECALL" | grep -oE '[0-9]+\.[0-9]+' | head -1)
+evidence_recall="${evidence_recall:-}"
+
+# Category lines: "  Single-Hop QA            18.6%    87.6%    82.7%"
+# Columns: Substr%, WdOvlp%, Ev.Rec% — we want WdOvlp (2nd percentage)
+single_hop=$(echo "${RAW_OUTPUT}" | grep "Single-Hop QA" | grep -oE '[0-9]+\.[0-9]+%' | sed -n '2p' | tr -d '%')
+single_hop="${single_hop:-}"
+
+temporal=$(echo "${RAW_OUTPUT}" | grep "Temporal Reasoning" | grep -oE '[0-9]+\.[0-9]+%' | sed -n '2p' | tr -d '%')
+temporal="${temporal:-}"
+
+multi_hop=$(echo "${RAW_OUTPUT}" | grep "Multi-Hop QA" | grep -oE '[0-9]+\.[0-9]+%' | sed -n '2p' | tr -d '%')
+multi_hop="${multi_hop:-}"
+
+open_domain=$(echo "${RAW_OUTPUT}" | grep "Open-Domain" | grep -oE '[0-9]+\.[0-9]+%' | sed -n '2p' | tr -d '%')
+open_domain="${open_domain:-}"
+
+adversarial=$(echo "${RAW_OUTPUT}" | grep "Adversarial" | grep -oE '[0-9]+\.[0-9]+%' | sed -n '2p' | tr -d '%')
+adversarial="${adversarial:-}"
+
+# Timing
+avg_query_ms=$(echo "${RAW_OUTPUT}" | grep "Avg query:" | grep -oE '[0-9]+ms' | tr -d 'ms' | head -1)
+avg_query_ms="${avg_query_ms:-}"
+
+# Git metadata
+DATE_STR="$(date '+%Y-%m-%d')"
+COMMIT="$(git -C "${REPO_DIR}" rev-parse --short HEAD 2>/dev/null || echo '')"
+BRANCH="$(git -C "${REPO_DIR}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '')"
+
+# ── Append CSV row ────────────────────────────────────────────────────────────
+CSV_ROW="${DATE_STR},${COMMIT},${BRANCH},,${SCORING_MODE},${SAMPLES},${EMBEDDING_MODEL},${overall_score},${single_hop},${temporal},${multi_hop},${open_domain},${adversarial},${evidence_recall},${avg_query_ms},${NOTES}"
+echo "${CSV_ROW}" >> "${RESULTS_CSV}"
+echo "Appended result to ${RESULTS_CSV}"
+
+# ── Print comparison table ────────────────────────────────────────────────────
+print_table() {
+    local mode="$1"
+    printf "\n## LoCoMo Benchmark — %s scoring\n\n" "${mode}"
+    printf "| Date | Model | Overall%% | 1-Hop | Temporal | Multi-Hop | Open | Adv | EvRec%% | Avg Q (ms) |\n"
+    printf "|------|-------|---------|-------|----------|-----------|------|-----|--------|------------|\n"
+
+    # Skip header line, filter by scoring_mode (col 5)
+    tail -n +2 "${RESULTS_CSV}" | awk -F',' -v mode="${mode}" '
+        NF > 0 && $5 == mode {
+            printf "| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n",
+                $1, $7, $8, $9, $10, $11, $12, $13, $14, $15
+        }
+    '
+    printf "\n"
+}
+
+TABLE="$(print_table "${SCORING_MODE}")"
+echo "${TABLE}"
+
+# ── Write benchmarks/LATEST.md ────────────────────────────────────────────────
+mkdir -p "$(dirname "${LATEST_MD}")"
+{
+    printf "# MAG Benchmark Results\n\n"
+    printf "Latest benchmark runs. Updated automatically by \`./scripts/bench.sh\`.\n\n"
+    printf "See \`docs/benchmark_log.csv\` for full history.\n"
+    printf "%s\n" "${TABLE}"
+} > "${LATEST_MD}"
+echo "Updated ${LATEST_MD}"

--- a/scripts/check-readme.sh
+++ b/scripts/check-readme.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# check-readme.sh — Analyze recent code changes and suggest README updates
+#
+# Usage:
+#   ./scripts/check-readme.sh
+#   ./scripts/check-readme.sh "voyage-nano int8, word-overlap 91.1%"
+#
+# Requires: ANTHROPIC_API_KEY set in environment (or .env.local)
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CONTEXT_NOTE="${1:-}"
+
+# Load .env.local if present (same pattern as the rest of the codebase)
+if [[ -f "${REPO_DIR}/.env.local" ]]; then
+    # shellcheck disable=SC2046
+    export $(grep -v '^#' "${REPO_DIR}/.env.local" | xargs) 2>/dev/null || true
+fi
+
+if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
+    echo "Error: ANTHROPIC_API_KEY is not set." >&2
+    echo "Set it in your environment or in .env.local" >&2
+    exit 1
+fi
+
+cd "${REPO_DIR}"
+
+# ── Gather inputs ─────────────────────────────────────────────────────────────
+DIFF="$(git diff HEAD~3..HEAD -- src/ benches/ 2>/dev/null || echo '(no diff available)')"
+README="$(cat README.md)"
+
+# Trim diff if it's very large (keep first 6000 chars to stay within context)
+if [[ ${#DIFF} -gt 6000 ]]; then
+    DIFF="${DIFF:0:6000}
+... (diff truncated for brevity)"
+fi
+
+CONTEXT_SECTION=""
+if [[ -n "$CONTEXT_NOTE" ]]; then
+    CONTEXT_SECTION="Additional context from the caller: ${CONTEXT_NOTE}"
+fi
+
+# ── Build prompt ──────────────────────────────────────────────────────────────
+PROMPT="You are reviewing a Rust MCP memory server project (MAG). Your task is to identify what in the diff below would be meaningful for users to know about in the README.
+
+Focus only on:
+1. New features or CLI flags users can invoke
+2. Changed benchmark scores (only if improved)
+3. Changed architecture that affects how users configure or run the system
+4. New supported models or embedders
+
+Do NOT suggest adding:
+- Internal refactoring details
+- Test changes
+- Documentation-only changes
+- Minor bug fixes unless user-visible
+
+Output format: for each suggested change, write a short block like:
+  SECTION: <which README section>
+  WHY: <one sentence reason>
+  BEFORE: <existing text to replace, or 'N/A' if new>
+  AFTER: <suggested replacement text>
+
+Be concise. If no README changes are needed, say so clearly.
+
+${CONTEXT_SECTION}
+
+--- README.md ---
+${README}
+
+--- git diff HEAD~3..HEAD -- src/ benches/ ---
+${DIFF}"
+
+# ── Call Haiku API ────────────────────────────────────────────────────────────
+echo "Analyzing diff against README..."
+echo "──────────────────────────────────────────────────────────────────────────"
+
+RESPONSE=$(curl -sf https://api.anthropic.com/v1/messages \
+    -H "x-api-key: ${ANTHROPIC_API_KEY}" \
+    -H "anthropic-version: 2023-06-01" \
+    -H "content-type: application/json" \
+    -d "$(jq -n \
+        --arg model "claude-haiku-4-5-20251001" \
+        --arg prompt "${PROMPT}" \
+        '{
+            model: $model,
+            max_tokens: 1024,
+            messages: [{role: "user", content: $prompt}]
+        }'
+    )")
+
+# Extract text from response
+echo "${RESPONSE}" | jq -r '.content[0].text // "Error: no response text"'
+echo "──────────────────────────────────────────────────────────────────────────"
+echo "(This is a suggestion only — no files were modified)"


### PR DESCRIPTION
## Summary

- Adds `scripts/bench.sh`: a standardized LoCoMo benchmark runner that maps model names (`bge-small`, `voyage-nano-int8/fp16/fp32/q4`) to the correct `cargo run` flags, appends a row to `docs/benchmark_log.csv` (existing 16-column format), and prints a markdown comparison table filtered by `--scoring-mode`
- Adds `scripts/check-readme.sh`: calls Claude Haiku to analyze recent code diffs vs the current README and suggest targeted updates (prints suggestions, no auto-edits)
- Adds `benchmarks/LATEST.md`: seed file updated by `bench.sh` after every run
- Updates `AGENTS.md` with commands for both new scripts

## Test plan

- [ ] `bash -n scripts/bench.sh` passes (syntax check)
- [ ] `bash -n scripts/check-readme.sh` passes (syntax check)
- [ ] `./scripts/bench.sh --model bge-small --samples 2` runs, appends a row to `docs/benchmark_log.csv`, prints comparison table, and updates `benchmarks/LATEST.md`
- [ ] `./scripts/bench.sh --model voyage-nano-int8` builds with correct `--voyage-onnx --voyage-quant int8` flags
- [ ] `./scripts/check-readme.sh` requires `ANTHROPIC_API_KEY` and calls Haiku correctly
- [ ] Comparison table correctly filters by `--scoring-mode` and shows one row per run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `./scripts/bench.sh` for standardized benchmark execution with configurable models, samples, and scoring modes.
  * Added `./scripts/check-readme.sh` for AI-assisted README update suggestions based on recent code changes.

* **Documentation**
  * Created `benchmarks/LATEST.md` displaying latest benchmark results with auto-update indicators.
  * Updated `AGENTS.md` with usage examples for new benchmark and README check commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->