### PR TITLE
refactor(core): gate dead modules behind daemon-http feature, remove dead abstractions (#120)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ doctest = false
 [features]
 default = ["real-embeddings"]
 real-embeddings = ["dep:ort", "dep:tokenizers", "dep:ndarray", "dep:dotenvy"]
+daemon-http = []
 mimalloc = ["dep:mimalloc"]
 sqlite-vec = ["dep:sqlite-vec"]
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,8 +5,6 @@ use clap::{Args, Parser, Subcommand};
 pub enum InitModeArg {
     /// Standard initialization with default database path.
     Default,
-    /// Reserved for future advanced configuration.
-    Advanced,
 }
 
 /// CLI representation of allowed feedback ratings.
@@ -1073,13 +1071,6 @@ mod tests {
         let args = vec!["mag", "ingest", "test content"];
         let cli = Cli::parse_from(args);
         assert_eq!(cli.init_mode, InitModeArg::Default);
-    }
-
-    #[test]
-    fn test_cli_advanced_init_mode() {
-        let args = vec!["mag", "--init-mode", "advanced", "ingest", "test content"];
-        let cli = Cli::parse_from(args);
-        assert_eq!(cli.init_mode, InitModeArg::Advanced);
     }
 
     #[test]

--- a/src/config_writer.rs
+++ b/src/config_writer.rs
@@ -143,12 +143,7 @@ pub fn write_config(tool: &DetectedTool, mode: TransportMode) -> Result<ConfigWr
     // Insert the mag entry
     current
         .as_object_mut()
-        .with_context(|| {
-            format!(
-                "MCP parent key is not an object in {}",
-                path.display()
-            )
-        })?
+        .with_context(|| format!("MCP parent key is not an object in {}", path.display()))?
         .insert("mag".to_string(), mag_entry);
 
     // Create backup if file existed
@@ -222,8 +217,7 @@ pub fn remove_config(tool: &DetectedTool) -> Result<RemoveResult> {
 
     // Backup before writing
     let bak = backup_path_for(path);
-    std::fs::copy(path, &bak)
-        .with_context(|| format!("creating backup at {}", bak.display()))?;
+    std::fs::copy(path, &bak).with_context(|| format!("creating backup at {}", bak.display()))?;
 
     // Serialize and write back
     let serialized = serialize_json(&root)?;
@@ -254,7 +248,7 @@ pub fn verify_config(tool: &DetectedTool, mode: TransportMode) -> Result<ConfigS
         Err(e) => {
             return Ok(ConfigStatus::Malformed {
                 error: e.to_string(),
-            })
+            });
         }
     };
 
