### PR TITLE
fix(bench): granite output tensor logits + log all 13 model benchmarks + expand README table

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,14 +99,23 @@ Current benchmark snapshots were captured on `2026-03-19` at commit `26e51cf3` o
 
 ### Embedding Model Comparison (LoCoMo word-overlap, 2 samples)
 
-| Model | Dim | WO% | EvRec% | 1-Hop | Temporal | Multi-Hop | Open | Adv | AvgEmb | SeedTime |
+| Model | Type | Dim | WO% | EvRec% | 1-Hop | Temporal | Multi-Hop | Open | Adv | AvgEmb |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| **bge-small-en-v1.5** *(default)* | 384 | 91.1% | 90.2% | 87.6% | 91.5% | 75.6% | 94.0% | 90.9% | 7.5 ms | 9.7 s |
-| voyage-4-nano INT8 | 1024 | 91.8% | 91.3% | 93.5% | 91.5% | 75.6% | 93.3% | 91.6% | 172 ms | 192 s |
-| voyage-4-nano INT8 | 512 | 91.3% | 91.6% | 88.8% | 91.5% | 75.6% | 93.7% | 91.6% | 58 ms | 62 s |
-| voyage-4-nano FP32 | 1024 | 91.8% | 91.3% | 93.5% | 91.5% | 75.6% | 93.3% | 91.6% | 82 ms | 105 s |
+| granite-embedding-30m-english | ONNX | 384 | 90.5% | 87.5% | 88.9% | 91.5% | 76.9% | 91.7% | 91.1% | 3.8 ms |
+| nomic-embed-text-v1.5 int8 | ONNX | 768 | 90.0% | 86.6% | 88.4% | 91.5% | 74.4% | 90.8% | 91.0% | 42 ms |
+| all-MiniLM-L12-v2 | ONNX | 384 | 90.9% | 90.4% | 86.8% | 91.5% | 75.6% | 92.6% | 93.1% | 27 ms |
+| **bge-small-en-v1.5** *(default)* | ONNX | 384 | 91.1% | 90.2% | 87.6% | 91.5% | 75.6% | 94.0% | 90.9% | 7.5 ms |
+| all-MiniLM-L6-v2 | ONNX | 384 | 91.2% | 90.2% | 88.1% | 91.5% | 76.9% | 92.9% | 92.7% | 39 ms |
+| e5-small-v2 | ONNX | 384 | 91.3% | 89.1% | 90.7% | 91.5% | 76.9% | 92.9% | 91.5% | 41 ms |
+| voyage-4-nano INT8 | ONNX | 512 | 91.3% | 91.6% | 88.8% | 91.5% | 75.6% | 93.7% | 91.6% | 58 ms |
+| voyage-4-lite | API | 1024 | 91.1% | 91.0% | 91.1% | 91.5% | 73.1% | 93.4% | 90.2% | 304 ms |
+| voyage-4-nano FP32 | ONNX | 1024 | 91.8% | 91.3% | 93.5% | 91.5% | 75.6% | 93.3% | 91.6% | 82 ms |
+| voyage-4-nano INT8 | ONNX | 1024 | 91.8% | 91.3% | 93.5% | 91.5% | 75.6% | 93.3% | 91.6% | 172 ms |
+| voyage-4 | API | 1024 | 92.0% | 92.7% | 92.3% | 91.5% | 75.6% | 94.8% | 90.6% | 297 ms |
+| bge-base-en-v1.5 | ONNX | 768 | 92.2% | 91.6% | 89.4% | 91.5% | 76.9% | 94.8% | 93.1% | 42 ms |
+| text-embedding-3-large | API | 3072 | 93.0% | 93.4% | 94.6% | 91.5% | 74.4% | 95.3% | 93.1% | 444 ms |
 
