### PR TITLE
docs(readme): update benchmarks — 91.1% LoCoMo WO + embedding comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,17 +81,43 @@ Copy `.mcp.json.example` to `.mcp.json` and point your MCP client at the local b
 
 ## Benchmarks
 
-Published benchmark snapshots were captured on `2026-03-12` at commit `66a9e3e97e0e65328864c4699ad6b14ccf8a24ae`, on `macOS aarch64, 12 CPU`. They do not include later review-only fixes on this PR branch.
+Current benchmark snapshots were captured on `2026-03-19` at commit `26e51cf3` on `macOS aarch64`. Word-overlap is the primary LoCoMo metric (comparable to AutoMem's published 90.5%).
+
+### LoCoMo (word-overlap scoring, 2 samples, bge-small-en-v1.5)
+
+| Category | Word-Overlap |
+| --- | --- |
+| **Overall** | **91.1%** |
+| Evidence recall | 90.2% |
+| Single-hop | 87.6% |
+| Temporal | 91.5% |
+| Multi-hop | 75.6% |
+| Open-domain | 94.0% |
+| Adversarial | 90.9% |
+
+788 memories, 304 questions across 2 samples. Avg query: 34 ms, avg embed: 7.5 ms, seed time: 9.7 s.
+
+### Embedding Model Comparison (LoCoMo word-overlap, 2 samples)
+
+| Model | Dim | WO% | EvRec% | 1-Hop | Temporal | Multi-Hop | Open | Adv | AvgEmb | SeedTime |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **bge-small-en-v1.5** *(default)* | 384 | 91.1% | 90.2% | 87.6% | 91.5% | 75.6% | 94.0% | 90.9% | 7.5 ms | 9.7 s |
+| voyage-4-nano INT8 | 1024 | 91.8% | 91.3% | 93.5% | 91.5% | 75.6% | 93.3% | 91.6% | 172 ms | 192 s |
+| voyage-4-nano INT8 | 512 | 91.3% | 91.6% | 88.8% | 91.5% | 75.6% | 93.7% | 91.6% | 58 ms | 62 s |
+| voyage-4-nano FP32 | 1024 | 91.8% | 91.3% | 93.5% | 91.5% | 75.6% | 93.3% | 91.6% | 82 ms | 105 s |
+
+bge-small-en-v1.5 is the default production embedder. voyage-4-nano adds +0.7 pp word-overlap at 23× slower embedding speed.
+
+### Other Benchmarks (earlier snapshot, 2026-03-12)
 
 | Benchmark | Result | Notes |
 | --- | --- | --- |
 | Local LongMemEval-style set | `98 / 100` | `1538 ms` seeding, `1013 ms` querying, `335568 KB` peak RSS |
-| LoCoMo10 | `476 / 1986` (`24.0%`) | `5882` memories ingested, `224.75 s` total, `20.22 ms` avg query |
 | Scale benchmark | `100% Recall@5` at `1K`, `5K`, `10K` | `19.61 ms` mean, `42.56 ms` p95, `51.94 ms` p99 at `10K` |
 | `omega-memory` comparison | MAG `98 / 100` vs omega `90 / 100` | omega seeded and queried faster on this local workload |
 | Official `LongMemEval_S` sample | `8 / 10` | external dataset fetch works; full `500`-question publication is still pending |
 
-Full methodology, commands, and result tables are in [docs/benchmarks.md](docs/benchmarks.md).
+Full methodology, commands, and result tables are in [docs/benchmarks.md](docs/benchmarks.md). Historical runs are tracked in [docs/benchmark_log.csv](docs/benchmark_log.csv).
 
 ### Benchmark Safety
 
@@ -107,7 +133,7 @@ MAG currently supports:
 - graph traversal and version-chain lookup
 - advanced retrieval that fuses vector and lexical candidates
 
-The advanced path combines vector similarity and FTS hits with reciprocal-rank fusion, then refines ranking with event type, time decay, word overlap, importance, priority, and feedback signals.
+The advanced path combines vector similarity and FTS hits with reciprocal-rank fusion, then refines ranking with event type, time decay, word overlap, importance, priority, and feedback signals. Queries are classified by intent (Keyword / Factual / Conceptual / General) to weight retrieval modes appropriately. Entity extraction runs at ingest time for auto-tagging and graph-edge creation.
 
 ## Architecture
 
@@ -120,6 +146,8 @@ mag
 │   ├── app_paths.rs
 │   ├── benchmarking.rs
 │   └── memory_core/
+│       └── storage/sqlite/
+│           └── entities.rs
 ├── benches/
 │   ├── longmemeval/
 │   ├── locomo/
@@ -140,7 +168,13 @@ cargo test --all-features
 
 ### Benchmark Commands
 
-Clone `omega-memory` locally first. The comparison script accepts either `--omega-repo` or the `OMEGA_REPO` environment variable.
+The recommended way to run the standard LoCoMo benchmark:
+
+```bash
+./scripts/bench.sh
+```
+
+For individual benchmarks or the omega-memory comparison, clone `omega-memory` locally first. The comparison script accepts either `--omega-repo` or the `OMEGA_REPO` environment variable.
 
 ```bash
 cargo run --release --bin fetch_benchmark_data -- --dataset all


### PR DESCRIPTION
## Summary

- Replace stale March 12 LoCoMo data (24.0% substring) with current scores: **91.1% word-overlap** (bge-small-en-v1.5, 2026-03-19)
- Add full LoCoMo category breakdown (single-hop, temporal, multi-hop, open-domain, adversarial)
- Add embedding model comparison table (bge-small vs voyage-4-nano INT8/FP32 at 512/1024 dim)
- Retain earlier LongMemEval, scale benchmark, and omega-memory comparison rows under "Other Benchmarks (earlier snapshot)"
- Retrieval Model section: note intent classification and entity extraction
- Architecture tree: add `entities.rs` under `memory_core/storage/sqlite/`
- Benchmark Commands: add `./scripts/bench.sh` as the recommended command

## Test plan

- [ ] Review rendered Markdown tables in GitHub PR preview
- [ ] Confirm no unintended sections were changed (Why MAG, Quick Start, License)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark results with latest performance data and detailed reporting metrics
  * Added embedding model comparison table for multiple configurations
  * Expanded retrieval model documentation with classification and extraction details
  * Updated architecture diagram references
  * Refined benchmark command guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->