### PR TITLE
feat(daemon): add HTTP server assembly, CLI wiring, and stdio fallback

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ sqlite-vec = ["dep:sqlite-vec"]
 anyhow = "1.0.101"
 async-trait = "0.1.89"
 axum = "0.8"
-clap = { version = "4.5.59", features = ["derive"] }
+clap = { version = "4.5.59", features = ["derive", "env"] }
 rusqlite = { version = "0.33", features = ["bundled"] }
 serde = { version = "1.0.228", features = ["derive"] }
 tokio = { version = "1.49.0", features = ["full"] }

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,0 +1,237 @@
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+
+use axum::body::Body;
+use axum::http::{Method, Request, Response, StatusCode};
+
+/// Constant-time string comparison to prevent timing attacks on token validation.
+fn constant_time_eq(a: &str, b: &str) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.bytes()
+        .zip(b.bytes())
+        .fold(0u8, |acc, (x, y)| acc | (x ^ y))
+        == 0
+}
+
+/// Tower layer that validates `Authorization: Bearer <token>` on incoming requests.
+/// `GET /health` is exempt from authentication.
+#[derive(Clone)]
+pub struct AuthLayer {
+    expected_token: Arc<String>,
+}
+
+impl AuthLayer {
+    pub fn new(token: String) -> Self {
+        Self {
+            expected_token: Arc::new(token),
+        }
+    }
+}
+
+impl<S> tower::Layer<S> for AuthLayer {
+    type Service = AuthService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        AuthService {
+            inner,
+            expected_token: Arc::clone(&self.expected_token),
+        }
+    }
+}
+
+/// Tower service produced by [`AuthLayer`] that performs Bearer token validation.
+#[derive(Clone)]
+pub struct AuthService<S> {
+    inner: S,
+    expected_token: Arc<String>,
+}
+
+impl<S, B> tower::Service<Request<B>> for AuthService<S>
+where
+    S: tower::Service<Request<B>, Response = Response<Body>> + Clone + Send + 'static,
+    S::Future: Send + 'static,
+    B: Send + 'static,
+{
+    type Response = S::Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: Request<B>) -> Self::Future {
+        if req.method() == Method::GET && req.uri().path() == "/health" {
+            let future = self.inner.call(req);
+            return Box::pin(future);
+        }
+
+        let authorized = req
+            .headers()
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.strip_prefix("Bearer "))
+            .is_some_and(|token| constant_time_eq(token, &self.expected_token));
+
+        if authorized {
+            let future = self.inner.call(req);
+            Box::pin(future)
+        } else {
+            Box::pin(async {
+                Ok(Response::builder()
+                    .status(StatusCode::UNAUTHORIZED)
+                    .body(Body::from("Unauthorized"))
+                    // Status + body-from-string is infallible; unwrap_or provides a fallback
+                    .unwrap_or_else(|_| Response::new(Body::from("Unauthorized"))))
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::Request;
+    use tower::{Service, ServiceBuilder, ServiceExt};
+
+    /// Build a trivial handler wrapped in AuthLayer for testing.
+    fn build_service(
+        token: &str,
+    ) -> impl Service<
+        Request<Body>,
+        Response = Response<Body>,
+        Error = std::convert::Infallible,
+        Future = impl Future<Output = Result<Response<Body>, std::convert::Infallible>> + Send,
+    > + Clone {
+        let handler = tower::service_fn(|_req: Request<Body>| async {
+            Ok::<_, std::convert::Infallible>(
+                Response::builder()
+                    .status(StatusCode::OK)
+                    .body(Body::from("ok"))
+                    .expect("building static response cannot fail"),
+            )
+        });
+
+        ServiceBuilder::new()
+            .layer(AuthLayer::new(token.to_owned()))
+            .service(handler)
+    }
+
+    #[tokio::test]
+    async fn valid_bearer_token_passes() {
+        let mut svc = build_service("secret-token");
+        let req = Request::builder()
+            .uri("/api/data")
+            .header("Authorization", "Bearer secret-token")
+            .body(Body::empty())
+            .expect("building test request cannot fail");
+
+        let resp = svc
+            .ready()
+            .await
+            .expect("service ready")
+            .call(req)
+            .await
+            .expect("call succeeds");
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn wrong_token_returns_401() {
+        let mut svc = build_service("secret-token");
+        let req = Request::builder()
+            .uri("/api/data")
+            .header("Authorization", "Bearer wrong-token")
+            .body(Body::empty())
+            .expect("building test request cannot fail");
+
+        let resp = svc
+            .ready()
+            .await
+            .expect("service ready")
+            .call(req)
+            .await
+            .expect("call succeeds");
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn missing_auth_header_returns_401() {
+        let mut svc = build_service("secret-token");
+        let req = Request::builder()
+            .uri("/api/data")
+            .body(Body::empty())
+            .expect("building test request cannot fail");
+
+        let resp = svc
+            .ready()
+            .await
+            .expect("service ready")
+            .call(req)
+            .await
+            .expect("call succeeds");
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn get_health_bypasses_auth() {
+        let mut svc = build_service("secret-token");
+        let req = Request::builder()
+            .method(Method::GET)
+            .uri("/health")
+            .body(Body::empty())
+            .expect("building test request cannot fail");
+
+        let resp = svc
+            .ready()
+            .await
+            .expect("service ready")
+            .call(req)
+            .await
+            .expect("call succeeds");
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn post_health_requires_auth() {
+        let mut svc = build_service("secret-token");
+        let req = Request::builder()
+            .method(Method::POST)
+            .uri("/health")
+            .body(Body::empty())
+            .expect("building test request cannot fail");
+
+        let resp = svc
+            .ready()
+            .await
+            .expect("service ready")
+            .call(req)
+            .await
+            .expect("call succeeds");
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[test]
+    fn constant_time_eq_equal_strings() {
+        assert!(constant_time_eq("hello", "hello"));
+    }
+
+    #[test]
+    fn constant_time_eq_different_strings() {
+        assert!(!constant_time_eq("hello", "world"));
+    }
+
+    #[test]
+    fn constant_time_eq_different_lengths() {
+        assert!(!constant_time_eq("short", "longer-string"));
+    }
+
+    #[test]
+    fn constant_time_eq_empty_strings() {
+        assert!(constant_time_eq("", ""));
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -57,39 +57,6 @@ pub struct SearchFilterArgs {
     pub event_before: Option<String>,
 }
 
-/// Events that can be sent to the MAG daemon via the hook client.
-///
-/// Each variant maps to a `/hook/*` HTTP endpoint on the daemon.
-#[derive(Debug, Clone)]
-#[allow(dead_code)] // Consumers come in a follow-up PR (CLI hook subcommand)
-pub enum HookEvent {
-    SessionStart {
-        project: Option<String>,
-        budget_tokens: Option<u64>,
-    },
-    SessionEnd {
-        project: Option<String>,
-        session_id: String,
-        summary: Option<String>,
-    },
-    CompactRefresh {
-        project: Option<String>,
-        budget_tokens: Option<u64>,
-    },
-    Search {
-        query: String,
-        project: Option<String>,
-        limit: Option<u32>,
-    },
-    Store {
-        content: String,
-        tags: Vec<String>,
-        importance: f64,
-        event_type: Option<String>,
-        project: Option<String>,
-    },
-}
-
 /// The main CLI entry point for MAG.
 #[derive(Parser)]
 #[command(name = "mag", version)]
@@ -381,11 +348,72 @@ pub enum Commands {
     DownloadModel,
     /// Downloads the cross-encoder model for reranking.
     DownloadCrossEncoder,
-    /// Starts the MCP server over stdio transport.
+    /// Starts the MAG daemon (MCP-over-HTTP + hook endpoints).
+    /// Pass --stdio to use the legacy stdio transport instead of HTTP.
     Serve {
+        /// TCP port to listen on (HTTP mode only).
+        #[arg(long, default_value_t = 19420, env = "MAG_PORT")]
+        port: u16,
+        /// Idle timeout in seconds before the daemon auto-shuts down (HTTP mode only).
+        #[arg(long, default_value_t = 1200)]
+        idle_timeout: u64,
         /// Enable cross-encoder reranking (disabled by default).
         #[arg(long)]
         cross_encoder: bool,
+        /// Use legacy stdio transport instead of HTTP daemon mode.
+        #[arg(long)]
+        stdio: bool,
+    },
+    /// Send a request to the MAG daemon's hook endpoint.
+    Hook {
+        #[command(subcommand)]
+        event: HookEvent,
+    },
+}
+
+/// Hook events that can be sent to the MAG daemon.
+#[derive(Subcommand, Debug)]
+pub enum HookEvent {
+    /// Notify session start — returns context injection.
+    SessionStart {
+        #[arg(long)]
+        project: Option<String>,
+        #[arg(long, default_value_t = 2000)]
+        budget_tokens: usize,
+    },
+    /// Notify session end — stores summary.
+    SessionEnd {
+        #[arg(long)]
+        project: Option<String>,
+        #[arg(long)]
+        session_id: Option<String>,
+    },
+    /// Refresh context after compaction.
+    CompactRefresh {
+        #[arg(long)]
+        project: Option<String>,
+        #[arg(long, default_value_t = 800)]
+        budget_tokens: usize,
+    },
+    /// Search memories.
+    Search {
+        query: String,
+        #[arg(long)]
+        project: Option<String>,
+        #[arg(long, default_value_t = 10)]
+        limit: usize,
+    },
+    /// Store a memory.
+    Store {
+        content: String,
+        #[arg(long)]
+        tags: Option<String>,
+        #[arg(long)]
+        importance: Option<f64>,
+        #[arg(long)]
+        event_type: Option<String>,
+        #[arg(long)]
+        project: Option<String>,
     },
 }
 
@@ -1096,8 +1124,16 @@ mod tests {
         let args = vec!["mag", "serve"];
         let cli = Cli::parse_from(args);
         match cli.command {
-            Commands::Serve { cross_encoder } => {
+            Commands::Serve {
+                port,
+                idle_timeout,
+                cross_encoder,
+                stdio,
+            } => {
+                assert_eq!(port, 19420);
+                assert_eq!(idle_timeout, 1200);
                 assert!(!cross_encoder);
+                assert!(!stdio);
             }
             _ => panic!("Expected Serve command"),
         }

--- a/src/hook_client.rs
+++ b/src/hook_client.rs
@@ -127,13 +127,11 @@ fn event_to_request(event: &HookEvent) -> (&'static str, serde_json::Value) {
         HookEvent::SessionEnd {
             project,
             session_id,
-            summary,
         } => (
             "/hook/session-end",
             json!({
                 "project": project,
                 "session_id": session_id,
-                "summary": summary,
             }),
         ),
         HookEvent::CompactRefresh {
@@ -185,7 +183,7 @@ mod tests {
     fn event_to_request_session_start() {
         let event = HookEvent::SessionStart {
             project: Some("test-proj".into()),
-            budget_tokens: Some(1000),
+            budget_tokens: 1000,
         };
         let (path, body) = event_to_request(&event);
         assert_eq!(path, "/hook/session-start");
@@ -197,20 +195,18 @@ mod tests {
     fn event_to_request_session_end() {
         let event = HookEvent::SessionEnd {
             project: Some("proj".into()),
-            session_id: "sid-123".into(),
-            summary: Some("done".into()),
+            session_id: Some("sid-123".into()),
         };
         let (path, body) = event_to_request(&event);
         assert_eq!(path, "/hook/session-end");
         assert_eq!(body["session_id"], "sid-123");
-        assert_eq!(body["summary"], "done");
     }
 
     #[test]
     fn event_to_request_compact_refresh() {
         let event = HookEvent::CompactRefresh {
             project: Some("proj".into()),
-            budget_tokens: Some(500),
+            budget_tokens: 500,
         };
         let (path, body) = event_to_request(&event);
         assert_eq!(path, "/hook/compact-refresh");
@@ -222,7 +218,7 @@ mod tests {
         let event = HookEvent::Search {
             query: "find me".into(),
             project: Some("proj".into()),
-            limit: Some(5),
+            limit: 5,
         };
         let (path, body) = event_to_request(&event);
         assert_eq!(path, "/hook/search");
@@ -234,23 +230,23 @@ mod tests {
     fn event_to_request_store() {
         let event = HookEvent::Store {
             content: "important note".into(),
-            tags: vec!["a".into(), "b".into()],
-            importance: 0.8,
+            tags: Some("a,b".into()),
+            importance: Some(0.8),
             event_type: Some("decision".into()),
             project: Some("proj".into()),
         };
         let (path, body) = event_to_request(&event);
         assert_eq!(path, "/hook/store");
         assert_eq!(body["content"], "important note");
-        assert_eq!(body["tags"], json!(["a", "b"]));
+        assert_eq!(body["tags"], "a,b");
     }
 
     #[test]
     fn event_to_request_store_with_none_fields() {
         let event = HookEvent::Store {
             content: "note".into(),
-            tags: vec![],
-            importance: 0.5,
+            tags: None,
+            importance: None,
             event_type: None,
             project: None,
         };

--- a/src/http_server.rs
+++ b/src/http_server.rs
@@ -1,0 +1,165 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use axum::routing::get;
+use axum::{Json, Router};
+use tokio::net::TcpListener;
+use tokio_util::sync::CancellationToken;
+
+use rmcp::transport::streamable_http_server::session::local::LocalSessionManager;
+use rmcp::transport::streamable_http_server::{StreamableHttpServerConfig, StreamableHttpService};
+
+use crate::auth::AuthLayer;
+use crate::daemon::DaemonInfo;
+use crate::hook_handlers::{AppState, hook_router};
+use crate::idle_timer::{IdleTimer, IdleTimerLayer};
+use crate::mcp_server::McpMemoryServer;
+use crate::memory_core::storage::SqliteStorage;
+
+/// Configuration for the MAG HTTP daemon.
+pub struct ServerConfig {
+    pub port: u16,
+    pub auth_token: String,
+    pub idle_timeout_secs: u64,
+    pub cross_encoder: bool,
+}
+
+/// Runs the MAG HTTP server with MCP-over-HTTP, hook endpoints, and health check.
+///
+/// This function blocks until the server shuts down (via ctrl-c or idle timeout).
+pub async fn run_http_server(
+    storage: SqliteStorage,
+    #[cfg(feature = "real-embeddings")] onnx: Option<Arc<crate::memory_core::OnnxEmbedder>>,
+    config: ServerConfig,
+) -> Result<()> {
+    // --- Cross-encoder reranking (optional) ---
+    #[cfg(feature = "real-embeddings")]
+    let storage = if config.cross_encoder {
+        tracing::info!("Cross-encoder reranking enabled");
+        let reranker = Arc::new(crate::memory_core::reranker::CrossEncoderReranker::new()?);
+        reranker.warmup().await?;
+        let reranker_for_tick = reranker.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(60));
+            loop {
+                interval.tick().await;
+                reranker_for_tick.maintenance_tick().await;
+            }
+        });
+        storage.with_reranker(reranker)
+    } else {
+        storage
+    };
+
+    #[cfg(not(feature = "real-embeddings"))]
+    if config.cross_encoder {
+        anyhow::bail!("--cross-encoder requires the `real-embeddings` feature to be enabled");
+    }
+
+    // --- ONNX maintenance tick ---
+    #[cfg(feature = "real-embeddings")]
+    if let Some(ref onnx_ref) = onnx {
+        let onnx_for_tick = onnx_ref.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(60));
+            loop {
+                interval.tick().await;
+                onnx_for_tick.maintenance_tick().await;
+            }
+        });
+    }
+
+    // --- SQLite periodic PRAGMA optimize ---
+    {
+        let storage_for_optimize = storage.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(3600));
+            loop {
+                interval.tick().await;
+                if let Err(e) = storage_for_optimize.optimize().await {
+                    tracing::warn!("PRAGMA optimize failed: {e}");
+                }
+            }
+        });
+    }
+
+    // --- Shutdown plumbing ---
+    let shutdown_token = CancellationToken::new();
+
+    // --- Idle timer ---
+    let timer = IdleTimer::new(Duration::from_secs(config.idle_timeout_secs));
+    timer.spawn_watchdog(shutdown_token.clone());
+
+    // --- MCP over Streamable HTTP ---
+    let mcp_storage = storage.clone();
+    let mcp_service: StreamableHttpService<McpMemoryServer, LocalSessionManager> =
+        StreamableHttpService::new(
+            move || Ok(McpMemoryServer::new(mcp_storage.clone())),
+            Default::default(),
+            StreamableHttpServerConfig {
+                stateful_mode: true,
+                cancellation_token: shutdown_token.child_token(),
+                ..Default::default()
+            },
+        );
+
+    // --- Axum router ---
+    let app = Router::new()
+        .nest_service("/mcp", mcp_service)
+        .merge(hook_router().with_state(AppState {
+            storage: storage.clone(),
+        }))
+        .route("/health", get(health_handler))
+        .layer(AuthLayer::new(config.auth_token.clone()))
+        .layer(IdleTimerLayer::new(timer));
+
+    // --- Bind listener ---
+    let listener = TcpListener::bind(format!("127.0.0.1:{}", config.port))
+        .await
+        .with_context(|| format!("binding to 127.0.0.1:{}", config.port))?;
+    let local_addr = listener
+        .local_addr()
+        .context("getting local address from listener")?;
+    tracing::info!("MAG daemon listening on {local_addr}");
+
+    // --- Write daemon info to disk ---
+    let info = DaemonInfo {
+        port: local_addr.port(),
+        pid: std::process::id(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        token: config.auth_token,
+    };
+    info.write().context("writing daemon info")?;
+
+    // --- Ctrl-C handler ---
+    let ctrl_c_token = shutdown_token.clone();
+    tokio::spawn(async move {
+        if let Err(e) = tokio::signal::ctrl_c().await {
+            tracing::error!("failed to listen for ctrl-c: {e}");
+        }
+        tracing::info!("Ctrl-C received, shutting down");
+        ctrl_c_token.cancel();
+    });
+
+    // --- Serve ---
+    axum::serve(listener, app)
+        .with_graceful_shutdown(async move { shutdown_token.cancelled_owned().await })
+        .await
+        .context("running HTTP server")?;
+
+    // --- Cleanup ---
+    DaemonInfo::remove();
+    tracing::info!("MAG daemon shut down cleanly");
+
+    Ok(())
+}
+
+/// Health check handler — exempt from authentication (see [`AuthLayer`]).
+async fn health_handler() -> Json<serde_json::Value> {
+    Json(serde_json::json!({
+        "status": "ok",
+        "version": env!("CARGO_PKG_VERSION"),
+        "pid": std::process::id(),
+    }))
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,19 +21,15 @@ use tracing::info;
 use memory_core::PlaceholderEmbedder;
 
 mod app_paths;
+mod auth;
 mod cli;
-#[allow(dead_code)] // Consumers come in a follow-up PR (http_server)
 mod daemon;
-#[allow(dead_code)] // Consumers come in a follow-up PR (CLI hook subcommand)
 mod hook_client;
-#[allow(dead_code)] // Consumers (daemon HTTP server) land in a follow-up PR.
 mod hook_handlers;
-#[allow(dead_code)] // Consumers (daemon HTTP server) land in a follow-up PR.
+mod http_server;
 mod idle_timer;
 mod mcp_server;
 mod memory_core;
-
-use mcp_server::McpMemoryServer;
 
 #[derive(Clone, Copy)]
 struct SearchTimeFilters<'a> {
@@ -103,6 +99,18 @@ async fn main() -> anyhow::Result<()> {
                 "benchmark_root": paths.benchmark_root,
             }))?
         );
+        return Ok(());
+    }
+
+    if let Commands::Hook { event } = &cli.command {
+        match hook_client::call_hook(event).await {
+            Ok(text) => {
+                print!("{text}");
+            }
+            Err(_) => {
+                // Daemon not reachable — silently exit so hooks don't block the caller.
+            }
+        }
         return Ok(());
     }
 
@@ -919,61 +927,97 @@ async fn main() -> anyhow::Result<()> {
         Commands::DownloadCrossEncoder => {
             unreachable!("download-cross-encoder is handled before storage initialization")
         }
-        Commands::Serve { cross_encoder } => {
-            info!("Starting MCP server over stdio");
+        Commands::Serve {
+            port,
+            idle_timeout,
+            cross_encoder,
+            stdio,
+        } => {
+            if *stdio {
+                // Legacy stdio transport mode.
+                info!("Starting MCP server over stdio");
 
-            #[cfg(feature = "real-embeddings")]
-            let mcp_storage = if *cross_encoder {
-                info!("Cross-encoder reranking enabled");
-                let reranker =
-                    std::sync::Arc::new(memory_core::reranker::CrossEncoderReranker::new()?);
-                reranker.warmup().await?;
-                let reranker_for_tick = reranker.clone();
-                tokio::spawn(async move {
-                    let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
-                    loop {
-                        interval.tick().await;
-                        reranker_for_tick.maintenance_tick().await;
-                    }
-                });
-                mcp_storage.with_reranker(reranker)
-            } else {
-                mcp_storage
-            };
-
-            #[cfg(not(feature = "real-embeddings"))]
-            if *cross_encoder {
-                anyhow::bail!(
-                    "--cross-encoder requires the `real-embeddings` feature to be enabled"
-                );
-            }
-
-            #[cfg(feature = "real-embeddings")]
-            {
-                let onnx_for_tick = onnx_embedder_ref.clone();
-                tokio::spawn(async move {
-                    let mut interval = tokio::time::interval(std::time::Duration::from_secs(60));
-                    loop {
-                        interval.tick().await;
-                        onnx_for_tick.maintenance_tick().await;
-                    }
-                });
-            }
-
-            {
-                let storage_for_optimize = mcp_storage.clone();
-                tokio::spawn(async move {
-                    let mut interval = tokio::time::interval(std::time::Duration::from_secs(3600));
-                    loop {
-                        interval.tick().await;
-                        if let Err(e) = storage_for_optimize.optimize().await {
-                            tracing::warn!("PRAGMA optimize failed: {e}");
+                #[cfg(feature = "real-embeddings")]
+                let mcp_storage = if *cross_encoder {
+                    info!("Cross-encoder reranking enabled");
+                    let reranker =
+                        std::sync::Arc::new(memory_core::reranker::CrossEncoderReranker::new()?);
+                    reranker.warmup().await?;
+                    let reranker_for_tick = reranker.clone();
+                    tokio::spawn(async move {
+                        let mut interval =
+                            tokio::time::interval(std::time::Duration::from_secs(60));
+                        loop {
+                            interval.tick().await;
+                            reranker_for_tick.maintenance_tick().await;
                         }
-                    }
-                });
-            }
+                    });
+                    mcp_storage.with_reranker(reranker)
+                } else {
+                    mcp_storage
+                };
 
-            McpMemoryServer::new(mcp_storage).serve_stdio().await?;
+                #[cfg(not(feature = "real-embeddings"))]
+                if *cross_encoder {
+                    anyhow::bail!(
+                        "--cross-encoder requires the `real-embeddings` feature to be enabled"
+                    );
+                }
+
+                #[cfg(feature = "real-embeddings")]
+                {
+                    let onnx_for_tick = onnx_embedder_ref.clone();
+                    tokio::spawn(async move {
+                        let mut interval =
+                            tokio::time::interval(std::time::Duration::from_secs(60));
+                        loop {
+                            interval.tick().await;
+                            onnx_for_tick.maintenance_tick().await;
+                        }
+                    });
+                }
+
+                {
+                    let storage_for_optimize = mcp_storage.clone();
+                    tokio::spawn(async move {
+                        let mut interval =
+                            tokio::time::interval(std::time::Duration::from_secs(3600));
+                        loop {
+                            interval.tick().await;
+                            if let Err(e) = storage_for_optimize.optimize().await {
+                                tracing::warn!("PRAGMA optimize failed: {e}");
+                            }
+                        }
+                    });
+                }
+
+                mcp_server::McpMemoryServer::new(mcp_storage)
+                    .serve_stdio()
+                    .await?;
+            } else {
+                // HTTP daemon mode (default).
+                info!("Starting MAG HTTP daemon on port {port}");
+
+                let token = daemon::read_or_create_auth_token()?;
+
+                let server_config = http_server::ServerConfig {
+                    port: *port,
+                    auth_token: token,
+                    idle_timeout_secs: *idle_timeout,
+                    cross_encoder: *cross_encoder,
+                };
+
+                http_server::run_http_server(
+                    mcp_storage,
+                    #[cfg(feature = "real-embeddings")]
+                    Some(onnx_embedder_ref.clone()),
+                    server_config,
+                )
+                .await?;
+            }
+        }
+        Commands::Hook { .. } => {
+            unreachable!("hook is handled before storage initialization")
         }
     }
 

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -230,6 +230,7 @@ impl McpMemoryServer {
         }
     }
 
+    #[allow(dead_code)] // Retained for stdio transport mode; HTTP is the default now.
     pub async fn serve_stdio(self) -> Result<()> {
         let service = self.serve(stdio()).await?;
         service.waiting().await?;

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -16,7 +16,7 @@ async fn mcp_stdio_lists_tools_and_calls_health() -> Result<(), Box<dyn std::err
         .serve(TokioChildProcess::new(
             Command::new(env!("CARGO_BIN_EXE_mag")).configure(|cmd| {
                 cmd.current_dir(env!("CARGO_MANIFEST_DIR"));
-                cmd.arg("serve");
+                cmd.args(["serve", "--stdio"]);
                 cmd.env("HOME", &test_home);
                 cmd.env("USERPROFILE", &test_home);
             }),


### PR DESCRIPTION
## Summary
- Add `src/http_server.rs` — full axum server with MCP-over-HTTP (StreamableHttpService), hook router, health endpoint, auth, idle timer, graceful shutdown
- Add `Commands::Hook` CLI subcommand with `HookEvent` enum (session-start, session-end, compact-refresh, search, store)
- Add `src/hook_client.rs` — sends hook events to running daemon via HTTP with auto-discovery from daemon.json
- Wire `Commands::Serve` to HTTP mode by default, `--stdio` flag for legacy stdio transport
- Background tasks (ONNX tick, reranker tick, SQLite optimize) moved from main.rs into http_server
- `DaemonInfo` written on start, removed on shutdown
- Ctrl-C → CancellationToken → graceful shutdown
- Updated MCP smoke tests for `--stdio` flag

## Wave 2 Units 6+7 of the HTTP daemon plan

## Test plan
- [ ] All 452+ tests pass (`cargo test --all-features`)
- [ ] `mag serve` starts HTTP daemon on port 19420
- [ ] `mag serve --stdio` preserves legacy MCP stdio behavior
- [ ] `/health` returns JSON status without auth
- [ ] Ctrl-C triggers graceful shutdown and removes daemon info
- [ ] `mag hook session-start --project test` works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new `Hook` command for triggering daemon hook events (SessionStart, SessionEnd, CompactRefresh, Search, and Store operations)
  * Extended `Serve` command with configurable `--port`, `--idle-timeout`, and `--stdio` options for flexible server deployment modes
  * Introduced HTTP daemon capability with Bearer token-based authentication and idle timeout protection
  * Added `/health` endpoint for server monitoring and health status checks
<!-- end of auto-generated comment: release notes by coderabbit.ai -->