### PR TITLE
fix(storage): rename cosine_similarity to dot_product and add source_type to MemoryInput (#117)

### DIFF
--- a/benches/longmemeval/local.rs
+++ b/benches/longmemeval/local.rs
@@ -155,6 +155,7 @@ fn default_input(
         agent_type: None,
         ttl_seconds: None,
         referenced_date: None,
+        source_type: None,
     }
 }
 

--- a/benches/longmemeval/official.rs
+++ b/benches/longmemeval/official.rs
@@ -91,6 +91,7 @@ async fn seed_official_question(
                 agent_type: Some(turn.role.clone()),
                 ttl_seconds: None,
                 referenced_date: None,
+                source_type: None,
             };
             storage.store(&memory_id, &turn.content, &input).await?;
             count += 1;

--- a/benches/scale_bench.rs
+++ b/benches/scale_bench.rs
@@ -155,6 +155,7 @@ fn generate_input(index: usize) -> MemoryInput {
         agent_type: None,
         ttl_seconds: None,
         referenced_date: None,
+        source_type: None,
     }
 }
 
@@ -396,6 +397,7 @@ async fn run_benchmark(args: &Args) -> Result<Vec<ScaleResult>> {
             agent_type: None,
             ttl_seconds: None,
             referenced_date: None,
+            source_type: None,
         };
         storage.store(&needle.id, &needle.content, &input).await?;
     }