@@ -363,9 +357,7 @@ fn atomic_write(path: &Path, content: &[u8]) -> Result<()> {
     let pid = std::process::id();
     let tmp_name = format!(
         "{}.mag.{pid}.tmp",
-        path.file_name()
-            .unwrap_or_default()
-            .to_string_lossy()
+        path.file_name().unwrap_or_default().to_string_lossy()
     );
     let tmp_path = path
         .parent()
@@ -386,15 +378,14 @@ fn atomic_write(path: &Path, content: &[u8]) -> Result<()> {
                 let same_dir_tmp = path
                     .parent()
                     .unwrap_or_else(|| Path::new("."))
-                    .join(format!("{}.mag.{pid}.xdev.tmp", path.file_name().unwrap_or_default().to_string_lossy()));
+                    .join(format!(
+                        "{}.mag.{pid}.xdev.tmp",
+                        path.file_name().unwrap_or_default().to_string_lossy()
+                    ));
                 std::fs::copy(&tmp_path, &same_dir_tmp)
                     .with_context(|| format!("cross-device copy to {}", same_dir_tmp.display()))?;
                 std::fs::rename(&same_dir_tmp, path).with_context(|| {
-                    format!(
-                        "renaming {} -> {}",
-                        same_dir_tmp.display(),
-                        path.display()
-                    )
+                    format!("renaming {} -> {}", same_dir_tmp.display(), path.display())
                 })?;
                 // Clean up the original temp file
                 let _ = std::fs::remove_file(&tmp_path);
@@ -679,7 +670,8 @@ mod tests {
             write_config(&detected, TransportMode::Command).expect("first write");
 
             // Simulate user editing the file
-            let modified = r#"{"mcpServers": {"mag": {"command": "mag", "args": ["serve"]}}, "extra": true}"#;
+            let modified =
+                r#"{"mcpServers": {"mag": {"command": "mag", "args": ["serve"]}}, "extra": true}"#;
             std::fs::write(&config_path, modified).expect("simulate user edit");
 
             // Write again (update)
@@ -700,10 +692,7 @@ mod tests {
 
             let result =
                 write_config(&detected, TransportMode::Command).expect("write should succeed");
-            assert_eq!(
-                result,
-                ConfigWriteResult::Written { backup_path: None }
-            );
+            assert_eq!(result, ConfigWriteResult::Written { backup_path: None });
         });
     }
 
@@ -917,7 +906,10 @@ mod tests {
 
             let result =
                 write_config(&detected, TransportMode::Stdio).expect("write should succeed");
-            assert!(matches!(result, ConfigWriteResult::UnsupportedFormat { .. }));
+            assert!(matches!(
+                result,
+                ConfigWriteResult::UnsupportedFormat { .. }
+            ));
         });
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,11 @@
 pub mod app_paths;
 pub mod benchmarking;
-pub mod config_writer;
+pub(crate) mod config_writer;
+#[cfg(feature = "daemon-http")]
 pub mod daemon;
 pub mod memory_core;
 pub mod setup;
-pub mod tool_detection;
+pub(crate) mod tool_detection;
 
 #[cfg(test)]
 pub(crate) mod test_helpers;

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,12 +21,15 @@ use tracing::info;
 use memory_core::PlaceholderEmbedder;
 
 mod app_paths;
-#[allow(dead_code)] // Consumers come in a follow-up PR (http_server)
+#[cfg(feature = "daemon-http")]
+#[allow(dead_code)]
 mod auth;
 mod cli;
-#[allow(dead_code)] // Consumers come in a follow-up PR (http_server)
+#[cfg(feature = "daemon-http")]
+#[allow(dead_code)]
 mod daemon;
-#[allow(dead_code)] // Consumers (daemon HTTP server) land in a follow-up PR.
+#[cfg(feature = "daemon-http")]
+#[allow(dead_code)]
 mod idle_timer;
 mod mcp_server;
 mod memory_core;
@@ -132,7 +135,6 @@ async fn main() -> anyhow::Result<()> {
 
     let storage_mode = match cli.init_mode {
         InitModeArg::Default => InitMode::Default,
-        InitModeArg::Advanced => InitMode::Advanced,
     };
     let warmup = matches!(&cli.command, Commands::Serve { .. });
 

--- a/src/memory_core/mod.rs
+++ b/src/memory_core/mod.rs
@@ -4,7 +4,6 @@ use std::str::FromStr;
 use anyhow::Result;
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
-use tracing::info;
 use uuid::Uuid;
 
 pub mod embedder;
@@ -332,9 +331,6 @@ pub struct MemoryInput {
     /// ISO 8601 timestamp for when the event actually occurred.
     /// When provided, this overrides the default `event_at = now()` on insert.
     pub referenced_date: Option<String>,
-    /// Source type label (e.g. `"cli_input"`, `"mcp"`, `"api"`).
-    /// Defaults to `"cli_input"` when `None`.
-    pub source_type: Option<String>,
 }
 
 impl Default for MemoryInput {
@@ -353,7 +349,6 @@ impl Default for MemoryInput {
             agent_type: None,
             ttl_seconds: None,
             referenced_date: None,
-            source_type: None,
         }
     }
 }
