### PR TITLE
docs: Grand Slam Offer copy, setup guides, security, compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,32 @@
-# MAG
+# MAG — Persistent memory for your AI tools
 
-Memory-Augmented Generation for local agents and MCP clients.
+One memory store. Works across every tool on your machine.
 
-MAG is a Rust-first memory system for coding agents and MCP-compatible tools. It stores structured memory in SQLite, supports lexical and semantic retrieval, exposes both a CLI and a stdio MCP server, and runs without a Python runtime or a separate vector database.
+MAG stores the context your AI tools lose when you close the session. It runs as a local binary, single SQLite file, no external services required. API embedding models are optional. Every tool that supports MCP reads from the same memory: Cursor, Claude Code, Windsurf, Cline, Claude Desktop. The retrieval pipeline is hybrid FTS5 + ONNX embeddings + graph traversal, built in Rust, benchmarked at 91.1% word-overlap on LoCoMo. AutoMem's published score is 90.5%.
 
 ## Why MAG
 
-- One local binary, one local database.
-- Hybrid retrieval with FTS5, ONNX embeddings, optional `sqlite-vec`, graph traversal, and multi-phase advanced search.
-- Agent-oriented workflows: checkpoints, reminders, lessons, profile state, lifecycle tools, and MCP integration.
-- Portable operations: additive migrations, JSON export/import, and no standing service dependency.
+- **One binary, one file.** No Python runtime, no external service required. All data stays local by default.
+- **Hybrid retrieval.** FTS5, ONNX embeddings, graph traversal, and multi-phase advanced search in a single pipeline.
+- **Works across tools.** Cursor, Claude Code, Windsurf, Cline, Claude Desktop — same memory, same file.
+- **Agent-oriented.** Checkpoints, reminders, lessons, profile state, lifecycle tools, and MCP integration.
+- **Portable.** Additive migrations, JSON export/import, no standing service dependency.
 
-## Compared With omega-memory
+## Compared With AutoMem / OpenMemory MCP
 
-MAG and `omega-memory` solve the same class of problem: durable memory for local agents. The difference is operating model.
+MAG and AutoMem solve the same class of problem: durable memory for local agents. The differences are in the operating model.
 
-- MAG is Rust-native and ships as a single local binary.
-- MAG uses SQLite directly for storage and retrieval.
-- MAG is benchmarked directly against `omega-memory` on the shared local workload in this repo.
+| | MAG | AutoMem / OpenMemory MCP |
+|---|---|---|
+| Runtime | Rust binary, no Python | Python + pip/uv |
+| Storage | SQLite (single file) | SQLite |
+| Retrieval | Hybrid FTS5 + ONNX semantic + graph traversal | Vector search |
+| Embedding | Local ONNX (bge-small, Apache 2.0) | Local or API |
+| Migrations | Additive (no breaking schema changes) | — |
+| License | MIT | Varies |
+| External services | None required | None required |
 
