### PR TITLE
feat(bench): switch all comparison ONNX models to int8 variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,25 +99,29 @@ Current benchmark snapshots were captured on `2026-03-19` at commit `26e51cf3` o
 
 ### Embedding Model Comparison (LoCoMo word-overlap, 2 samples)
 
-| Model | Type | Dim | WO% | EvRec% | 1-Hop | Temporal | Multi-Hop | Open | Adv | AvgEmb |
-| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| granite-embedding-30m-english | ONNX | 384 | 90.5% | 87.5% | 88.9% | 91.5% | 76.9% | 91.7% | 91.1% | 3.8 ms |
-| nomic-embed-text-v1.5 int8 | ONNX | 768 | 90.0% | 86.6% | 88.4% | 91.5% | 74.4% | 90.8% | 91.0% | 42 ms |
-| snowflake-arctic-embed-s | ONNX | 384 | 90.5% | 87.6% | 89.5% | 91.5% | 73.1% | 93.0% | 89.5% | 36 ms |
-| snowflake-arctic-embed-xs | ONNX | 384 | 90.8% | 88.7% | 88.1% | 91.5% | 76.9% | 93.5% | 90.2% | 30 ms |
-| gte-small | ONNX | 384 | 90.9% | 90.8% | 89.1% | 91.5% | 73.1% | 93.7% | 90.2% | 65 ms |
-| all-MiniLM-L12-v2 | ONNX | 384 | 90.9% | 90.4% | 86.8% | 91.5% | 75.6% | 92.6% | 93.1% | 27 ms |
-| **bge-small-en-v1.5** *(default)* | ONNX | 384 | 91.1% | 90.2% | 87.6% | 91.5% | 75.6% | 94.0% | 90.9% | 7.5 ms |
-| all-MiniLM-L6-v2 | ONNX | 384 | 91.2% | 90.2% | 88.1% | 91.5% | 76.9% | 92.9% | 92.7% | 39 ms |
-| e5-small-v2 | ONNX | 384 | 91.3% | 89.1% | 90.7% | 91.5% | 76.9% | 92.9% | 91.5% | 41 ms |
-| voyage-4-nano INT8 | ONNX | 512 | 91.3% | 91.6% | 88.8% | 91.5% | 75.6% | 93.7% | 91.6% | 58 ms |
-| voyage-4-lite | API | 1024 | 91.1% | 91.0% | 91.1% | 91.5% | 73.1% | 93.4% | 90.2% | 304 ms |
-| voyage-4-nano FP32/INT8 | ONNX | 1024 | 91.8% | 91.3% | 93.5% | 91.5% | 75.6% | 93.3% | 91.6% | 82–172 ms |
-| voyage-4 | API | 1024 | 92.0% | 92.7% | 92.3% | 91.5% | 75.6% | 94.8% | 90.6% | 297 ms |
-| bge-base-en-v1.5 | ONNX | 768 | 92.2% | 91.6% | 89.4% | 91.5% | 76.9% | 94.8% | 93.1% | 42 ms |
-| text-embedding-3-large | API | 3072 | 93.0% | 93.4% | 94.6% | 91.5% | 74.4% | 95.3% | 93.1% | 444 ms |
+ONNX models use int8 quantization unless marked ¹ (no pre-built int8 available); the voyage-4-nano 1024-dim row uses mixed int8/fp32 quantization (int8 and fp32 runs averaged). API models are unquantized. Temporal Reasoning is 91.5% for every model and excluded. Scores across models within ~1 pp are within benchmark variance (304 questions, ~1.5% SE).
 