--- a/src/memory_core/embedder.rs
+++ b/src/memory_core/embedder.rs
@@ -835,7 +835,7 @@ pub(crate) async fn download_file(url: &str, path: &Path) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::memory_core::storage::sqlite::cosine_similarity;
+    use crate::memory_core::storage::sqlite::dot_product;
 
     #[test]
     fn test_placeholder_embedder_dimension() {
@@ -875,25 +875,25 @@ mod tests {
     }
 
     #[test]
-    fn test_cosine_similarity_identical() {
+    fn test_dot_product_identical() {
         let a = vec![0.5_f32, 0.5, 0.5, 0.5];
-        let score = cosine_similarity(&a, &a);
+        let score = dot_product(&a, &a);
         assert!((score - 1.0).abs() < 1e-6);
     }
 
     #[test]
-    fn test_cosine_similarity_orthogonal() {
+    fn test_dot_product_orthogonal() {
         let a = vec![1.0_f32, 0.0, 0.0];
         let b = vec![0.0_f32, 1.0, 0.0];
-        let score = cosine_similarity(&a, &b);
+        let score = dot_product(&a, &b);
         assert!(score.abs() < 1e-6);
     }
 
     #[test]
-    fn test_cosine_similarity_different_lengths() {
+    fn test_dot_product_different_lengths() {
         let a = vec![1.0_f32, 0.0, 0.0];
         let b = vec![1.0_f32, 0.0];
-        let score = cosine_similarity(&a, &b);
+        let score = dot_product(&a, &b);
         assert_eq!(score, 0.0);
     }
 

--- a/src/memory_core/mod.rs
+++ b/src/memory_core/mod.rs
@@ -332,6 +332,9 @@ pub struct MemoryInput {
     /// ISO 8601 timestamp for when the event actually occurred.
     /// When provided, this overrides the default `event_at = now()` on insert.
     pub referenced_date: Option<String>,
+    /// Source type label (e.g. `"cli_input"`, `"mcp"`, `"api"`).
+    /// Defaults to `"cli_input"` when `None`.
+    pub source_type: Option<String>,
 }
 
 impl Default for MemoryInput {
@@ -350,6 +353,7 @@ impl Default for MemoryInput {
             agent_type: None,
             ttl_seconds: None,
             referenced_date: None,
+            source_type: None,
         }
     }
 }

--- a/src/memory_core/storage/sqlite/admin.rs
+++ b/src/memory_core/storage/sqlite/admin.rs
@@ -736,7 +736,7 @@ impl MaintenanceManager for SqliteStorage {
                         if embeddings[j].is_none() {
                             continue;
                         }
-                        let sim = cosine_similarity(
+                        let sim = dot_product(
                             embeddings[i].as_ref().unwrap(),
                             embeddings[j].as_ref().unwrap(),
                         ) as f64;

--- a/src/memory_core/storage/sqlite/advanced.rs
+++ b/src/memory_core/storage/sqlite/advanced.rs
@@ -149,7 +149,7 @@ fn collect_vector_candidates(
             ) = row.context("failed to decode advanced vector row")?;
             let candidate_emb: Vec<f32> =
                 decode_embedding(&embedding_blob).context("failed to decode stored embedding")?;
-            let similarity = cosine_similarity(query_embedding, &candidate_emb) as f64;
+            let similarity = dot_product(query_embedding, &candidate_emb) as f64;
             if similarity < 0.1 {
                 continue;
             }
@@ -748,7 +748,7 @@ fn fuse_refine_and_output(
                         let vec_sim = embedding_blob.and_then(|blob| {
                             decode_embedding(&blob)
                                 .ok()
-                                .map(|emb| cosine_similarity(query_embedding, &emb) as f64)
+                                .map(|emb| dot_product(query_embedding, &emb) as f64)
                         });
                         neighbor_score *= feedback_factor(fb_score, scoring_params);
 

--- a/src/memory_core/storage/sqlite/crud.rs
+++ b/src/memory_core/storage/sqlite/crud.rs
@@ -27,6 +27,7 @@ impl Storage for SqliteStorage {
         let agent_type = input.agent_type.clone();
         let ttl_seconds = input.ttl_seconds;
         let referenced_date = input.referenced_date.clone();
+        let source_type = input.source_type.clone();
         let id_for_store = id.clone();
 
         let (outcome, superseded_ids, final_tags) = tokio::task::spawn_blocking(move || {
@@ -198,7 +199,7 @@ impl Storage for SqliteStorage {
                         && let Ok(candidate_embedding) =
                             decode_embedding(emb_blob)
                     {
-                        let cosine = cosine_similarity(emb_data, &candidate_embedding);
+                        let cosine = dot_product(emb_data, &candidate_embedding);
                         cosine >= SUPERSESSION_COSINE_THRESHOLD
                     } else {
                         false // No embedding = cannot supersede
@@ -253,7 +254,7 @@ impl Storage for SqliteStorage {
                     NULL,
                     COALESCE(?16, strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
                     ?4,
-                    'cli_input',
+                    ?17,
                     strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
                     ?5,
                     ?6,
@@ -302,6 +303,7 @@ impl Storage for SqliteStorage {
                     ttl_seconds,
                     normalized_hash,
                     event_at_value,
+                    source_type.as_deref().unwrap_or("cli_input"),
                 ],
             )
             .context("failed to insert memory")?;

--- a/src/memory_core/storage/sqlite/graph.rs
+++ b/src/memory_core/storage/sqlite/graph.rs
@@ -245,7 +245,7 @@ impl SimilarFinder for SqliteStorage {
                     ) = row.context("failed to decode similar row")?;
                     let embedding: Vec<f32> = decode_embedding(&embedding_blob)
                         .context("failed to decode candidate embedding")?;
-                    let score = cosine_similarity(&source_embedding, &embedding);
+                    let score = dot_product(&source_embedding, &embedding);
                     ranked.push(SemanticResult {
                         id,
                         content,

--- a/src/memory_core/storage/sqlite/helpers.rs
+++ b/src/memory_core/storage/sqlite/helpers.rs
@@ -1031,10 +1031,19 @@ fn decode_binary_embedding(blob: &[u8]) -> Vec<f32> {
         .collect()
 }
 
-pub(crate) fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+/// Dot product of two vectors. Equivalent to cosine similarity when inputs are L2-normalized.
+pub(crate) fn dot_product(a: &[f32], b: &[f32]) -> f32 {
     if a.len() != b.len() || a.is_empty() {
         return 0.0;
     }
+    debug_assert!(
+        (a.iter().map(|v| v * v).sum::<f32>().sqrt() - 1.0).abs() < 0.01,
+        "input a is not L2-normalized"
+    );
+    debug_assert!(
+        (b.iter().map(|v| v * v).sum::<f32>().sqrt() - 1.0).abs() < 0.01,
+        "input b is not L2-normalized"
+    );
     a.iter().zip(b.iter()).map(|(x, y)| x * y).sum()
 }
 

--- a/src/memory_core/storage/sqlite/mod.rs
+++ b/src/memory_core/storage/sqlite/mod.rs
@@ -1032,7 +1032,7 @@ impl SqliteStorage {
                         row.context("failed to decode auto relate row")?;
                     let embedding: Vec<f32> = decode_embedding(&embedding_blob)
                         .context("failed to decode candidate embedding for auto relate")?;
-                    let score = cosine_similarity(&source_embedding, &embedding);
+                    let score = dot_product(&source_embedding, &embedding);
                     if score >= 0.45 {
                         ranked.push((id, score));
                     }
@@ -1261,7 +1261,7 @@ mod schema;
 mod search;
 mod session;
 
-pub(crate) use helpers::cosine_similarity;
+pub(crate) use helpers::dot_product;
 use helpers::{
     ConnPool, EPOCH_FALLBACK, append_search_filters, build_fts5_query, canonical_hash,
     content_hash, decode_embedding, encode_embedding, escape_like_pattern, event_type_from_sql,

--- a/src/memory_core/storage/sqlite/search.rs
+++ b/src/memory_core/storage/sqlite/search.rs
@@ -327,7 +327,7 @@ impl SemanticSearcher for SqliteStorage {
                     ) = row.context("failed to decode semantic search row")?;
                     let candidate: Vec<f32> = decode_embedding(&embedding_blob)
                         .context("failed to decode stored embedding")?;
-                    let score = cosine_similarity(&query_embedding, &candidate);
+                    let score = dot_product(&query_embedding, &candidate);
                     ranked.push(SemanticResult {
                         id,
                         content,


### PR DESCRIPTION
## Summary
- Renames `cosine_similarity` to `dot_product` with doc comment clarifying it requires L2-normalized inputs
- Adds `debug_assert!` for input normalization validation
- Adds `source_type: Option<String>` field to `MemoryInput` struct
- Replaces hardcoded `'cli_input'` in crud.rs INSERT with parameterized value from `MemoryInput.source_type`
- Updates all 8 call sites + 3 test functions for the rename
- Updates 4 bench files with explicit `source_type: None`

Closes #117

## Test plan
- [x] 998 tests pass (`cargo test --all-features`)
- [x] Clippy clean (`cargo clippy --all-targets --all-features -- -D warnings`)
- [x] All existing `cosine_similarity` references updated to `dot_product`
- [x] `MemoryInput::default()` includes `source_type: None` for backward compat

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added source type tracking for memory inputs to identify their origin.

* **Updates**
  * Changed vector similarity calculation from cosine similarity to dot product across all memory operations.

* **Tests**
  * Updated similarity metric tests to reflect the new calculation method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->