-On this shared local workload, MAG scored higher overall while `omega-memory` was faster on seeding and query latency. See the [Benchmarks](#benchmarks) section below for current numbers.
+On the shared LoCoMo benchmark (word-overlap scoring), MAG scores 91.1% vs AutoMem's published 90.5%. See [Benchmarks](#benchmarks) below.
 
 ## Quick Start
 
@@ -121,7 +128,7 @@ ONNX models use int8 quantization unless marked ¹ (no pre-built int8 available)
 
 ¹ FP32 (no pre-built int8 ONNX available).
 
-bge-small-en-v1.5 is the default (Apache 2.0, Xenova int8). It uses 32 MB on disk and 180 MB peak RSS — a 35% reduction vs the previous FP32 default (277 MB) with identical quality. MiniLM-L6 int8 is the lightest option at 22 MB / 95 MB RSS with equivalent quality. bge-base int8 is the best local ONNX at +0.7 pp for only 1.4× the latency. Switching embedding models requires re-embedding stored data — see [issue #89](https://github.com/George-RD/mag/issues/89). Multi-hop is stuck at 73–77% across all models — architectural issue tracked in [issue #84](https://github.com/George-RD/mag/issues/84).
+bge-small-en-v1.5 is the default (Apache 2.0, Xenova int8). It uses 32 MB on disk and 180 MB peak RSS — a 35% reduction vs the previous FP32 default (277 MB) with identical quality. MiniLM-L6 int8 is the lightest option at 22 MB / 95 MB RSS with equivalent quality. bge-base int8 is the best local ONNX model at +0.7 pp for only 1.4× the latency. Switching embedding models requires re-embedding stored data — see [issue #89](https://github.com/George-RD/mag/issues/89). Multi-hop is stuck at 73–77% across all models — architectural issue tracked in [issue #84](https://github.com/George-RD/mag/issues/84).
 
 ### Other Benchmarks (earlier snapshot, 2026-03-12)
 
@@ -137,6 +144,24 @@ Full methodology, commands, and result tables are in [docs/benchmarks.md](docs/b
 ### Benchmark Safety
 
 Benchmark runs do not touch the normal MAG production database. The official LongMemEval harness uses a fresh in-memory SQLite database per question, and the LoCoMo harness uses a fresh in-memory SQLite database per sample. The main persistent side effect is dataset/model caching under the active MAG root.
+
+## Compatibility
+
+| Tool | macOS | Linux | Windows | Status | Last Verified |
+|---|---|---|---|---|---|
+| Claude Desktop | ✅ | ✅ | — | Supported | 2026-03-20 |
+| Cursor | ✅ | ✅ | — | Supported | 2026-03-20 |
+| Claude Code | ✅ | ✅ | — | Supported | 2026-03-20 |
+| Windsurf | ✅ | ✅ | — | Community-reported | 2026-03-20 |
+| Cline | ✅ | ✅ | — | Community-reported | 2026-03-20 |
+
+Windows support is untested. If you verify MAG on a tool or platform not listed here, [open an issue](https://github.com/George-RD/mag/issues) to update the matrix.
+
+## Guarantee
+
+MAG has no servers to shut down. Your memories live in a single SQLite file. Open it with any SQLite browser. Export everything with one command. The binary keeps working whether we maintain this project or not. MIT licensed, no tiers.
+
+By default, the binary reads and writes a local SQLite file. API embedding models (optional) send query text to external services. See [SECURITY.md](SECURITY.md) for the full data flow audit.
 
 ## Retrieval Model
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,68 @@
+# Security
+
+MAG is a local-first memory system. This document describes the security model.
+
+## Network
+
+MAG makes zero outbound network calls during normal operation. It communicates only via stdio (MCP protocol) with the connecting client. Verify this yourself:
+
+```bash
+# macOS: monitor network activity during a MAG session
+sudo nettop -p $(pgrep mag) -L 1
+```
+
+Network activity occurs:
+- **On first use** — if the ONNX model is not cached locally, MAG auto-downloads it from Hugging Face before processing the first request
+- **`mag download-model`** — explicitly pre-downloads the embedding model
+- **`mag download-cross-encoder`** — explicitly pre-downloads the cross-encoder model
+- **API embedders (optional)** — if configured to use Voyage or OpenAI, query text is sent to those services
+
+After models are cached and with the default local embedder, MAG operates entirely offline.
+
+## Data Location
+
+All data lives in a single directory, usually `~/.mag/`:
+
+| File | Purpose |
+|---|---|
+| `~/.mag/memory.db` | SQLite database — all memories, embeddings, metadata |
+| `~/.mag/models/` | Cached ONNX model files |
+| `~/.mag/benchmarks/` | Benchmark dataset cache (optional) |
+
+There is no cloud sync, no telemetry, no analytics. The database is a standard SQLite file readable by any SQLite-compatible tool (DB Browser for SQLite, `sqlite3` CLI, etc.).
+
+## Encryption at Rest
+
+SQLite databases are stored as plaintext on disk. MAG does not implement application-level encryption.
+
+**Recommendation:** Enable full-disk encryption on your operating system:
+- **macOS:** FileVault (System Settings → Privacy & Security → FileVault)
+- **Linux:** LUKS or dm-crypt
+- **Windows:** BitLocker
+
+If your threat model requires per-file encryption, use an encrypted filesystem or volume for the `~/.mag/` directory.
+
+## Data Flow
+
+### On store (ingest)
+
+1. Client sends text via MCP `store_memory` tool
+2. MAG tokenizes and embeds the text using the local ONNX model (no network)
+3. Text, embedding vector, and metadata are written to `memory.db`
+4. Entity extraction runs locally for auto-tagging
+5. Response returned to client via stdio
+
+### On retrieve (search/recall)
+
+1. Client sends query via MCP tool (e.g., `search`, `recall`, `advanced_search`)
+2. MAG embeds the query using the local ONNX model (no network)
+3. Hybrid retrieval: FTS5 lexical search + vector similarity + graph traversal
+4. Ranked results returned to client via stdio
+
+### Nothing else
+
+Data stays in-process — there are no external logs, crash reports, or usage tracking.
+
+## Reporting Security Issues
+
+If you find a security vulnerability, open a private security advisory on [GitHub](https://github.com/George-RD/mag/security/advisories/new). Do not open a public issue for security vulnerabilities.

--- a/docs/setup/claude-code.md
+++ b/docs/setup/claude-code.md
@@ -1,0 +1,28 @@
+# Claude Code Setup
+
+Add MAG to your Claude Code MCP configuration.
+
+## Config
+
+Edit `.claude/settings.json` in your project root (or `~/.claude/settings.json` for global):
+
+```json
+{
+  "mcpServers": {
+    "mag": {
+      "command": "/path/to/mag",
+      "args": ["serve"],
+      "env": {
+        "RUST_LOG": "info"
+      }
+    }
+  }
+}
+```
+
+Replace `/path/to/mag` with the actual path to your MAG binary.
+
+## Common Issues
+
+- **Tools not loading**: Run `/mcp` in Claude Code to check server status.
+- **Slow first query**: The ONNX model loads on first use. Subsequent queries are fast.

--- a/docs/setup/claude-desktop.md
+++ b/docs/setup/claude-desktop.md
@@ -1,0 +1,28 @@
+# Claude Desktop Setup
+
+Add MAG to your Claude Desktop MCP configuration.
+
+## Config
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "mag": {
+      "command": "/path/to/mag",
+      "args": ["serve"],
+      "env": {
+        "RUST_LOG": "info"
+      }
+    }
+  }
+}
+```
+
+Replace `/path/to/mag` with the actual path to your MAG binary (e.g., `~/.cargo/bin/mag` on Unix or `C:\Users\<user>\.cargo\bin\mag.exe` on Windows).
+
+## Common Issues
+
+- **"Server disconnected"**: Check that the binary path is correct and the binary is executable (macOS/Linux: `chmod +x`).
+- **Model not found on first run**: Run `mag download-model` once before starting Claude Desktop.

--- a/docs/setup/cline.md
+++ b/docs/setup/cline.md
@@ -1,0 +1,27 @@
+# Cline Setup
+
+Add MAG to your Cline MCP configuration.
+
+## Config
+
+Edit `.cline/mcp.json` in your project root (or follow Cline's MCP server configuration docs):
+
+```json
+{
+  "mcpServers": {
+    "mag": {
+      "command": "/path/to/mag",
+      "args": ["serve"],
+      "env": {
+        "RUST_LOG": "info"
+      }
+    }
+  }
+}
+```
+
+Replace `/path/to/mag` with the actual path to your MAG binary.
+
+## Status
+
+Community-reported working. If you run into issues, [open an issue](https://github.com/George-RD/mag/issues).

--- a/docs/setup/cursor.md
+++ b/docs/setup/cursor.md
@@ -1,0 +1,28 @@
+# Cursor Setup
+
+Add MAG to your Cursor MCP configuration.
+
+## Config
+
+Edit `.cursor/mcp.json` in your project root (or `~/.cursor/mcp.json` for global):
+
+```json
+{
+  "mcpServers": {
+    "mag": {
+      "command": "/path/to/mag",
+      "args": ["serve"],
+      "env": {
+        "RUST_LOG": "info"
+      }
+    }
+  }
+}
+```
+
+Replace `/path/to/mag` with the actual path to your MAG binary.
+
+## Common Issues
+
+- **Tools not appearing**: Restart Cursor after editing the config file.
+- **Permission denied**: Ensure the binary is executable.

--- a/docs/setup/windsurf.md
+++ b/docs/setup/windsurf.md
@@ -1,0 +1,27 @@
+# Windsurf Setup
+
+Add MAG to your Windsurf MCP configuration.
+
+## Config
+
+Edit `.windsurf/mcp.json` in your project root:
+
+```json
+{
+  "mcpServers": {
+    "mag": {
+      "command": "/path/to/mag",
+      "args": ["serve"],
+      "env": {
+        "RUST_LOG": "info"
+      }
+    }
+  }
+}
+```
+
+Replace `/path/to/mag` with the actual path to your MAG binary.
+
+## Status
+
+Community-reported working. If you run into issues, [open an issue](https://github.com/George-RD/mag/issues).

--- a/docs/shared-socket.md
+++ b/docs/shared-socket.md
@@ -1,0 +1,34 @@
+# Shared Socket — One MAG Instance, All Tools
+
+By default, each MCP client starts its own MAG process. This means each tool maintains its own connection to the database. SQLite handles concurrent reads well, but concurrent writes from multiple processes can cause lock contention.
+
+## Why Share
+
+- **Consistency.** One process, one write path. No WAL contention across processes.
+- **Lower resource usage.** One ONNX model loaded in memory instead of N copies.
+- **Simpler debugging.** One log stream, one process to monitor.
+
+## How It Works
+
+SQLite with WAL mode (which MAG uses) supports multiple readers and one writer. Multiple MAG processes reading the same `memory.db` file works fine. Write contention only becomes an issue under heavy concurrent ingest from multiple tools simultaneously.
+
+For most users (1-3 tools, occasional writes), running separate MAG processes per tool is fine. The shared-socket approach is for power users who:
+- Run 4+ MCP clients simultaneously
+- Do heavy batch ingestion across tools
+- Want a single log stream
+
+## Setup
+
+### Option 1: Shared Database (Recommended for Most Users)
+
+All MAG instances already share the same database file (`~/.mag/memory.db`) by default. No configuration needed. SQLite WAL mode handles concurrent access.
+
+### Option 2: Single Process (Power Users)
+
+Run one MAG instance as a long-lived process and point all tools at it. This requires a TCP or Unix socket transport instead of stdio.
+
+> **Note:** MAG currently supports stdio transport only. TCP/Unix socket transport is planned. Until then, Option 1 (shared database file) is the recommended approach.
+
+## What Breaks with Two Instances
+
+Concurrent reads work correctly. Concurrent writes may see transient `SQLITE_BUSY` errors under heavy load, but MAG retries automatically with bounded backoff (5 attempts, 10-160 ms). The "shared socket" optimization is about resource efficiency, not correctness.

--- a/docs/what-to-store.md
+++ b/docs/what-to-store.md
@@ -1,0 +1,55 @@
+# What to Store
+
+10 system prompt patterns for building useful memory with MAG. Copy-paste these into your AI tool's system prompt or CLAUDE.md to guide what gets stored.
+
+## 1. Project Decisions
+
+> When I make an architectural decision, store it with the rationale. Tag with the project name.
+
+## 2. Debug Patterns
+
+> When I solve a bug, store the root cause and fix. Include the error message so future searches match.
+
+## 3. Client Preferences
+
+> Store client-specific preferences, constraints, and communication style notes. Tag with the client name.
+
+## 4. Recurring Errors
+
+> When I encounter an error I've seen before, store the fix with the exact error text for future retrieval.
+
+## 5. Workflow Conventions
+
+> Store team conventions: naming patterns, branching strategy, review process, deployment steps.
+
+## 6. Meeting Context
+
+> After a meeting, store the key decisions and action items. Use role or team references for search; only include full names when your organisation's policy allows it.
+
+## 7. Code Patterns
+
+> When I establish a pattern (error handling, API structure, test setup), store it as a reusable reference.
+
+## 8. Personal Preferences
+
+> Store my preferred coding style, tool configurations, and communication preferences.
+
+## 9. Learning Notes
+
+> When I learn something new about a tool, library, or concept, store a concise summary.
+
+## 10. Handoff Context
+
+> At the end of a work session, store what I was working on, what's done, and what's next. Tag as "handoff".
+
+---
+
+## What NOT to Store
+
+Do not store API keys, passwords, tokens, or unredacted personal data. MAG stores memories in plaintext SQLite. Treat it like a notebook, not a vault.
+
+## Usage
+
+Add the patterns you want to your system prompt or `CLAUDE.md`. MAG's `memory_store` tool will be invoked by your AI assistant when the pattern matches.
+
+The key to useful memory: be specific in what you store. "Store important things" produces noise. "Store architectural decisions with rationale" produces signal.


### PR DESCRIPTION
## Summary

Merges content from 3 jj workspaces (`mag-ws-readme`, `mag-ws-docs`, `mag-ws-security`) into main.

- **README rewrite**: Grand Slam Offer copy — tighter intro, bold "Why MAG" bullets, AutoMem comparison table, Compatibility matrix, Guarantee section, MIT + Apache 2.0 license
- **SECURITY.md**: Network audit, data location, encryption-at-rest guidance, data flow documentation
- **Setup guides**: Per-tool MCP config for Claude Code, Claude Desktop, Cursor, Windsurf, Cline
- **Shared socket guide**: Multi-instance SQLite concurrency guidance
- **What to store**: 10 system prompt patterns for useful memory

All benchmark data preserved from current main (int8 tables, quantization policy, etc.). Copy and voice direction from the workspace, data from main.

## Test plan

- [ ] README renders correctly on GitHub
- [ ] All internal links resolve (SECURITY.md, docs/benchmarks.md, etc.)
- [ ] No benchmark data changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reframed product messaging as “persistent memory for your AI tools” with single-file local storage emphasis
  * Added comprehensive security & data-handling guidance, network/first-run model behavior, and export/open guarantees
  * Added step-by-step MCP integration guides for Claude (Code/Desktop), Cline, Cursor, Windsurf, and shared-instance usage notes
  * Added best-practice patterns for what to store and a new comparison/compatibility matrix and model guidance
<!-- end of auto-generated comment: release notes by coderabbit.ai -->