-bge-small-en-v1.5 is the default production embedder. voyage-4-nano adds +0.7 pp word-overlap at 23× slower embedding speed.
+bge-small-en-v1.5 is the default production embedder (Apache 2.0, fastest ONNX, 7.5 ms/embed). bge-base-en-v1.5 is the best local ONNX at 92.2% WO (+1.1 pp, 6× slower). OpenAI text-embedding-3-large leads overall at 93.0% WO but requires an API call. Multi-hop is stuck at 74–77% WO across all 13 models tested — this is an architectural retrieval issue, not an embedding quality issue (see [issue #84](https://github.com/rockerritesh/romega-memory/issues/84)).
 
 ### Other Benchmarks (earlier snapshot, 2026-03-12)
 

--- a/benches/locomo/main.rs
+++ b/benches/locomo/main.rs
@@ -333,7 +333,7 @@ fn main() -> Result<()> {
                 None,
                 "https://huggingface.co/ibm-granite/granite-embedding-30m-english/resolve/main/tokenizer.json",
                 384,
-                "last_hidden_state",
+                "logits",
                 false, // RoBERTa: no token_type_ids
             )?),
             "granite-embedding-30m-english".to_string(),

--- a/docs/benchmark_log.csv
+++ b/docs/benchmark_log.csv
@@ -3,3 +3,16 @@ date,commit,branch,issue_or_pr,scoring_mode,samples,embedding_model,overall_scor
 2026-03-19,d285236,worktree-agent-a830499b,,word-overlap,10,onnx-bge-small,83.9,76.0,82.3,45.6,90.3,86.4,85.0,47.7,speaker/conversation/session tags + top_k 50 + speaker-tag recall + dynamic limits (50/75/100)
 2026-03-19,ea1ac85,worktree-agent-a830499b,,word-overlap,10,onnx-bge-small,86.87,81.7,82.9,51.6,92.9,89.2,85.4,45.1,+adaptive dual-match boost +substring overlap +year expansion +adversarial scoring +-ies stemmer +speaker nickname prefix
 2026-03-19,7a078be,worktree-agent-a830499b,PR#70,word-overlap,10,onnx-bge-small,90.52,88.0,85.2,56.4,96.0,92.9,92.2,44.1,+conv-size scaling (turns/5) +stemmer dedup/ied +may stopword +semicolon extraction +evidence ID normalization — TARGET 90%+ ACHIEVED
+2026-03-19,fbea68c,main,77,word-overlap,2,bge-small-en-v1.5,91.1,87.6,91.5,75.6,94.0,90.9,90.2,7.5,default production embedder
+2026-03-19,fbea68c,main,77,word-overlap,2,voyage-4-nano-int8-1024,91.8,93.5,91.5,75.6,93.3,91.6,91.3,172,voyage-4-nano ONNX INT8 1024-dim Matryoshka
+2026-03-19,fbea68c,main,77,word-overlap,2,voyage-4-nano-int8-512,91.3,88.8,91.5,75.6,93.7,91.6,91.6,58,voyage-4-nano ONNX INT8 512-dim Matryoshka
+2026-03-19,fbea68c,main,77,word-overlap,2,voyage-4-nano-fp32-1024,91.8,93.5,91.5,75.6,93.3,91.6,91.3,82,voyage-4-nano ONNX FP32 1024-dim
+2026-03-19,fbea68c,main,82,word-overlap,2,granite-embedding-30m-english,90.5,88.9,91.5,76.9,91.7,91.1,87.5,3.8,output tensor logits not last_hidden_state; 2x faster than bge-small
+2026-03-19,fbea68c,main,82,word-overlap,2,all-MiniLM-L6-v2,91.2,88.1,91.5,76.9,92.9,92.7,90.2,39.3,
+2026-03-19,fbea68c,main,82,word-overlap,2,all-MiniLM-L12-v2,90.9,86.8,91.5,75.6,92.6,93.1,90.4,26.6,
+2026-03-19,fbea68c,main,82,word-overlap,2,e5-small-v2,91.3,90.7,91.5,76.9,92.9,91.5,89.1,40.5,xenova mirror
+2026-03-19,fbea68c,main,82,word-overlap,2,bge-base-en-v1.5,92.2,89.4,91.5,76.9,94.8,93.1,91.6,42.1,best local onnx
+2026-03-19,fbea68c,main,82,word-overlap,2,nomic-embed-text-v1.5-int8,90.0,88.4,91.5,74.4,90.8,91.0,86.6,41.7,no prefix injection; underperforms published MTEB score
+2026-03-19,fbea68c,main,82,word-overlap,2,voyage-4-lite-api,91.1,91.1,91.5,73.1,93.4,90.2,91.0,304,voyage api
+2026-03-19,fbea68c,main,82,word-overlap,2,voyage-4-api,92.0,92.3,91.5,75.6,94.8,90.6,92.7,297,voyage api
+2026-03-19,fbea68c,main,82,word-overlap,2,text-embedding-3-large-openai,93.0,94.6,91.5,74.4,95.3,93.1,93.4,444,openai api; best quality overall


### PR DESCRIPTION
## Summary

- **Fix** `benches/locomo/main.rs`: granite-embedding-30m-english exports under `logits` output tensor, not `last_hidden_state` (same as BERT-style models). Without this fix the benchmark panics when selecting `--granite`.
- **Fix** `src/memory_core/embedder.rs`: resolve clippy `collapsible_if` lint in `ensure_model_downloaded` by extracting the `try_exists` result to a `let` binding.
- **Log** `docs/benchmark_log.csv`: append all 13 model benchmark results from this session (bge-small, voyage-4-nano ONNX x3, granite, MiniLM-L6, MiniLM-L12, e5-small, bge-base, nomic, voyage-4-lite API, voyage-4 API, OpenAI text-embedding-3-large API).
- **Update** `README.md`: expand embedding model comparison table from 4 rows (ONNX only) to 13 rows covering all ONNX and API models tested; add note on multi-hop plateau across all models (→ issue #84).

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all-features` passes (500+ tests + MCP smoke + parity harness)
- [x] `--granite` bench flag now uses correct `logits` tensor name (manually verified in previous session run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated embedding model benchmark comparison with restructured columns and expanded model set including local ONNX and API-based embedding options.

* **Updates**
  * Adjusted Granite embedding output configuration for revised performance metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->