### PR TITLE
docs(agents): entities.rs, benchmark CSV, voyage gotchas, CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,7 @@ Rust MCP memory server — stores memories in SQLite with ONNX embeddings (bge-s
   - `search.rs` — FTS5 BM25 + vector similarity
   - `advanced.rs` — 6-phase RRF pipeline (vector + FTS5 + rerank + refinement + graph + abstention)
   - `graph.rs` — relationship traversal (BFS, max_hops)
+  - `entities.rs` — entity extraction (people, tools, projects) with auto-tagging on store
   - `lifecycle.rs` — TTL, sweep, feedback
   - `session.rs` — checkpoint, profile, session_info
   - `admin.rs` — health/export/import/stats, backup/restore
@@ -110,7 +111,7 @@ Run `prek run` for gates 1-3.
 ## Post-Implementation Checklist
 
 - [ ] Quality gates pass (`prek run`)
-- [ ] Benchmark shows no regression (if applicable)
+- [ ] Benchmark shows no regression (if applicable); if changed, append row to `docs/benchmark_log.csv`
 - [ ] New public APIs have tests
 - [ ] Run code simplification review — check for unnecessary complexity, duplication, missed reuse
 - [ ] Update AGENTS.md if architecture or conventions changed
@@ -151,6 +152,8 @@ This repo uses jj (Jujutsu) in colocated mode.
 - Model files (~134 MB) auto-download on first use; `~/.mag/models/` preferred, `~/.romega-memory/models/` legacy
 - `GRAPH_NEIGHBOR_FACTOR=0.1` — graph enrichment Phase 5 re-enabled at conservative factor; guarded by `if > 0.0`
 - Git hooks do NOT fire under jj — run `prek run` explicitly before pushing
+- Benchmark history: `docs/benchmark_log.csv` (16 cols); methodology at `docs/benchmarks.md`
+- voyage-4-nano ONNX: 2048-dim native; use `--embedder-dim` for Matryoshka truncation (512/1024/2048); quant: int8, fp16, fp32, q4
 
 ## Tool-Specific Notes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,4 @@
 All agent guidance lives in [AGENTS.md](./AGENTS.md). Read that file for commands, conventions, architecture, quality gates, and gotchas.
 
 This file exists only because Claude Code looks for `CLAUDE.md` by convention.
+AGENTS.md is vendor-neutral and applies to all AI coding tools (Claude Code, Cursor, Windsurf, Copilot).


### PR DESCRIPTION
## Summary

- Add `entities.rs` to key modules list (merged in #65)
- Add `docs/benchmark_log.csv` pointer to Gotchas
- Add voyage-4-nano ONNX gotcha (dims, quants)
- Update Post-Implementation checklist to remind appending bench CSV row
- Clarify CLAUDE.md is vendor-neutral in CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced architecture overview with expanded storage module guidance.
  * Updated Post-Implementation Checklist with benchmark logging methodology and history references.
  * Added comprehensive embedding configuration documentation, including truncation and quantization mode details.
  * Clarified vendor-neutral applicability across multiple AI coding tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->