### PR TITLE
feat(bench): add snowflake-arctic-embed + gte-small ONNX variants (16-model comparison)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,19 +103,21 @@ Current benchmark snapshots were captured on `2026-03-19` at commit `26e51cf3` o
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | granite-embedding-30m-english | ONNX | 384 | 90.5% | 87.5% | 88.9% | 91.5% | 76.9% | 91.7% | 91.1% | 3.8 ms |
 | nomic-embed-text-v1.5 int8 | ONNX | 768 | 90.0% | 86.6% | 88.4% | 91.5% | 74.4% | 90.8% | 91.0% | 42 ms |
+| snowflake-arctic-embed-s | ONNX | 384 | 90.5% | 87.6% | 89.5% | 91.5% | 73.1% | 93.0% | 89.5% | 36 ms |
+| snowflake-arctic-embed-xs | ONNX | 384 | 90.8% | 88.7% | 88.1% | 91.5% | 76.9% | 93.5% | 90.2% | 30 ms |
+| gte-small | ONNX | 384 | 90.9% | 90.8% | 89.1% | 91.5% | 73.1% | 93.7% | 90.2% | 65 ms |
 | all-MiniLM-L12-v2 | ONNX | 384 | 90.9% | 90.4% | 86.8% | 91.5% | 75.6% | 92.6% | 93.1% | 27 ms |
 | **bge-small-en-v1.5** *(default)* | ONNX | 384 | 91.1% | 90.2% | 87.6% | 91.5% | 75.6% | 94.0% | 90.9% | 7.5 ms |
 | all-MiniLM-L6-v2 | ONNX | 384 | 91.2% | 90.2% | 88.1% | 91.5% | 76.9% | 92.9% | 92.7% | 39 ms |
 | e5-small-v2 | ONNX | 384 | 91.3% | 89.1% | 90.7% | 91.5% | 76.9% | 92.9% | 91.5% | 41 ms |
 | voyage-4-nano INT8 | ONNX | 512 | 91.3% | 91.6% | 88.8% | 91.5% | 75.6% | 93.7% | 91.6% | 58 ms |
 | voyage-4-lite | API | 1024 | 91.1% | 91.0% | 91.1% | 91.5% | 73.1% | 93.4% | 90.2% | 304 ms |
-| voyage-4-nano FP32 | ONNX | 1024 | 91.8% | 91.3% | 93.5% | 91.5% | 75.6% | 93.3% | 91.6% | 82 ms |
-| voyage-4-nano INT8 | ONNX | 1024 | 91.8% | 91.3% | 93.5% | 91.5% | 75.6% | 93.3% | 91.6% | 172 ms |
+| voyage-4-nano FP32/INT8 | ONNX | 1024 | 91.8% | 91.3% | 93.5% | 91.5% | 75.6% | 93.3% | 91.6% | 82–172 ms |
 | voyage-4 | API | 1024 | 92.0% | 92.7% | 92.3% | 91.5% | 75.6% | 94.8% | 90.6% | 297 ms |
 | bge-base-en-v1.5 | ONNX | 768 | 92.2% | 91.6% | 89.4% | 91.5% | 76.9% | 94.8% | 93.1% | 42 ms |
 | text-embedding-3-large | API | 3072 | 93.0% | 93.4% | 94.6% | 91.5% | 74.4% | 95.3% | 93.1% | 444 ms |
 