-bge-small-en-v1.5 is the default (Apache 2.0, 7.5 ms/embed). It outperforms snowflake-arctic-embed and gte-small on this workload despite MTEB suggesting arctic-embed-s is marginally better — MTEB and LoCoMo don't always correlate. bge-base-en-v1.5 is the best local ONNX (+1.1 pp, 6× slower). Multi-hop is stuck at 73–77% WO across all 16 models — architectural issue tracked in [issue #84](https://github.com/George-RD/mag/issues/84).
+| Model | Params | Dim | WO% | EvRec% | 1-Hop | Multi-Hop | Open | Adv | AvgEmb | File | RAM |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| granite-embedding-30m-english ¹ | 30M | 384 | 90.5% | 87.5% | 88.9% | 76.9% | 91.7% | 91.1% | 3.8 ms | 116 MB | 350 MB |
+| snowflake-arctic-embed-xs int8 | 22M | 384 | 90.2% | 88.7% | 87.0% | 76.9% | 92.7% | 89.5% | 3.9 ms | 22 MB | 137 MB |
+| e5-small-v2 int8 | 33M | 384 | 90.8% | 88.6% | 88.4% | 73.1% | 93.0% | 91.1% | 4.8 ms | 32 MB | 152 MB |
+| all-MiniLM-L6-v2 int8 | 22M | 384 | 91.3% | 89.2% | 88.5% | 76.9% | 93.1% | 92.3% | 7.4 ms | 22 MB | 95 MB |
+| **bge-small-en-v1.5 int8** *(default)* | 33M | 384 | 91.1% | 90.2% | 87.6% | 75.6% | 94.0% | 90.9% | 7.0 ms | 32 MB | 180 MB |
+| snowflake-arctic-embed-s int8 | 33M | 384 | 90.8% | 87.8% | 89.5% | 73.1% | 93.0% | 90.8% | 7.8 ms | 32 MB | 178 MB |
+| bge-base-en-v1.5 int8 | 109M | 768 | 91.8% | 90.4% | 87.1% | 76.9% | 94.9% | 92.7% | 10.5 ms | 105 MB | 265 MB |
+| gte-small int8 | 33M | 384 | 90.9% | 89.5% | 86.2% | 73.1% | 94.0% | 91.7% | 11.7 ms | 32 MB | 162 MB |
+| all-MiniLM-L12-v2 int8 | 33M | 384 | 91.1% | 90.4% | 86.8% | 75.6% | 94.3% | 90.9% | 12.3 ms | 32 MB | 158 MB |
+| nomic-embed-text-v1.5 int8 | 137M | 768 | 90.0% | 86.6% | 88.4% | 74.4% | 90.8% | 91.0% | 42 ms | 131 MB | 351 MB |
+| voyage-4-nano int8 512-dim | — | 512 | 91.3% | 91.6% | 88.8% | 75.6% | 93.7% | 91.6% | 58 ms | — | — |
+| voyage-4-nano int8/fp32 1024-dim | — | 1024 | 91.8% | 91.3% | 93.5% | 75.6% | 93.3% | 91.6% | 82–172 ms | — | — |
+| voyage-4-lite (API) | — | 1024 | 91.1% | 91.0% | 91.1% | 73.1% | 93.4% | 90.2% | 304 ms | — | — |
+| voyage-4 (API) | — | 1024 | 92.0% | 92.7% | 92.3% | 75.6% | 94.8% | 90.6% | 297 ms | — | — |
+| text-embedding-3-large (API) | — | 3072 | 93.0% | 93.4% | 94.6% | 74.4% | 95.3% | 93.1% | 444 ms | — | — |
+
+¹ FP32 (no pre-built int8 ONNX available).
+
+bge-small-en-v1.5 is the default (Apache 2.0, Xenova int8). It uses 32 MB on disk and 180 MB peak RSS — a 35% reduction vs the previous FP32 default (277 MB) with identical quality. MiniLM-L6 int8 is the lightest option at 22 MB / 95 MB RSS with equivalent quality. bge-base int8 is the best local ONNX at +0.7 pp for only 1.4× the latency. Switching embedding models requires re-embedding stored data — see [issue #89](https://github.com/George-RD/mag/issues/89). Multi-hop is stuck at 73–77% across all models — architectural issue tracked in [issue #84](https://github.com/George-RD/mag/issues/84).
 
 ### Other Benchmarks (earlier snapshot, 2026-03-12)
 

--- a/benches/locomo/main.rs
+++ b/benches/locomo/main.rs
@@ -111,16 +111,16 @@ struct Args {
     /// Use ibm-granite/granite-embedding-30m-english ONNX (384-dim, RoBERTa).
     #[arg(long)]
     granite: bool,
-    /// Use sentence-transformers/all-MiniLM-L6-v2 ONNX (384-dim, BERT).
+    /// Use Xenova/all-MiniLM-L6-v2 int8 ONNX (384-dim, BERT).
     #[arg(long)]
     minilm_l6: bool,
-    /// Use sentence-transformers/all-MiniLM-L12-v2 ONNX (384-dim, BERT).
+    /// Use Xenova/all-MiniLM-L12-v2 int8 ONNX (384-dim, BERT).
     #[arg(long)]
     minilm_l12: bool,
-    /// Use Xenova/e5-small-v2 ONNX (384-dim, BERT).
+    /// Use Xenova/e5-small-v2 int8 ONNX (384-dim, BERT).
     #[arg(long)]
     e5_small: bool,
-    /// Use BAAI/bge-base-en-v1.5 ONNX (768-dim, BERT).
+    /// Use Xenova/bge-base-en-v1.5 int8 ONNX (768-dim, BERT).
     #[arg(long)]
     bge_base: bool,
     /// Use nomic-ai/nomic-embed-text-v1.5 int8 ONNX (768-dim, NomicBERT).
@@ -128,13 +128,13 @@ struct Args {
     /// The benchmark harness does NOT add these prefixes — scores will be slightly below MTEB reported.
     #[arg(long)]
     nomic: bool,
-    /// Use Snowflake/snowflake-arctic-embed-xs ONNX (22M, 384-dim, MiniLM-based).
+    /// Use Snowflake/snowflake-arctic-embed-xs int8 ONNX (22M, 384-dim, MiniLM-based).
     #[arg(long)]
     arctic_xs: bool,
-    /// Use Snowflake/snowflake-arctic-embed-s ONNX (33M, 384-dim, e5-small-unsupervised based).
+    /// Use Snowflake/snowflake-arctic-embed-s int8 ONNX (33M, 384-dim, e5-small-unsupervised based).
     #[arg(long)]
     arctic_s: bool,
-    /// Use thenlper/gte-small ONNX (33M, 384-dim, pure BERT).
+    /// Use Xenova/gte-small int8 ONNX (33M, 384-dim, pure BERT).
     #[arg(long)]
     gte_small: bool,
     /// Voyage AI model name (default: voyage-4-lite).
@@ -360,67 +360,67 @@ fn main() -> Result<()> {
         )
     } else if args.minilm_l6 {
         if !args.json {
-            eprintln!("Embedder: all-MiniLM-L6-v2 ONNX (384-dim)");
+            eprintln!("Embedder: all-MiniLM-L6-v2 int8 ONNX (384-dim)");
         }
         (
             Arc::new(OnnxEmbedder::with_model_and_data(
-                "all-MiniLM-L6-v2",
-                "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/onnx/model.onnx",
+                "all-MiniLM-L6-v2-int8",
+                "https://huggingface.co/Xenova/all-MiniLM-L6-v2/resolve/main/onnx/model_int8.onnx",
                 None,
-                "https://huggingface.co/sentence-transformers/all-MiniLM-L6-v2/resolve/main/tokenizer.json",
+                "https://huggingface.co/Xenova/all-MiniLM-L6-v2/resolve/main/tokenizer.json",
                 384,
                 "last_hidden_state",
                 true, // BERT: uses token_type_ids
             )?),
-            "all-MiniLM-L6-v2".to_string(),
+            "all-MiniLM-L6-v2-int8".to_string(),
         )
     } else if args.minilm_l12 {
         if !args.json {
-            eprintln!("Embedder: all-MiniLM-L12-v2 ONNX (384-dim)");
+            eprintln!("Embedder: all-MiniLM-L12-v2 int8 ONNX (384-dim)");
         }
         (
             Arc::new(OnnxEmbedder::with_model_and_data(
-                "all-MiniLM-L12-v2",
-                "https://huggingface.co/sentence-transformers/all-MiniLM-L12-v2/resolve/main/onnx/model.onnx",
+                "all-MiniLM-L12-v2-int8",
+                "https://huggingface.co/Xenova/all-MiniLM-L12-v2/resolve/main/onnx/model_int8.onnx",
                 None,
-                "https://huggingface.co/sentence-transformers/all-MiniLM-L12-v2/resolve/main/tokenizer.json",
+                "https://huggingface.co/Xenova/all-MiniLM-L12-v2/resolve/main/tokenizer.json",
                 384,
                 "last_hidden_state",
                 true, // BERT: uses token_type_ids
             )?),
-            "all-MiniLM-L12-v2".to_string(),
+            "all-MiniLM-L12-v2-int8".to_string(),
         )
     } else if args.e5_small {
         if !args.json {
-            eprintln!("Embedder: e5-small-v2 ONNX (384-dim)");
+            eprintln!("Embedder: e5-small-v2 int8 ONNX (384-dim)");
         }
         (
             Arc::new(OnnxEmbedder::with_model_and_data(
-                "e5-small-v2",
-                "https://huggingface.co/Xenova/e5-small-v2/resolve/main/onnx/model.onnx",
+                "e5-small-v2-int8",
+                "https://huggingface.co/Xenova/e5-small-v2/resolve/main/onnx/model_int8.onnx",
                 None,
                 "https://huggingface.co/Xenova/e5-small-v2/resolve/main/tokenizer.json",
                 384,
                 "last_hidden_state",
                 true, // BERT: uses token_type_ids
             )?),
-            "e5-small-v2".to_string(),
+            "e5-small-v2-int8".to_string(),
         )
     } else if args.bge_base {
         if !args.json {
-            eprintln!("Embedder: bge-base-en-v1.5 ONNX (768-dim)");
+            eprintln!("Embedder: bge-base-en-v1.5 int8 ONNX (768-dim)");
         }
         (
             Arc::new(OnnxEmbedder::with_model_and_data(
-                "bge-base-en-v1.5",
-                "https://huggingface.co/BAAI/bge-base-en-v1.5/resolve/main/onnx/model.onnx",
+                "bge-base-en-v1.5-int8",
+                "https://huggingface.co/Xenova/bge-base-en-v1.5/resolve/main/onnx/model_int8.onnx",
                 None,
-                "https://huggingface.co/BAAI/bge-base-en-v1.5/resolve/main/tokenizer.json",
+                "https://huggingface.co/Xenova/bge-base-en-v1.5/resolve/main/tokenizer.json",
                 768,
                 "last_hidden_state",
                 true, // BERT: uses token_type_ids
             )?),
-            "bge-base-en-v1.5".to_string(),
+            "bge-base-en-v1.5-int8".to_string(),
         )
     } else if args.nomic {
         if !args.json {
@@ -446,51 +446,51 @@ fn main() -> Result<()> {
         )
     } else if args.arctic_xs {
         if !args.json {
-            eprintln!("Embedder: snowflake-arctic-embed-xs ONNX (22M, 384-dim)");
+            eprintln!("Embedder: snowflake-arctic-embed-xs int8 ONNX (22M, 384-dim)");
         }
         (
             Arc::new(OnnxEmbedder::with_model_and_data(
-                "snowflake-arctic-embed-xs",
-                "https://huggingface.co/Snowflake/snowflake-arctic-embed-xs/resolve/main/onnx/model.onnx",
+                "snowflake-arctic-embed-xs-int8",
+                "https://huggingface.co/Snowflake/snowflake-arctic-embed-xs/resolve/main/onnx/model_int8.onnx",
                 None,
                 "https://huggingface.co/Snowflake/snowflake-arctic-embed-xs/resolve/main/tokenizer.json",
                 384,
                 "last_hidden_state",
                 true, // arctic-xs ONNX export includes token_type_ids
             )?),
-            "snowflake-arctic-embed-xs".to_string(),
+            "snowflake-arctic-embed-xs-int8".to_string(),
         )
     } else if args.arctic_s {
         if !args.json {
-            eprintln!("Embedder: snowflake-arctic-embed-s ONNX (33M, 384-dim)");
+            eprintln!("Embedder: snowflake-arctic-embed-s int8 ONNX (33M, 384-dim)");
         }
         (
             Arc::new(OnnxEmbedder::with_model_and_data(
-                "snowflake-arctic-embed-s",
-                "https://huggingface.co/Snowflake/snowflake-arctic-embed-s/resolve/main/onnx/model.onnx",
+                "snowflake-arctic-embed-s-int8",
+                "https://huggingface.co/Snowflake/snowflake-arctic-embed-s/resolve/main/onnx/model_int8.onnx",
                 None,
                 "https://huggingface.co/Snowflake/snowflake-arctic-embed-s/resolve/main/tokenizer.json",
                 384,
                 "last_hidden_state",
                 true, // arctic-s ONNX export includes token_type_ids
             )?),
-            "snowflake-arctic-embed-s".to_string(),
+            "snowflake-arctic-embed-s-int8".to_string(),
         )
     } else if args.gte_small {
         if !args.json {
-            eprintln!("Embedder: gte-small ONNX (33M, 384-dim)");
+            eprintln!("Embedder: gte-small int8 ONNX (33M, 384-dim)");
         }
         (
             Arc::new(OnnxEmbedder::with_model_and_data(
-                "gte-small",
-                "https://huggingface.co/thenlper/gte-small/resolve/main/onnx/model.onnx",
+                "gte-small-int8",
+                "https://huggingface.co/Xenova/gte-small/resolve/main/onnx/model_int8.onnx",
                 None,
-                "https://huggingface.co/thenlper/gte-small/resolve/main/tokenizer.json",
+                "https://huggingface.co/Xenova/gte-small/resolve/main/tokenizer.json",
                 384,
                 "last_hidden_state",
                 true, // pure BERT: uses token_type_ids
             )?),
-            "gte-small".to_string(),
+            "gte-small-int8".to_string(),
         )
     } else {
         if !args.json {

--- a/docs/benchmark_log.csv
+++ b/docs/benchmark_log.csv
@@ -1,4 +1,4 @@
-date,commit,branch,issue_or_pr,scoring_mode,samples,embedding_model,overall_score,single_hop,temporal,multi_hop,open_domain,adversarial,evidence_recall,avg_query_ms,notes
+date,commit,branch,issue_or_pr,scoring_mode,samples,embedding_model,overall_score,single_hop,temporal,multi_hop,open_domain,adversarial,evidence_recall,avg_embed_ms,notes
 2026-03-18,d285236,main,,word-overlap,10,onnx-bge-small,70.6,,,,,,,,baseline before gap-closing changes
 2026-03-19,d285236,worktree-agent-a830499b,,word-overlap,10,onnx-bge-small,83.9,76.0,82.3,45.6,90.3,86.4,85.0,47.7,speaker/conversation/session tags + top_k 50 + speaker-tag recall + dynamic limits (50/75/100)
 2026-03-19,ea1ac85,worktree-agent-a830499b,,word-overlap,10,onnx-bge-small,86.87,81.7,82.9,51.6,92.9,89.2,85.4,45.1,+adaptive dual-match boost +substring overlap +year expansion +adversarial scoring +-ies stemmer +speaker nickname prefix
@@ -19,3 +19,11 @@ date,commit,branch,issue_or_pr,scoring_mode,samples,embedding_model,overall_scor
 2026-03-19,fbea68c,main,86,word-overlap,2,snowflake-arctic-embed-xs,90.78,88.1,91.5,76.9,93.5,90.2,88.72,30.4,22M params; ONNX includes token_type_ids despite MiniLM base
 2026-03-19,fbea68c,main,86,word-overlap,2,snowflake-arctic-embed-s,90.54,89.5,91.5,73.1,93.0,89.5,87.57,35.8,33M params; ONNX includes token_type_ids
 2026-03-19,fbea68c,main,86,word-overlap,2,gte-small,90.92,89.1,91.5,73.1,93.7,90.2,90.81,65.3,33M params pure BERT; 724MB peak RSS vs 241MB for arctic-xs
+2026-03-19,c7b160d,feat/onnx-int8-models,87,word-overlap,2,all-MiniLM-L6-v2-int8,91.3,88.5,91.5,76.9,93.1,92.3,89.2,7.4,Xenova int8; 5x speedup over FP32 (was 39ms)
+2026-03-19,c7b160d,feat/onnx-int8-models,87,word-overlap,2,all-MiniLM-L12-v2-int8,91.1,86.8,91.5,75.6,94.3,90.9,90.4,12.3,Xenova int8; 2x speedup over FP32 (was 27ms)
+2026-03-19,c7b160d,feat/onnx-int8-models,87,word-overlap,2,e5-small-v2-int8,90.8,88.4,91.5,73.1,93.0,91.1,88.6,4.8,Xenova int8; 8x speedup over FP32 (was 41ms)
+2026-03-19,c7b160d,feat/onnx-int8-models,87,word-overlap,2,bge-base-en-v1.5-int8,91.8,87.1,91.5,76.9,94.9,92.7,90.4,10.5,Xenova int8; 4x speedup over FP32 (was 42ms); 110MB vs 438MB
+2026-03-19,c7b160d,feat/onnx-int8-models,87,word-overlap,2,snowflake-arctic-embed-xs-int8,90.2,87.0,91.5,76.9,92.7,89.5,88.7,3.9,Snowflake official int8; 8x speedup over FP32 (was 30ms)
+2026-03-19,c7b160d,feat/onnx-int8-models,87,word-overlap,2,gte-small-int8,90.9,86.2,91.5,73.1,94.0,91.7,89.5,11.7,Xenova int8; 6x speedup over FP32 (was 65ms)
+2026-03-19,c7b160d,feat/onnx-int8-models,87,word-overlap,2,snowflake-arctic-embed-s-int8,90.8,89.5,91.5,73.1,93.0,90.8,87.8,7.8,Snowflake official int8; 4.6x speedup over FP32 (was 36ms)
+2026-03-19,c7b160d,feat/onnx-int8-models,89,word-overlap,2,bge-small-en-v1.5-xenova-int8,91.1,87.6,91.5,75.6,94.0,90.9,90.2,7.0,switch production default to Xenova int8; 180MB RAM vs 277MB FP32 (-35%); quality unchanged

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -13,7 +13,7 @@
 # CSV format (16 columns):
 #   date,commit,branch,issue_or_pr,scoring_mode,samples,embedding_model,
 #   overall_score,single_hop,temporal,multi_hop,open_domain,adversarial,
-#   evidence_recall,avg_query_ms,notes
+#   evidence_recall,avg_embed_ms,notes
 
 set -euo pipefail
 
@@ -21,7 +21,7 @@ REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 RESULTS_CSV="${REPO_DIR}/docs/benchmark_log.csv"
 LATEST_MD="${REPO_DIR}/benchmarks/LATEST.md"
 
-CSV_HEADER="date,commit,branch,issue_or_pr,scoring_mode,samples,embedding_model,overall_score,single_hop,temporal,multi_hop,open_domain,adversarial,evidence_recall,avg_query_ms,notes"
+CSV_HEADER="date,commit,branch,issue_or_pr,scoring_mode,samples,embedding_model,overall_score,single_hop,temporal,multi_hop,open_domain,adversarial,evidence_recall,avg_embed_ms,notes"
 
 # ── Defaults ─────────────────────────────────────────────────────────────────
 MODEL="bge-small"
@@ -45,77 +45,63 @@ done
 # ── Model → default dim + cargo flags ────────────────────────────────────────
 case "$MODEL" in
     bge-small)
-        DEFAULT_DIM=384
         EMBEDDING_MODEL="onnx-bge-small"
         CARGO_FLAGS=(--release --bin locomo_bench -- --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
         ;;
     voyage-nano-int8)
-        DEFAULT_DIM=1024
         EMBEDDING_MODEL="voyage-nano-int8"
         DIM_ARG="${DIM:-1024}"
         CARGO_FLAGS=(--release --bin locomo_bench -- --voyage-onnx --voyage-quant int8 --embedder-dim "${DIM_ARG}" --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
         ;;
     voyage-nano-fp16)
-        DEFAULT_DIM=1024
         EMBEDDING_MODEL="voyage-nano-fp16"
         DIM_ARG="${DIM:-1024}"
         CARGO_FLAGS=(--release --bin locomo_bench -- --voyage-onnx --voyage-quant fp16 --embedder-dim "${DIM_ARG}" --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
         ;;
     voyage-nano-fp32)
-        DEFAULT_DIM=1024
         EMBEDDING_MODEL="voyage-nano-fp32"
         DIM_ARG="${DIM:-1024}"
         CARGO_FLAGS=(--release --bin locomo_bench -- --voyage-onnx --voyage-quant fp32 --embedder-dim "${DIM_ARG}" --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
         ;;
     voyage-nano-q4)
-        DEFAULT_DIM=1024
         EMBEDDING_MODEL="voyage-nano-q4"
         DIM_ARG="${DIM:-1024}"
         CARGO_FLAGS=(--release --bin locomo_bench -- --voyage-onnx --voyage-quant q4 --embedder-dim "${DIM_ARG}" --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
         ;;
     granite)
-        DEFAULT_DIM=384
         EMBEDDING_MODEL="granite-embedding-30m-english"
         CARGO_FLAGS=(--release --bin locomo_bench -- --granite --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
         ;;
     minilm-l6)
-        DEFAULT_DIM=384
-        EMBEDDING_MODEL="all-MiniLM-L6-v2"
+        EMBEDDING_MODEL="all-MiniLM-L6-v2-int8"
         CARGO_FLAGS=(--release --bin locomo_bench -- --minilm-l6 --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
         ;;
     minilm-l12)
-        DEFAULT_DIM=384
-        EMBEDDING_MODEL="all-MiniLM-L12-v2"
+        EMBEDDING_MODEL="all-MiniLM-L12-v2-int8"
         CARGO_FLAGS=(--release --bin locomo_bench -- --minilm-l12 --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
         ;;
     e5-small)
-        DEFAULT_DIM=384
-        EMBEDDING_MODEL="e5-small-v2"
+        EMBEDDING_MODEL="e5-small-v2-int8"
         CARGO_FLAGS=(--release --bin locomo_bench -- --e5-small --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
         ;;
     bge-base)
-        DEFAULT_DIM=768
-        EMBEDDING_MODEL="bge-base-en-v1.5"
+        EMBEDDING_MODEL="bge-base-en-v1.5-int8"
         CARGO_FLAGS=(--release --bin locomo_bench -- --bge-base --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
         ;;
     nomic)
-        DEFAULT_DIM=768
         EMBEDDING_MODEL="nomic-embed-text-v1.5-int8"
         CARGO_FLAGS=(--release --bin locomo_bench -- --nomic --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
         ;;
     arctic-xs)
-        DEFAULT_DIM=384
-        EMBEDDING_MODEL="snowflake-arctic-embed-xs"
+        EMBEDDING_MODEL="snowflake-arctic-embed-xs-int8"
         CARGO_FLAGS=(--release --bin locomo_bench -- --arctic-xs --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
         ;;
     arctic-s)
-        DEFAULT_DIM=384
-        EMBEDDING_MODEL="snowflake-arctic-embed-s"
+        EMBEDDING_MODEL="snowflake-arctic-embed-s-int8"
         CARGO_FLAGS=(--release --bin locomo_bench -- --arctic-s --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
         ;;
     gte-small)
-        DEFAULT_DIM=384
-        EMBEDDING_MODEL="gte-small"
+        EMBEDDING_MODEL="gte-small-int8"
         CARGO_FLAGS=(--release --bin locomo_bench -- --gte-small --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
         ;;
     *)
@@ -135,10 +121,10 @@ fi
 
 # ── Run benchmark, capture output ────────────────────────────────────────────
 cd "${REPO_DIR}"
-echo "Running: cargo ${CARGO_FLAGS[*]}"
+echo "Running: cargo run ${CARGO_FLAGS[*]}"
 echo "──────────────────────────────────────────────────────────────────────────"
 
-RAW_OUTPUT="$(cargo "${CARGO_FLAGS[@]}" 2>&1)"
+RAW_OUTPUT="$(cargo run "${CARGO_FLAGS[@]}" 2>&1)"
 EXIT_CODE=$?
 echo "${RAW_OUTPUT}"
 echo "──────────────────────────────────────────────────────────────────────────"
@@ -175,9 +161,9 @@ open_domain="${open_domain:-}"
 adversarial=$(echo "${RAW_OUTPUT}" | grep "Adversarial" | grep -oE '[0-9]+\.[0-9]+%' | sed -n '2p' | tr -d '%')
 adversarial="${adversarial:-}"
 
-# Timing
-avg_query_ms=$(echo "${RAW_OUTPUT}" | grep "Avg query:" | grep -oE '[0-9]+ms' | tr -d 'ms' | head -1)
-avg_query_ms="${avg_query_ms:-}"
+# Timing — log avg embed latency (ms) for the embedding step only.
+avg_embed_ms=$(echo "${RAW_OUTPUT}" | grep "Avg embed:" | grep -oE '[0-9]+(\.[0-9]+)?ms' | tr -d 'ms' | head -1)
+avg_embed_ms="${avg_embed_ms:-}"
 
 # Git metadata
 DATE_STR="$(date '+%Y-%m-%d')"
@@ -185,7 +171,7 @@ COMMIT="$(git -C "${REPO_DIR}" rev-parse --short HEAD 2>/dev/null || echo '')"
 BRANCH="$(git -C "${REPO_DIR}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '')"
 
 # ── Append CSV row ────────────────────────────────────────────────────────────
-CSV_ROW="${DATE_STR},${COMMIT},${BRANCH},,${SCORING_MODE},${SAMPLES},${EMBEDDING_MODEL},${overall_score},${single_hop},${temporal},${multi_hop},${open_domain},${adversarial},${evidence_recall},${avg_query_ms},${NOTES}"
+CSV_ROW="${DATE_STR},${COMMIT},${BRANCH},,${SCORING_MODE},${SAMPLES},${EMBEDDING_MODEL},${overall_score},${single_hop},${temporal},${multi_hop},${open_domain},${adversarial},${evidence_recall},${avg_embed_ms},${NOTES}"
 echo "${CSV_ROW}" >> "${RESULTS_CSV}"
 echo "Appended result to ${RESULTS_CSV}"
 
@@ -193,7 +179,7 @@ echo "Appended result to ${RESULTS_CSV}"
 print_table() {
     local mode="$1"
     printf "\n## LoCoMo Benchmark — %s scoring\n\n" "${mode}"
-    printf "| Date | Model | Overall%% | 1-Hop | Temporal | Multi-Hop | Open | Adv | EvRec%% | Avg Q (ms) |\n"
+    printf "| Date | Model | Overall%% | 1-Hop | Temporal | Multi-Hop | Open | Adv | EvRec%% | Avg Emb (ms) |\n"
     printf "|------|-------|---------|-------|----------|-----------|------|-----|--------|------------|\n"
 
     # Skip header line, filter by scoring_mode (col 5)

--- a/src/memory_core/embedder.rs
+++ b/src/memory_core/embedder.rs
@@ -55,13 +55,13 @@ pub(crate) fn normalize_embedding(vec: &mut [f32]) {
 }
 
 #[cfg(feature = "real-embeddings")]
-const MODEL_NAME: &str = "bge-small-en-v1.5";
+const MODEL_NAME: &str = "bge-small-en-v1.5-int8";
 #[cfg(feature = "real-embeddings")]
 const MODEL_URL: &str =
-    "https://huggingface.co/BAAI/bge-small-en-v1.5/resolve/main/onnx/model.onnx";
+    "https://huggingface.co/Xenova/bge-small-en-v1.5/resolve/main/onnx/model_int8.onnx";
 #[cfg(feature = "real-embeddings")]
 const TOKENIZER_URL: &str =
-    "https://huggingface.co/BAAI/bge-small-en-v1.5/resolve/main/tokenizer.json";
+    "https://huggingface.co/Xenova/bge-small-en-v1.5/resolve/main/tokenizer.json";
 
 #[cfg(feature = "real-embeddings")]
 const EMBEDDING_CACHE_CAPACITY: std::num::NonZeroUsize = std::num::NonZeroUsize::new(2048).unwrap();
@@ -104,7 +104,7 @@ struct ModelFiles {
 impl OnnxEmbedder {
     pub fn new() -> Result<Self> {
         Self::with_model(
-            "bge-small-en-v1.5",
+            MODEL_NAME,
             MODEL_URL,
             TOKENIZER_URL,
             384,
@@ -702,7 +702,7 @@ fn ensure_model_files_blocking(
     model_data_url: Option<&str>,
     tokenizer_url: &str,
 ) -> Result<ModelFiles> {
-    if model_files_exist(&model_dir, model_data_url.is_some()) {
+    if model_files_exist(&model_dir, model_data_url) {
         return Ok(model_files_for_dir(model_dir, model_data_url));
     }
 
@@ -731,7 +731,7 @@ async fn ensure_model_files_async(
     tokenizer_url: &str,
 ) -> Result<ModelFiles> {
     let files = model_files_for_dir(model_dir, model_data_url);
-    if model_files_exist(&files.directory, model_data_url.is_some()) {
+    if model_files_exist(&files.directory, model_data_url) {
         return Ok(files);
     }
 
@@ -768,13 +768,10 @@ async fn ensure_model_files_async(
 }
 
 #[cfg(feature = "real-embeddings")]
-fn model_files_exist(model_dir: &Path, has_data_file: bool) -> bool {
-    let files = model_files_for_dir(
-        model_dir.to_path_buf(),
-        if has_data_file { Some("") } else { None },
-    );
+fn model_files_exist(model_dir: &Path, model_data_url: Option<&str>) -> bool {
+    let files = model_files_for_dir(model_dir.to_path_buf(), model_data_url);
     let base = files.model_path.exists() && files.tokenizer_path.exists();
-    if has_data_file {
+    if model_data_url.is_some() {
         base && files.model_data_path.as_ref().is_some_and(|p| p.exists())
     } else {
         base


### PR DESCRIPTION
## Summary

Rebased version of #87 (originally merged into `feat/arctic-gte-bench` instead of `main`).

- Replace all FP32 model.onnx URLs with pre-built int8 variants for fair comparison with bge-small
- Switch default bge-small to Xenova int8 (32 MB disk, 180 MB RAM vs 277 MB FP32)
- Update MODEL_NAME cache key to `bge-small-en-v1.5-int8` to invalidate stale FP32 cache
- Fix `model_files_exist` bug: pass actual data URL instead of `Some("")`
- Remove unused `DEFAULT_DIM` from bench.sh
- Rename `avg_query_ms` → `avg_embed_ms` for schema clarity
- Clarify README: granite is FP32, voyage-4-nano 1024-dim is mixed int8/fp32

## Test plan

- [x] `cargo fmt --check` passes
- [x] `cargo clippy -D warnings` passes
- [ ] `cargo test --all-features`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated LoCoMo benchmark documentation with reorganized embedding model comparison table, including quantization variants and resource-usage metrics.

* **Improvements**
  * Enhanced embedding models with int8 quantization support for improved performance and reduced memory footprint.
  * Updated benchmark reporting metrics from query timing to embed timing for more accurate performance measurement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->