### PR TITLE
fix(auth): use SHA-256 hash comparison in constant_time_eq (#115)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ mag search "how should retries work?"
 # → "The retry logic should use exponential backoff with jitter" (score: 0.94)
 ```
 
-That's it. One command to install, one to store, one to recall. Add MAG to your MCP client and your AI tools remember automatically.
+That's it. One command to install, one to store, one to recall. The installer auto-detects your AI tools and configures them — no manual JSON editing needed.
 
 ---
 
@@ -52,13 +52,17 @@ That's it. One command to install, one to store, one to recall. Add MAG to your 
 
 ## Works With
 
-| Tool | macOS | Linux | Status |
+| Tool | macOS | Linux | Auto-configured |
 |---|---|---|---|
-| Claude Desktop | ✅ | ✅ | Supported |
-| Cursor | ✅ | ✅ | Supported |
-| Claude Code | ✅ | ✅ | Supported |
-| Windsurf | ✅ | ✅ | Community-reported |
-| Cline | ✅ | ✅ | Community-reported |
+| Claude Code | ✅ | ✅ | `mag setup` |
+| Claude Desktop | ✅ | ✅ | `mag setup` |
+| Cursor | ✅ | ✅ | `mag setup` |
+| VS Code + Copilot | ✅ | ✅ | `mag setup` |
+| Windsurf | ✅ | ✅ | `mag setup` |
+| Cline | ✅ | ✅ | `mag setup` |
+| Gemini CLI | ✅ | ✅ | `mag setup` |
+| Zed | ✅ | ✅ | Manual |
+| Codex (OpenAI) | ✅ | ✅ | Manual |
 
 Any tool that supports MCP can connect to MAG. Windows is untested - [report your results](https://github.com/George-RD/mag/issues).
 
@@ -119,9 +123,20 @@ Every mode: zero third-party data access, full data portability, MIT licensed.
 
 ---
 
-## Configure Your MCP Client
+## Configure Your AI Tools
 
-MAG runs as an MCP server. Add it to your client config:
+The installer runs `mag setup` automatically. To reconfigure at any time:
+
+```bash
+mag setup
+```
+
+This detects installed AI tools, shows their configuration status, and writes the correct MCP config for each one. Use `--non-interactive` for CI or scripted environments.
+
+<details>
+<summary>Manual configuration</summary>
+
+MAG runs as an MCP server. Add it to your client's config file:
 
 ```json
 {
@@ -134,11 +149,7 @@ MAG runs as an MCP server. Add it to your client config:
 }
 ```
 
-**Claude Code:**
-
-```bash
-claude mcp add mag -- mag serve
-```
+**Claude Code:** `claude mcp add mag -- mag serve`
 
 **npx (no install):**
 
@@ -154,6 +165,8 @@ claude mcp add mag -- mag serve
 ```
 
 Per-tool setup guides: [Claude Desktop](docs/setup/claude-desktop.md) | [Cursor](docs/setup/cursor.md) | [Claude Code](docs/setup/claude-code.md) | [Windsurf](docs/setup/windsurf.md) | [Cline](docs/setup/cline.md)
+
+</details>
 
 ---
 

--- a/conductor/campaign-audit-remediation.md
+++ b/conductor/campaign-audit-remediation.md
@@ -1,0 +1,67 @@
+# Campaign: Codebase Audit Remediation
+
+**Issues:** #115-#127
+**Started:** 2026-03-27
+**Status:** Wave 1 implementation in progress
+
+## Wave Structure
+
+### Wave 1 — Critical Security (parallel, in worktrees)
+| Issue | Title | Status | Approach |
+|-------|-------|--------|----------|
+| #115 | Timing side-channel in constant_time_eq | IMPLEMENTING | SHA-256 hash comparison; sha2 already a dep |
+| #116 | Input validation limits (DoS) | IMPLEMENTING | 23 params need bounds; MAX_RESULT_LIMIT=1000 |
+| #127 | Unsafe transmute in sqlite-vec | SCOUTING | Check sqlite-vec API for typed fn pointer |
+
+### Wave 2 — Bug Fixes (parallel)
+| Issue | Title | Status | Approach |
+|-------|-------|--------|----------|
+| #117 | cosine_similarity naming + source_type | IMPLEMENTING | Rename to dot_product (all callers normalize); add source_type to MemoryInput |
+
+### Wave 3 — Architecture Refactors (sequential: #120 → #118+#122 → #119 → #123)
+| Issue | Title | Status | Approach |
+|-------|-------|--------|----------|
+| #120 | Remove dead abstractions | SPEC READY | Gate auth/daemon/idle_timer behind feature; remove PlaceholderPipeline extras; remove InitMode::Advanced |
+| #118 | Split god modules | SPEC READY | mod.rs→types.rs+traits.rs+pipeline.rs; helpers.rs→6 focused files |
+| #122 | Deduplicate code patterns | SPEC READY | Activate resolve_priority helper (5 copies→1); extract collect_candidates; flatten get_synonyms |
+| #119 | Separate scoring from storage | SPEC READY | Extract scoring module; HIGH RISK for benchmark regression |
+| #123 | Schema version tracking | SPEC READY | Add schema_migrations table; detect existing version from columns; 14 ALTERs→versioned |
+
+### Wave 4 — Performance (#122 dedup MUST precede)
+| Issue | Title | Status | Approach |
+|-------|-------|--------|----------|
+| #121 | Hot-path inefficiencies | SPEC READY | Parallelize sub-queries; prepare once outside loop; cache token_set; batch graph queries |
+
+### Wave 5 — Testing (can overlap with Wave 3-4)
+| Issue | Title | Status | Approach |
+|-------|-------|--------|----------|
+| #126 | Flaky test fixes | SPEC READY | tokio::time::pause(); serial_test for env vars; remove sleeps |
+| #124 | MCP protocol coverage | SPEC READY | Cover remaining 9/16 tools; add edge cases, unicode |
+| #125 | Property/fuzz/stress tests | SPEC READY | Add proptest for scoring; fuzz targets for import/search/stem |
+
+## Key Decisions
+
+1. **#115**: Use SHA-256 approach (no new dep) over subtle crate
+2. **#117**: Rename to `dot_product` not `dot_product_normalized` (simpler)
+3. **#119**: HIGH RISK — must run full LoCoMo benchmark before/after
+4. **#120**: Gate dead modules behind `daemon-http` feature flag (don't delete — HTTP server is planned)
+5. **#122**: Priority resolution — activate existing dead helper in helpers.rs:1042
+6. **#123**: Use sequential integer versioning (v0-v4 for existing schema)
+
+## Implementation Protocol
+
+Each work unit follows:
+1. `jj describe -m "type(scope): description (#issue)"` — frequently during work
+2. Quality gates: `prek run` (fmt + clippy + test)
+3. `/simplify` review
+4. `jj bookmark set <branch> -r @- && jj git push --bookmark <branch> --allow-new`
+5. `gh pr create` with issue reference
+6. Merge immediately on green
+
+## Findings Log
+
+- scout-116: 23 unbounded parameters in MCP server, no validation infrastructure exists
+- scout-118-120: 27 traits in mod.rs but only SqliteStorage implements them; PlaceholderPipeline is dead weight
+- scout-121-122: Priority resolution duplicated 5x; dead resolve_priority helper at helpers.rs:1042; conn.prepare inside loop at advanced.rs:890
+- scout-123: 14 ALTER TABLE + 20 CREATE INDEX run on EVERY DB open; no version tracking
+- scout-124-126: 7/16 MCP tools tested; no proptest/fuzz deps; 2 sleep-based flaky tests

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -7,12 +7,18 @@ use axum::body::Body;
 use axum::http::{Method, Request, Response, StatusCode};
 
 /// Constant-time string comparison to prevent timing attacks on token validation.
+///
+/// Both inputs are hashed with SHA-256 before comparison, ensuring the comparison
+/// always operates on fixed-length (32-byte) digests regardless of input lengths.
+/// This eliminates the timing side-channel that would otherwise leak token length.
 fn constant_time_eq(a: &str, b: &str) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    a.bytes()
-        .zip(b.bytes())
+    use sha2::{Digest, Sha256};
+    let hash_a = Sha256::digest(a.as_bytes());
+    let hash_b = Sha256::digest(b.as_bytes());
+    hash_a
+        .as_slice()
+        .iter()
+        .zip(hash_b.as_slice().iter())
         .fold(0u8, |acc, (x, y)| acc | (x ^ y))
         == 0
 }


### PR DESCRIPTION
## Summary
- Replaces vulnerable `constant_time_eq` with SHA-256 hash comparison to eliminate timing side-channel
- Old impl had early return on length mismatch, leaking token length via timing
- New impl hashes both inputs first, always comparing fixed-length 32-byte digests
- Uses existing `sha2` dependency — no new crates needed

Closes #115

## Test plan
- [x] Existing `constant_time_eq` unit tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo test --all-features` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Simplified onboarding process with new automated setup flow for configuring AI tools
  * Added support documentation for additional tools including VS Code + Copilot and Gemini CLI
  * Included detailed reconfiguration instructions and setup behavior documentation

* **Security**
  * Enhanced authentication with improved constant-time comparison logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->