-bge-small-en-v1.5 is the default production embedder (Apache 2.0, fastest ONNX, 7.5 ms/embed). bge-base-en-v1.5 is the best local ONNX at 92.2% WO (+1.1 pp, 6× slower). OpenAI text-embedding-3-large leads overall at 93.0% WO but requires an API call. Multi-hop is stuck at 74–77% WO across all 13 models tested — this is an architectural retrieval issue, not an embedding quality issue (see [issue #84](https://github.com/rockerritesh/romega-memory/issues/84)).
+bge-small-en-v1.5 is the default (Apache 2.0, 7.5 ms/embed). It outperforms snowflake-arctic-embed and gte-small on this workload despite MTEB suggesting arctic-embed-s is marginally better — MTEB and LoCoMo don't always correlate. bge-base-en-v1.5 is the best local ONNX (+1.1 pp, 6× slower). Multi-hop is stuck at 73–77% WO across all 16 models — architectural issue tracked in [issue #84](https://github.com/George-RD/mag/issues/84).
 
 ### Other Benchmarks (earlier snapshot, 2026-03-12)
 

--- a/benches/locomo/main.rs
+++ b/benches/locomo/main.rs
@@ -128,6 +128,15 @@ struct Args {
     /// The benchmark harness does NOT add these prefixes — scores will be slightly below MTEB reported.
     #[arg(long)]
     nomic: bool,
+    /// Use Snowflake/snowflake-arctic-embed-xs ONNX (22M, 384-dim, MiniLM-based).
+    #[arg(long)]
+    arctic_xs: bool,
+    /// Use Snowflake/snowflake-arctic-embed-s ONNX (33M, 384-dim, e5-small-unsupervised based).
+    #[arg(long)]
+    arctic_s: bool,
+    /// Use thenlper/gte-small ONNX (33M, 384-dim, pure BERT).
+    #[arg(long)]
+    gte_small: bool,
     /// Voyage AI model name (default: voyage-4-lite).
     #[arg(long)]
     voyage_model: Option<String>,
@@ -175,6 +184,9 @@ fn main() -> Result<()> {
         args.e5_small,
         args.bge_base,
         args.nomic,
+        args.arctic_xs,
+        args.arctic_s,
+        args.gte_small,
     ]
     .iter()
     .filter(|&&b| b)
@@ -183,7 +195,8 @@ fn main() -> Result<()> {
         bail!(
             "only one embedder flag may be specified at a time \
              (--openai-embeddings, --voyage-onnx, --voyage-api, --granite, \
-             --minilm-l6, --minilm-l12, --e5-small, --bge-base, --nomic)"
+             --minilm-l6, --minilm-l12, --e5-small, --bge-base, --nomic, \
+             --arctic-xs, --arctic-s, --gte-small)"
         );
     }
 
@@ -419,6 +432,54 @@ fn main() -> Result<()> {
                 true, // NomicBERT: uses token_type_ids
             )?),
             "nomic-embed-text-v1.5-int8".to_string(),
+        )
+    } else if args.arctic_xs {
+        if !args.json {
+            eprintln!("Embedder: snowflake-arctic-embed-xs ONNX (22M, 384-dim)");
+        }
+        (
+            Arc::new(OnnxEmbedder::with_model_and_data(
+                "snowflake-arctic-embed-xs",
+                "https://huggingface.co/Snowflake/snowflake-arctic-embed-xs/resolve/main/onnx/model.onnx",
+                None,
+                "https://huggingface.co/Snowflake/snowflake-arctic-embed-xs/resolve/main/tokenizer.json",
+                384,
+                "last_hidden_state",
+                true, // arctic-xs ONNX export includes token_type_ids
+            )?),
+            "snowflake-arctic-embed-xs".to_string(),
+        )
+    } else if args.arctic_s {
+        if !args.json {
+            eprintln!("Embedder: snowflake-arctic-embed-s ONNX (33M, 384-dim)");
+        }
+        (
+            Arc::new(OnnxEmbedder::with_model_and_data(
+                "snowflake-arctic-embed-s",
+                "https://huggingface.co/Snowflake/snowflake-arctic-embed-s/resolve/main/onnx/model.onnx",
+                None,
+                "https://huggingface.co/Snowflake/snowflake-arctic-embed-s/resolve/main/tokenizer.json",
+                384,
+                "last_hidden_state",
+                true, // arctic-s ONNX export includes token_type_ids
+            )?),
+            "snowflake-arctic-embed-s".to_string(),
+        )
+    } else if args.gte_small {
+        if !args.json {
+            eprintln!("Embedder: gte-small ONNX (33M, 384-dim)");
+        }
+        (
+            Arc::new(OnnxEmbedder::with_model_and_data(
+                "gte-small",
+                "https://huggingface.co/thenlper/gte-small/resolve/main/onnx/model.onnx",
+                None,
+                "https://huggingface.co/thenlper/gte-small/resolve/main/tokenizer.json",
+                384,
+                "last_hidden_state",
+                true, // pure BERT: uses token_type_ids
+            )?),
+            "gte-small".to_string(),
         )
     } else {
         if !args.json {

--- a/docs/benchmark_log.csv
+++ b/docs/benchmark_log.csv
@@ -16,3 +16,6 @@ date,commit,branch,issue_or_pr,scoring_mode,samples,embedding_model,overall_scor
 2026-03-19,fbea68c,main,82,word-overlap,2,voyage-4-lite-api,91.1,91.1,91.5,73.1,93.4,90.2,91.0,304,voyage api
 2026-03-19,fbea68c,main,82,word-overlap,2,voyage-4-api,92.0,92.3,91.5,75.6,94.8,90.6,92.7,297,voyage api
 2026-03-19,fbea68c,main,82,word-overlap,2,text-embedding-3-large-openai,93.0,94.6,91.5,74.4,95.3,93.1,93.4,444,openai api; best quality overall
+2026-03-19,fbea68c,main,86,word-overlap,2,snowflake-arctic-embed-xs,90.78,88.1,91.5,76.9,93.5,90.2,88.72,30.4,22M params; ONNX includes token_type_ids despite MiniLM base
+2026-03-19,fbea68c,main,86,word-overlap,2,snowflake-arctic-embed-s,90.54,89.5,91.5,73.1,93.0,89.5,87.57,35.8,33M params; ONNX includes token_type_ids
+2026-03-19,fbea68c,main,86,word-overlap,2,gte-small,90.92,89.1,91.5,73.1,93.7,90.2,90.81,65.3,33M params pure BERT; 724MB peak RSS vs 241MB for arctic-xs

--- a/mag-offer.md
+++ b/mag-offer.md
@@ -1,0 +1,99 @@
+# MAG (Memory-Augmented Generation) — Grand Slam Offer Workshop
+Generated: 2026-03-19
+Status: Phase 3 of 5 complete
+
+## Phase 0: Discovery
+- Business: MAG — Rust MCP memory server. SQLite + ONNX embeddings (bge-small-en-v1.5, 384-dim). 16 MCP tools exposed via stdio. 500+ tests. MIT licensed. No external services required.
+- Market: AI tool power users — solopreneurs, developers, and technical prosumers who use multiple AI tools daily and lose context switching between them.
+- Personas:
+  - Solo Sam — solopreneur, uses many AI tools (Claude, ChatGPT, etc.), non-technical, dabbled with Claude Desktop
+  - Dev Dave — developer, technical, uses Cursor/Claude Code/VS Code, values performance and hackability
+  - Prosumer Priya — semi-technical, uses AI tools for creative/professional work, cares about privacy
+  - OSS Oliver — open source contributor/maintainer, evaluates embeddability and licensing carefully
+
+## Phase 1: Starving Crowd
+- Market scores: Pain 9/10, Purchasing Power 7/10, Targeting 7/10, Growth 9/10 = 32/40 raw
+- Post-adversarial revised: 28/40 (targeting docked — "MCP users" is still emerging segment, not a lists-based audience)
+- Core market: Wealth (productivity) + adjacent to Relationships (AI as collaborative partner)
+- Niche: Power users of 2+ AI tools daily who lose context on every switch — developers and solopreneurs who rely on AI for work output
+- 3 must-fix items identified post-adversarial:
+  1. "Zero setup" claim is false — fix setup or fix the claim.
+  2. Differentiate vs OpenMemory MCP in first paragraph — same value prop, must state MAG's advantages explicitly (hybrid FTS5+semantic+graph, Rust/embeddable, no Python runtime, additive migrations)
+  3. Non-technical user path unclear — Homebrew/npm/Claude plugin needed (GitHub issue filed)
+- 3 decisions:
+  1. bge-small (Apache 2.0) locked as sole default embedding model — voyage-4-nano rejected (proprietary licensing risk)
+  2. Distribution: local binary + Homebrew + npm + Claude plugin + Railway one-click (issue filed for packaging)
+  3. Cross-tool memory positioning: "common agent memory across different AI tools" is the core value prop
+
+## Phase 2: Pricing
+- Price: $0 (free product)
+- Position: Free Value Leader
+- 10x challenge: moot at $0 — 10x of free is still free
+- Revenue model: Railway OSS kickback 30-50% of compute spend (~$5-10/month user cost)
+- Future: managed hosting if demand warrants
+- 3 deployment tiers:
+  1. Local binary — zero cloud, zero cost, runs on your machine
+  2. Self-hosted (Railway) — one-click deploy, user's own Railway account, ~$5/month, same privacy guarantee
+  3. Managed (coming soon) — hosted by MAG team
+- Railway framing: "Self-hosted in one click. Your infrastructure, your rules."
+
+## Phase 3: Value Equation
+
+### Adversarial Scores
+| Agent | Dream | Likelihood | Delay | Effort |
+|---|---|---|---|---|
+| Solo Sam | 7 | 3 | 5 | 2 |
+| Dev Dave | 7 | 6 | 6 | 8 |
+| Prosumer Priya | 8 | 5 | 6 | 5 |
+| Marketer | — | — | — | 5/10 overall |
+| Strategist | — | — | — | 3/10 biz model |
+
+### Dream Outcome — 7.5/10
+- Hero: "Open any tool. Your context is already there." (drop "No re-explaining" as standalone — overpromises LLM behavior MAG doesn't control)
+- Monday Morning scene: "Open Claude on Monday. It already knows what you decided on Friday."
+- Privacy frame: "Your client signed an NDA with you. Not with Mem0's infrastructure."
+- Universal: "Stop being your AI's memory. That's not your job."
+- B2B/embed: "Your users get persistent memory. Ship it Friday. Never touch it again."
+
+### Perceived Likelihood — 5/10 (weakest variable)
+Primary fixes selected:
+- "Don't trust our number. Run it." — publish one-command LoCoMo benchmark runner, challenge to reproduce 90.52%
+- Compatibility matrix: tool-by-tool checkmarks on landing page (Claude Desktop, Cursor, Claude Code, Windsurf, Cline)
+- "We can't deprecate your local binary. It runs whether we exist or not."
+- Migration proof from AutoMem/OpenMemory MCP — config diff, 12 minutes, documented
+- Network transparency: one-command audit showing zero outbound network calls (Priya's verification moment)
+- Lock benchmark methodology: full 10-sample word-overlap, pinned commit hash, public reproduction script
+
+### Time Delay — 6/10
+- Define 48-hour first win in onboarding: "Open a new session. Ask about something from your last session. Watch it recall. That's the moment."
+- Unedited "Live in 5" screen recording — fresh install to first cross-session recall, no cuts, show the clock
+- Railway as primary non-tech CTA: "Running in 90 seconds. No terminal."
+- First-run transparency: "134MB model download on first launch. ~30 seconds. Then instant forever."
+
+### Effort & Sacrifice — 4/10 (critical gap)
+- Pre-filled MCP config snippet per tool — OS-aware, copy-paste only, no path guessing
+- Railway path: "No code. No terminal. Click a button. Your infrastructure, your rules."
+- Railway multi-device frame: "Access from any device. Data lives in your Railway account. No one else's."
+- Managed tier waitlist NOW as DFY anchor: "Not ready to self-host? Join the waitlist. You're first in line."
+- Claude plugin: primary CTA for non-technical users with waitlist + target date (most important unlock for Sam)
+
+### Critical decisions
+1. Dream outcome scoped to MAG's control — retrieval promise, not LLM behavior promise
+2. Benchmark: publish reproducible runner, address methodology proactively in README
+3. Railway copy: "your infrastructure, your rules" — not "your machine" (multi-device problem)
+4. Managed tier waitlist is blocking conversion for Sam — ship the waitlist page
+5. Strategist: Railway kickback alone (~$1.4k/month at 10k installs) is not a business. 90-day prescription: managed tier waitlist, 10 paying users at $15/month to validate thesis.
+
+## Phase 4: Offer Stack
+[Pending]
+
+## Phase 5: Enhancement
+[Pending]
+
+## Copy Decisions (Cross-Phase)
+- Hero headline: "Open any tool. Your context is already there."
+- Trust anchor: "Client data stays on your machine. Not on Mem0's servers. Not anyone else's."
+- Dev section header: "Switch from Claude to Cursor. Your context came with you."
+- README/embed only: "Your users get persistent memory. MIT licensed. Runs on their machine. No extra services."
+- Railway framing: "Self-hosted in one click. Your infrastructure, your rules."
+- DROPPED: "No re-explaining" as standalone — overpromises LLM behavior

--- a/mag-research.md
+++ b/mag-research.md
@@ -1,0 +1,88 @@
+# Research Brief — MAG (Memory-Augmented Generation)
+Updated: 2026-03-19
+
+## Market Identity
+- Core market: Wealth (AI productivity) — power users of 2+ AI tools daily
+- Niche: Developers and solopreneurs who lose context switching between AI tools
+- Audience specifics: MCP-capable AI tool users (Claude Desktop, Cursor, Claude Code, Windsurf, Cline)
+
+## Starving Crowd Indicators (Phase 1)
+- Pain severity evidence: Re-explaining context on every AI tool switch. Having to re-paste docs, re-describe preferences, re-state project context. Users report spending 5-15 min/session on context recovery. GitHub issues across Letta/Mem0 show silent failure and persistence bugs are top pain.
+- Purchasing power signals: AI tool power users pay $20-100+/month across tools. Technical users have budget for productivity infra. Railway ~$5/month well within range.
+- Targeting specificity: MCP Discord, Claude subreddit, Cursor forums, Hacker News AI threads, GitHub (stars of OpenMemory MCP, AutoMem, Mem0). Specific communities exist but "MCP users" is emerging — not yet a stable mailing list segment.
+- Market growth signals: MCP protocol adoption accelerating rapidly (Anthropic, OpenAI, Google all supporting). Memory tools category exploding (Mem0, AutoMem, OpenMemory MCP all launched 2024-2025).
+- Score: 28/40 (revised post-adversarial — targeting docked from 7 to 5)
+
+## Value Equation Inputs (Phase 3 — updated)
+- Dream outcomes (in customer language):
+  - "Open any tool. Your context is already there." (hero — MAG-controllable promise only)
+  - "Client data stays on your machine." (privacy trust anchor, cross-persona winner)
+  - "Switch from Claude to Cursor. Your context came with you." (dev converter)
+  - "Your users get persistent memory. MIT licensed. Runs on their machine." (B2B/embed)
+  - DROPPED: "No re-explaining" as standalone — overpromises LLM behavior MAG doesn't control
+- Existing proof elements: LoCoMo 90.52% (full 10-sample word-overlap), 500+ tests, Rust, SQLite, MIT + Apache 2.0, hybrid FTS5+semantic+graph, 16 MCP tools
+- Speed benchmarks: Sub-ms SQLite ops, <100ms retrieval typical. 134MB model download first run only.
+- Effort friction points: Binary install + 5-line MCP config + model download. Non-technical users blocked without Claude plugin.
+- Competitor promises:
+  - AutoMem: Python, Railway one-click, similar MCP value prop, no graph retrieval
+  - OpenMemory MCP: Python, local, MCP, no hybrid retrieval
+  - Mem0: managed cloud, API-first, data on their servers
+
+## Phase 3 Adversarial Findings
+
+### Perceived Likelihood gaps (weakest variable)
+- Sam: No non-technical demo. Can't find proof it works for someone like her.
+- Priya: Needs network-level verification. "I need to see Little Snitch see nothing." Claim vs. verifiable evidence.
+- Dave: Needs to read source before trusting. Wants benchmark methodology explained.
+- Marketer: Benchmark credibility risk — technical buyers who find benchmark_log.csv and see the scoring-mode changes may question the 90.52% number. AutoMem's benchmark is peer-reviewed; MAG's is internal. Fix: reproducible one-command benchmark runner.
+
+### Effort gaps
+- Sam: 2/10. Completely locked out without Claude plugin. Managed waitlist is the bridge.
+- Priya: 5/10. Railway OK once she understands "your account, your container." Multi-device gap: "stays on your machine" breaks for her iPad use case.
+- Fix: "Your infrastructure, your rules" framing for Railway. Managed waitlist now.
+
+### Dream outcome refinement
+- "No re-explaining" removed from primary promise — MAG controls retrieval, not LLM behavior
+- Scope promise to: context survives sessions, cross-tool retrieval, privacy
+- Priya's framing: "Your client signed an NDA with you. Not with Mem0's infrastructure."
+
+## Offer Landscape (Phase 4)
+- Top competitors:
+  1. AutoMem — Python, Railway one-click, similar value prop, no graph retrieval, no hybrid FTS5+semantic
+  2. OpenMemory MCP (Mem0 OSS) — Python, local, MCP, no hybrid retrieval
+  3. Mem0 (managed) — cloud, API-first, data on their servers, paid
+- MAG differentiation: Rust (no Python runtime), hybrid FTS5+semantic+graph retrieval, embeddable library, additive-only migrations, MIT + Apache 2.0 stack
+- Delivery model: OSS binary/library + Railway template
+- Operational costs: near zero (user self-hosts or Railway kickback)
+- Customer switching costs: SQLite export/import easy; main lock-in is memory accumulation over time
+
+## Enhancement Data (Phase 5)
+- Bonus anchoring values: [TBD in Phase 5]
+- Scarcity precedents: none applicable (OSS)
+- Guarantee norms: OSS has no guarantee by convention; MIT license disclaimer
+- Naming landscape: "MAG" = Memory-Augmented Generation (plays on RAG). Competitors: AutoMem, OpenMemory, Mem0. MAG is distinctive.
+
+## Customer Personas (Phase 3 evolution)
+
+### Solo Sam (Solopreneur)
+Phase 0: Non-technical solopreneur, uses Claude Desktop + ChatGPT + others. Doesn't want to think about infrastructure.
+Phase 1: Pain 9/10. Would not install via terminal. Needs one-click or plugin.
+Phase 2: Free is good. Railway OK at $5/month if she understands it's her account.
+Phase 3: Dream 7, Likelihood 3, Delay 5, Effort 2. "Fix the front door. The house is worth it." Claude plugin + waitlist date is the unlock. Managed tier waitlist captures her now.
+
+### Dev Dave (Developer)
+Phase 0: Technical developer, Cursor + Claude Code + VS Code. Values performance, hackability.
+Phase 1: Pain 8/10. "Zero setup" claim failed — spotted cargo + config = not zero setup. Would install via Homebrew/npm.
+Phase 2: Free correct. Railway self-hosting makes sense.
+Phase 3: Dream 7, Likelihood 6, Delay 6, Effort 8. Setup is fine. Wants to read source code before trusting. Needs concrete demo of a developer conversation being retrieved. Show the retrieval path on a real tech session, not a toy example.
+
+### Prosumer Priya (Semi-technical)
+Phase 0: Privacy-conscious. Client data cannot leave her machine.
+Phase 1: Pain 9/10. "Client data stays on your machine" is primary buy signal. Railway OK once she understands it's her account.
+Phase 2: Would pay $10/month for managed privacy-respecting option.
+Phase 3: Dream 8, Likelihood 5, Delay 6, Effort 5. Needs network verification moment (one-command audit, Little Snitch rule). Multi-device gap: has MacBook + iPad — "your machine" framing breaks. "Your infrastructure, your rules" is more accurate. Plugin timeline matters — "coming later" is not a date.
+
+### OSS Oliver (OSS contributor/maintainer)
+Phase 0: Evaluates embeddability and licensing carefully. Would integrate MAG into own project.
+Phase 1: Pain 7/10 (less personal, more embed value). Apache 2.0 + MIT = clean commercial use.
+Phase 3: [Not reviewed this phase — B2B/embed focus, lower priority for Phase 3]

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -103,10 +103,26 @@ case "$MODEL" in
         EMBEDDING_MODEL="nomic-embed-text-v1.5-int8"
         CARGO_FLAGS=(--release --bin locomo_bench -- --nomic --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
         ;;
+    arctic-xs)
+        DEFAULT_DIM=384
+        EMBEDDING_MODEL="snowflake-arctic-embed-xs"
+        CARGO_FLAGS=(--release --bin locomo_bench -- --arctic-xs --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
+        ;;
+    arctic-s)
+        DEFAULT_DIM=384
+        EMBEDDING_MODEL="snowflake-arctic-embed-s"
+        CARGO_FLAGS=(--release --bin locomo_bench -- --arctic-s --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
+        ;;
+    gte-small)
+        DEFAULT_DIM=384
+        EMBEDDING_MODEL="gte-small"
+        CARGO_FLAGS=(--release --bin locomo_bench -- --gte-small --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
+        ;;
     *)
         echo "Unknown model: ${MODEL}" >&2
         echo "Valid models: bge-small, voyage-nano-int8, voyage-nano-fp16, voyage-nano-fp32, voyage-nano-q4," >&2
-        echo "              granite, minilm-l6, minilm-l12, e5-small, bge-base, nomic" >&2
+        echo "              granite, minilm-l6, minilm-l12, e5-small, bge-base, nomic," >&2
+        echo "              arctic-xs, arctic-s, gte-small" >&2
         exit 1
         ;;
 esac


### PR DESCRIPTION
## Summary

- **Add** `--arctic-xs` flag: Snowflake/snowflake-arctic-embed-xs (22M, 384-dim, 30ms)
- **Add** `--arctic-s` flag: Snowflake/snowflake-arctic-embed-s (33M, 384-dim, 36ms)
- **Add** `--gte-small` flag: thenlper/gte-small (33M, 384-dim, 65ms)
- **Add** corresponding `arctic-xs`, `arctic-s`, `gte-small` cases to `scripts/bench.sh`
- **Log** all 16 model benchmark results to `docs/benchmark_log.csv`
- **Update** `README.md` with full 16-model comparison table

## Key findings

All three new models score 90.5–90.9% WO — below bge-small-en-v1.5 (91.1%) on this workload despite arctic-embed-s beating bge-small on MTEB retrieval (51.98 vs 51.68). MTEB and LoCoMo don't always correlate. bge-small remains the best balance of accuracy and speed at 384-dim.

Note: both arctic models export token_type_ids in their ONNX graphs despite being based on non-BERT architectures — `use_token_type_ids: true` confirmed at runtime.

## Test plan

- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo test --all-features` passes
- [x] All three models ran successfully in worktree benchmark (models auto-downloaded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for three additional embedding options: arctic-xs, arctic-s, and gte-small (CLI and bench tooling).

* **Documentation**
  * Updated the Embedding Model Comparison table: added snowflake-arctic-embed-s, snowflake-arctic-embed-xs, and gte-small; combined voyage-4-nano FP32/INT8 with a reported latency range; adjusted multi-hop set size and removed prior top-model claim; updated referenced issue link.
  * Added mag-offer.md and mag-research.md documents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->