@@ -955,86 +950,6 @@ impl Ingestor for PlaceholderPipeline {
 impl Processor for PlaceholderPipeline {
     async fn process(&self, input: &str) -> Result<String> {
         Ok(format!("processed: {}", input))
-    }
-}
-
-#[async_trait]
-impl Storage for PlaceholderPipeline {
-    async fn store(&self, id: &str, data: &str, _input: &MemoryInput) -> Result<()> {
-        info!(memory_id = %id, content_len = data.len(), "Storing placeholder payload");
-        Ok(())
-    }
-}
-
-#[async_trait]
-impl Retriever for PlaceholderPipeline {
-    async fn retrieve(&self, id: &str) -> Result<String> {
-        Ok(format!("retrieved: {}", id))
-    }
-}
-
-#[async_trait]
-impl Searcher for PlaceholderPipeline {
-    async fn search(
-        &self,
-        query: &str,
-        _limit: usize,
-        _opts: &SearchOptions,
-    ) -> Result<Vec<SearchResult>> {
-        Ok(vec![SearchResult {
-            id: "placeholder".to_string(),
-            content: format!("search result for: {query}"),
-            tags: Vec::new(),
-            importance: 0.5,
-            metadata: serde_json::json!({}),
-            event_type: None,
-            session_id: None,
-            project: None,
-            entity_id: None,
-            agent_type: None,
-        }])
-    }
-}
-
-#[async_trait]
-impl Recents for PlaceholderPipeline {
-    async fn recent(&self, _limit: usize, _opts: &SearchOptions) -> Result<Vec<SearchResult>> {
-        Ok(vec![SearchResult {
-            id: "placeholder-recent".to_string(),
-            content: "recent result".to_string(),
-            tags: Vec::new(),
-            importance: 0.5,
-            metadata: serde_json::json!({}),
-            event_type: None,
-            session_id: None,
-            project: None,
-            entity_id: None,
-            agent_type: None,
-        }])
-    }
-}
-
-#[async_trait]
-impl SemanticSearcher for PlaceholderPipeline {
-    async fn semantic_search(
-        &self,
-        query: &str,
-        _limit: usize,
-        _opts: &SearchOptions,
-    ) -> Result<Vec<SemanticResult>> {
-        Ok(vec![SemanticResult {
-            id: "placeholder-semantic".to_string(),
-            content: format!("semantic result for: {query}"),
-            tags: Vec::new(),
-            importance: 0.5,
-            metadata: serde_json::json!({}),
-            event_type: None,
-            session_id: None,
-            project: None,
-            entity_id: None,
-            agent_type: None,
-            score: 1.0,
-        }])
     }
 }
 

--- a/src/memory_core/storage/sqlite/mod.rs
+++ b/src/memory_core/storage/sqlite/mod.rs
@@ -69,8 +69,6 @@ enum StoreOutcome {
 pub enum InitMode {
     /// Use the resolved default database path (`~/.mag/memory.db` with legacy fallback).
     Default,
-    /// Reserved for future advanced configuration (currently delegates to `Default`).
-    Advanced,
 }
 
 /// SQLite-backed persistent storage for the memory system.
@@ -98,24 +96,18 @@ pub struct SqliteStorage {
 #[cfg(feature = "sqlite-vec")]
 fn ensure_vec_extension_registered() {
     use std::sync::Once;
-
-    /// Expected signature for SQLite extension entry points.
-    type SqliteExtensionInit = unsafe extern "C" fn(
-        *mut rusqlite::ffi::sqlite3,
-        *mut *mut i8,
-        *const rusqlite::ffi::sqlite3_api_routines,
-    ) -> i32;
-
     static VEC_INIT: Once = Once::new();
     VEC_INIT.call_once(|| unsafe {
-        // SAFETY: `sqlite_vec::sqlite3_vec_init` is a valid SQLite extension entry point
-        // whose actual signature matches `SqliteExtensionInit`. The transmute converts the
-        // Rust function pointer representation for use with SQLite's C FFI. This is the
-        // standard pattern for registering statically-linked SQLite extensions via
-        // `sqlite3_auto_extension`.
-        let init_fn: SqliteExtensionInit =
-            std::mem::transmute(sqlite_vec::sqlite3_vec_init as *const ());
-        rusqlite::ffi::sqlite3_auto_extension(Some(init_fn));
+        rusqlite::ffi::sqlite3_auto_extension(Some(std::mem::transmute::<
+            *const (),
+            unsafe extern "C" fn(
+                *mut rusqlite::ffi::sqlite3,
+                *mut *mut i8,
+                *const rusqlite::ffi::sqlite3_api_routines,
+            ) -> i32,
+        >(
+            sqlite_vec::sqlite3_vec_init as *const ()
+        )));
     });
 }
 
@@ -130,7 +122,6 @@ impl SqliteStorage {
     pub fn new(mode: InitMode, embedder: Arc<dyn Embedder>) -> Result<Self> {
         match mode {
             InitMode::Default => Self::new_default(embedder),
-            InitMode::Advanced => Self::new_advanced_placeholder(embedder),
         }
     }
 
@@ -138,11 +129,6 @@ impl SqliteStorage {
     pub fn new_default(embedder: Arc<dyn Embedder>) -> Result<Self> {
         let path = default_db_path()?;
         Self::new_with_path(path, embedder)
-    }
-
-    /// Placeholder for advanced initialization (currently delegates to [`new_default`](Self::new_default)).
-    pub fn new_advanced_placeholder(embedder: Arc<dyn Embedder>) -> Result<Self> {
-        Self::new_default(embedder)
     }
 
     /// Opens (or creates) a database at the given `path`, creating parent directories as needed.

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -49,10 +49,9 @@ pub async fn run_setup(args: SetupArgs) -> Result<()> {
 
     // Detect phase
     println!("\n  Detecting AI coding tools...\n");
-    let result: DetectionResult =
-        tokio::task::spawn_blocking(|| detect_phase(None))
-            .await
-            .context("tool detection task panicked")?;
+    let result: DetectionResult = tokio::task::spawn_blocking(|| detect_phase(None))
+        .await
+        .context("tool detection task panicked")?;
 
     present_detection(&result);
 
@@ -69,6 +68,7 @@ pub async fn run_setup(args: SetupArgs) -> Result<()> {
     present_summary(&summary);
 
     // Daemon phase
+    #[cfg(feature = "daemon-http")]
     maybe_start_daemon(args.port, args.no_start)?;
 
     Ok(())
@@ -95,10 +95,10 @@ fn present_detection(result: &DetectionResult) {
     println!("  Detected tools:\n");
     for dt in &result.detected {
         let status_icon = match &dt.mag_status {
-            MagConfigStatus::Configured => "\u{2713}",          // check mark
-            MagConfigStatus::NotConfigured => "\u{2717}",       // X mark
-            MagConfigStatus::Misconfigured(_) => "\u{26a0}",    // warning
-            MagConfigStatus::Unreadable(_) => "\u{26a0}",       // warning
+            MagConfigStatus::Configured => "\u{2713}",    // check mark
+            MagConfigStatus::NotConfigured => "\u{2717}", // X mark
+            MagConfigStatus::Misconfigured(_) => "\u{26a0}", // warning
+            MagConfigStatus::Unreadable(_) => "\u{26a0}", // warning
         };
         let status_label = match &dt.mag_status {
             MagConfigStatus::Configured => "configured",
@@ -119,7 +119,11 @@ fn present_detection(result: &DetectionResult) {
 
     if !result.not_found.is_empty() {
         println!();
-        let not_found_names: Vec<&str> = result.not_found.iter().map(|t: &tool_detection::AiTool| t.display_name()).collect();
+        let not_found_names: Vec<&str> = result
+            .not_found
+            .iter()
+            .map(|t: &tool_detection::AiTool| t.display_name())
+            .collect();
         tracing::debug!(tools = ?not_found_names, "tools not found");
     }
     println!();
@@ -196,9 +200,7 @@ fn select_tools<'a>(
     select_tools_interactive(&actionable)
 }
 
-fn select_tools_interactive<'a>(
-    tools: &[&'a DetectedTool],
-) -> Result<Vec<&'a DetectedTool>> {
+fn select_tools_interactive<'a>(tools: &[&'a DetectedTool]) -> Result<Vec<&'a DetectedTool>> {
     println!(
         "  Configure {} tool{}? [Y/n] ",
         tools.len(),
@@ -225,10 +227,7 @@ fn select_tools_interactive<'a>(
 // Configuration phase
 // ---------------------------------------------------------------------------
 
-fn configure_tools(
-    tools: &[&DetectedTool],
-    mode: TransportMode,
-) -> Result<ConfigureSummary> {
+fn configure_tools(tools: &[&DetectedTool], mode: TransportMode) -> Result<ConfigureSummary> {
     let mut summary = ConfigureSummary::default();
 
     for tool in tools {
@@ -310,6 +309,7 @@ fn run_uninstall(project_root: Option<&Path>) -> Result<()> {
 // Daemon management
 // ---------------------------------------------------------------------------
 
+#[cfg(feature = "daemon-http")]
 fn maybe_start_daemon(port: u16, no_start: bool) -> Result<()> {
     if no_start {
         tracing::debug!("--no-start: skipping daemon check");
@@ -328,9 +328,7 @@ fn maybe_start_daemon(port: u16, no_start: bool) -> Result<()> {
         _ => {}
     }
 
-    println!(
-        "  Tip: start the MAG daemon with `mag serve` (port {port}).\n"
-    );
+    println!("  Tip: start the MAG daemon with `mag serve` (port {port}).\n");
 
     Ok(())
 }
@@ -345,7 +343,9 @@ pub fn parse_transport(s: &str, port: u16) -> Result<TransportMode> {
         "command" | "cmd" => Ok(TransportMode::Command),
         "http" => Ok(TransportMode::Http { port }),
         "stdio" => Ok(TransportMode::Stdio),
-        other => anyhow::bail!("unknown transport mode: '{other}' (expected command, http, or stdio)"),
+        other => {
+            anyhow::bail!("unknown transport mode: '{other}' (expected command, http, or stdio)")
+        }
     }
 }
 
@@ -410,7 +410,10 @@ mod tests {
         let result = parse_transport("grpc", 4242);
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
-        assert!(msg.contains("grpc"), "error should mention the bad input: {msg}");
+        assert!(
+            msg.contains("grpc"),
+            "error should mention the bad input: {msg}"
+        );
     }
 
     // -----------------------------------------------------------------------
@@ -523,9 +526,10 @@ mod tests {
     #[test]
     fn select_tools_all_configured_returns_empty() {
         let result = DetectionResult {
-            detected: vec![
-                make_detected(AiTool::ClaudeCode, MagConfigStatus::Configured),
-            ],
+            detected: vec![make_detected(
+                AiTool::ClaudeCode,
+                MagConfigStatus::Configured,
+            )],
             not_found: vec![],
         };
         let args = SetupArgs {

--- a/src/tool_detection.rs
+++ b/src/tool_detection.rs
@@ -131,6 +131,7 @@ pub struct DetectionResult {
     pub not_found: Vec<AiTool>,
 }
 
+#[allow(dead_code)] // Used by tests; kept for future callers.
 impl DetectionResult {
     /// Returns tools that are installed but do not have MAG configured.
     pub fn unconfigured(&self) -> Vec<&DetectedTool> {
@@ -196,6 +197,7 @@ pub fn detect_all_tools(project_root: Option<&Path>) -> DetectionResult {
 /// Returns a `Vec<DetectedTool>` with all found config locations for this tool
 /// (e.g., both global and project-level). Returns an empty `Vec` if the tool
 /// is not found at any of its known paths.
+#[allow(dead_code)] // Used by tests; kept for future callers.
 pub fn detect_tool(tool: AiTool, project_root: Option<&Path>) -> Vec<DetectedTool> {
     let home = match crate::app_paths::home_dir() {
         Ok(h) => h,
@@ -478,7 +480,7 @@ fn check_mag_in_json(
                     _ => {
                         return MagConfigStatus::Misconfigured(
                             "missing source: custom".to_string(),
-                        )
+                        );
                     }
                 }
             }
@@ -591,7 +593,8 @@ mod tests {
     #[test]
     fn detects_claude_code_project_config() {
         with_temp_home(|_home| {
-            let project = std::env::temp_dir().join(format!("mag-project-{}", uuid::Uuid::new_v4()));
+            let project =
+                std::env::temp_dir().join(format!("mag-project-{}", uuid::Uuid::new_v4()));
             let claude_dir = project.join(".claude");
             std::fs::create_dir_all(&claude_dir).unwrap();
             std::fs::write(
@@ -627,7 +630,8 @@ mod tests {
     #[test]
     fn detects_project_local_cursor_config() {
         with_temp_home(|_home| {
-            let project = std::env::temp_dir().join(format!("mag-project-{}", uuid::Uuid::new_v4()));
+            let project =
+                std::env::temp_dir().join(format!("mag-project-{}", uuid::Uuid::new_v4()));
             let cursor_dir = project.join(".cursor");
             std::fs::create_dir_all(&cursor_dir).unwrap();
             std::fs::write(cursor_dir.join("mcp.json"), r#"{"mcpServers": {}}"#).unwrap();
@@ -802,11 +806,7 @@ mod tests {
         with_temp_home(|home| {
             let gemini_dir = home.join(".gemini");
             std::fs::create_dir_all(&gemini_dir).unwrap();
-            std::fs::write(
-                gemini_dir.join("settings.json"),
-                r#"{"mcpServers": {}}"#,
-            )
-            .unwrap();
+            std::fs::write(gemini_dir.join("settings.json"), r#"{"mcpServers": {}}"#).unwrap();
 
             let result = detect_tool(AiTool::GeminiCli, None);
             assert!(!result.is_empty());
@@ -829,8 +829,11 @@ mod tests {
                 std::fs::create_dir_all(&dir).unwrap();
                 dir.join("claude_desktop_config.json")
             };
-            std::fs::write(&config_path, r#"{"mcpServers": {"mag": {"command": "mag"}}}"#)
-                .unwrap();
+            std::fs::write(
+                &config_path,
+                r#"{"mcpServers": {"mag": {"command": "mag"}}}"#,
+            )
+            .unwrap();
 
             let result = detect_tool(AiTool::ClaudeDesktop, None);
             assert!(!result.is_empty());


### PR DESCRIPTION
## Summary
- Gates `auth`, `daemon`, `idle_timer` modules behind `daemon-http` feature flag (were `#[allow(dead_code)]`, 643 lines)
- Removes `InitMode::Advanced` (silently fell back to `Default` — dead placeholder)
- Removes 5 unreachable `PlaceholderPipeline` trait impls (Storage, Retriever, Searcher, Recents, SemanticSearcher)
- Narrows `config_writer` and `tool_detection` visibility to `pub(crate)`
- Fixes pre-existing formatting issues in 4 files

Closes #120

## Test plan
- [x] 997 tests pass (`cargo test --all-features`)
- [x] Clippy clean
- [x] Default build no longer compiles dead daemon code
- [x] `--features daemon-http` still compiles all modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an optional feature flag for daemon functionality.

* **Feature Removals**
  * Removed the advanced initialization mode from the CLI; only the default initialization mode is now available.

* **Changes**
  * Daemon-related features are now conditionally compiled and require the optional daemon-http feature flag to be enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->