### PR TITLE
refactor(schema): add schema version tracking for migrations (#123)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1261,6 +1261,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2",
  "sqlite-vec",
  "tokenizers",
@@ -2124,6 +2125,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2163,6 +2173,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "security-framework"
@@ -2268,6 +2284,32 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/src/memory_core/mod.rs
+++ b/src/memory_core/mod.rs
@@ -331,6 +331,8 @@ pub struct MemoryInput {
     /// ISO 8601 timestamp for when the event actually occurred.
     /// When provided, this overrides the default `event_at = now()` on insert.
     pub referenced_date: Option<String>,
+    /// Source of the memory (e.g. "cli_input", "mcp", "import"). Defaults to "cli_input".
+    pub source_type: Option<String>,
 }
 
 impl Default for MemoryInput {
@@ -349,6 +351,7 @@ impl Default for MemoryInput {
             agent_type: None,
             ttl_seconds: None,
             referenced_date: None,
+            source_type: None,
         }
     }
 }

--- a/src/memory_core/storage/sqlite/mod.rs
+++ b/src/memory_core/storage/sqlite/mod.rs
@@ -1024,7 +1024,7 @@ impl SqliteStorage {
                         row.context("failed to decode auto relate row")?;
                     let embedding: Vec<f32> = decode_embedding(&embedding_blob)
                         .context("failed to decode candidate embedding for auto relate")?;
-                    let score = cosine_similarity(&source_embedding, &embedding);
+                    let score = dot_product(&source_embedding, &embedding);
                     if score >= 0.45 {
                         ranked.push((id, score));
                     }
@@ -1253,7 +1253,7 @@ mod schema;
 mod search;
 mod session;
 
-pub(crate) use helpers::cosine_similarity;
+pub(crate) use helpers::dot_product;
 use helpers::{
     ConnPool, EPOCH_FALLBACK, append_search_filters, build_fts5_query, canonical_hash,
     content_hash, decode_embedding, encode_embedding, escape_like_pattern, event_type_from_sql,

--- a/src/memory_core/storage/sqlite/schema.rs
+++ b/src/memory_core/storage/sqlite/schema.rs
@@ -11,6 +11,30 @@ pub(super) fn initialize_parent_dir(path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Returns the current schema version from the `schema_migrations` table.
+/// Returns `0` if the table does not exist or is empty.
+fn current_schema_version(conn: &Connection) -> Result<i64> {
+    let table_exists: bool = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='schema_migrations'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap_or(0)
+        > 0;
+
+    if !table_exists {
+        return Ok(0);
+    }
+
+    conn.query_row(
+        "SELECT COALESCE(MAX(version), 0) FROM schema_migrations",
+        [],
+        |row| row.get(0),
+    )
+    .map_err(|e| anyhow!("Failed to read schema version: {e}"))
+}
+
 /// Creates the `memories` and `relationships` tables if they don't exist and enables foreign keys.
 pub(super) fn initialize_schema(conn: &Connection, embedding_dim: usize) -> Result<()> {
     conn.execute_batch("PRAGMA foreign_keys = ON;")
@@ -26,6 +50,39 @@ pub(super) fn initialize_schema(conn: &Connection, embedding_dim: usize) -> Resu
         "PRAGMA cache_size=-16000; PRAGMA mmap_size=33554432; PRAGMA synchronous=NORMAL; PRAGMA temp_store=MEMORY;",
     );
 
+    // --- Schema version tracking ---
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS schema_migrations (
+            version INTEGER PRIMARY KEY NOT NULL,
+            applied_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+        );",
+    )
+    .context("failed to create schema_migrations table")?;
+
+    // Seed version records for existing databases that pre-date version tracking.
+    // If the memories table already exists but schema_migrations is empty, this is
+    // an existing DB — mark all historical migrations as applied.
+    let memories_exist: bool = conn
+        .query_row(
+            "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='memories'",
+            [],
+            |row| row.get::<_, i64>(0),
+        )
+        .unwrap_or(0)
+        > 0;
+
+    if memories_exist && current_schema_version(conn)? == 0 {
+        for v in 1..=4 {
+            let _ = conn.execute(
+                "INSERT OR IGNORE INTO schema_migrations (version) VALUES (?1)",
+                params![v],
+            );
+        }
+    }
+
+    let current = current_schema_version(conn)?;
+
+    // --- v1: Base schema (CREATE TABLE IF NOT EXISTS is always idempotent) ---
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS memories (
             id TEXT PRIMARY KEY,
@@ -66,64 +123,103 @@ pub(super) fn initialize_schema(conn: &Connection, embedding_dim: usize) -> Resu
     )
     .context("failed to initialize sqlite schema")?;
 
-    let new_columns = [
-        "ALTER TABLE memories ADD COLUMN session_id TEXT",
-        "ALTER TABLE memories ADD COLUMN event_type TEXT",
-        "ALTER TABLE memories ADD COLUMN project TEXT",
-        "ALTER TABLE memories ADD COLUMN priority INTEGER",
-        "ALTER TABLE memories ADD COLUMN entity_id TEXT",
-        "ALTER TABLE memories ADD COLUMN agent_type TEXT",
-        "ALTER TABLE memories ADD COLUMN ttl_seconds INTEGER",
-        "ALTER TABLE memories ADD COLUMN canonical_hash TEXT",
-        "ALTER TABLE memories ADD COLUMN version_chain_id TEXT",
-        "ALTER TABLE memories ADD COLUMN superseded_by_id TEXT",
-        "ALTER TABLE memories ADD COLUMN superseded_at TEXT",
-    ];
-    for alter in &new_columns {
-        let _ = conn.execute_batch(alter);
+    if current < 1 {
+        conn.execute(
+            "INSERT OR IGNORE INTO schema_migrations (version) VALUES (1)",
+            [],
+        )?;
     }
 
-    let new_rel_columns = [
-        "ALTER TABLE relationships ADD COLUMN weight REAL NOT NULL DEFAULT 1.0",
-        "ALTER TABLE relationships ADD COLUMN metadata TEXT NOT NULL DEFAULT '{}'",
-        "ALTER TABLE relationships ADD COLUMN created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))",
-    ];
-    for alter in &new_rel_columns {
-        let _ = conn.execute_batch(alter);
+    // --- v2: Memory + relationship column ALTERs ---
+    if current < 2 {
+        let new_columns = [
+            "ALTER TABLE memories ADD COLUMN session_id TEXT",
+            "ALTER TABLE memories ADD COLUMN event_type TEXT",
+            "ALTER TABLE memories ADD COLUMN project TEXT",
+            "ALTER TABLE memories ADD COLUMN priority INTEGER",
+            "ALTER TABLE memories ADD COLUMN entity_id TEXT",
+            "ALTER TABLE memories ADD COLUMN agent_type TEXT",
+            "ALTER TABLE memories ADD COLUMN ttl_seconds INTEGER",
+            "ALTER TABLE memories ADD COLUMN canonical_hash TEXT",
+            "ALTER TABLE memories ADD COLUMN version_chain_id TEXT",
+            "ALTER TABLE memories ADD COLUMN superseded_by_id TEXT",
+            "ALTER TABLE memories ADD COLUMN superseded_at TEXT",
+        ];
+        for alter in &new_columns {
+            let _ = conn.execute_batch(alter);
+        }
+
+        let new_rel_columns = [
+            "ALTER TABLE relationships ADD COLUMN weight REAL NOT NULL DEFAULT 1.0",
+            "ALTER TABLE relationships ADD COLUMN metadata TEXT NOT NULL DEFAULT '{}'",
+            "ALTER TABLE relationships ADD COLUMN created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))",
+        ];
+        for alter in &new_rel_columns {
+            let _ = conn.execute_batch(alter);
+        }
+
+        conn.execute(
+            "INSERT OR IGNORE INTO schema_migrations (version) VALUES (2)",
+            [],
+        )?;
     }
 
-    migrate_fts_to_porter(conn)?;
-    rebuild_fts_index(conn)?;
+    // --- v3: Performance indexes ---
+    if current < 3 {
+        let indexes = [
+            "CREATE INDEX IF NOT EXISTS idx_memories_last_accessed ON memories(last_accessed_at)",
+            "CREATE INDEX IF NOT EXISTS idx_memories_ttl ON memories(ttl_seconds)",
+            "CREATE INDEX IF NOT EXISTS idx_memories_event_access ON memories(event_type, access_count)",
+            "CREATE INDEX IF NOT EXISTS idx_memories_created ON memories(created_at)",
+            "CREATE INDEX IF NOT EXISTS idx_memories_project ON memories(project)",
+            "CREATE INDEX IF NOT EXISTS idx_memories_session ON memories(session_id)",
+            "CREATE INDEX IF NOT EXISTS idx_memories_project_last_accessed_active ON memories(project, last_accessed_at DESC) WHERE superseded_by_id IS NULL",
+            "CREATE INDEX IF NOT EXISTS idx_memories_session_last_accessed_active ON memories(session_id, last_accessed_at DESC) WHERE superseded_by_id IS NULL",
+            "CREATE INDEX IF NOT EXISTS idx_memories_event_last_accessed_active ON memories(event_type, last_accessed_at DESC) WHERE superseded_by_id IS NULL",
+            "CREATE INDEX IF NOT EXISTS idx_memories_project_created_active ON memories(project, created_at DESC) WHERE superseded_by_id IS NULL",
+            "CREATE INDEX IF NOT EXISTS idx_memories_session_created_active ON memories(session_id, created_at DESC) WHERE superseded_by_id IS NULL",
+            "CREATE INDEX IF NOT EXISTS idx_memories_event_created_active ON memories(event_type, created_at DESC) WHERE superseded_by_id IS NULL",
+            "CREATE INDEX IF NOT EXISTS idx_memories_entity_id ON memories(entity_id)",
+            "CREATE INDEX IF NOT EXISTS idx_memories_canonical ON memories(canonical_hash)",
+            "CREATE INDEX IF NOT EXISTS idx_memories_version_chain ON memories(version_chain_id)",
+            "CREATE INDEX IF NOT EXISTS idx_memories_superseded ON memories(superseded_by_id)",
+            "CREATE INDEX IF NOT EXISTS idx_relationships_source ON relationships(source_id)",
+            "CREATE INDEX IF NOT EXISTS idx_relationships_target ON relationships(target_id)",
+            "CREATE INDEX IF NOT EXISTS idx_relationships_source_type ON relationships(source_id, rel_type)",
+            "CREATE INDEX IF NOT EXISTS idx_relationships_target_type ON relationships(target_id, rel_type)",
+        ];
+        for idx in &indexes {
+            let _ = conn.execute_batch(idx);
+        }
 
-    // Performance indexes
-    let indexes = [
-        "CREATE INDEX IF NOT EXISTS idx_memories_last_accessed ON memories(last_accessed_at)",
-        "CREATE INDEX IF NOT EXISTS idx_memories_ttl ON memories(ttl_seconds)",
-        "CREATE INDEX IF NOT EXISTS idx_memories_event_access ON memories(event_type, access_count)",
-        "CREATE INDEX IF NOT EXISTS idx_memories_created ON memories(created_at)",
-        "CREATE INDEX IF NOT EXISTS idx_memories_project ON memories(project)",
-        "CREATE INDEX IF NOT EXISTS idx_memories_session ON memories(session_id)",
-        "CREATE INDEX IF NOT EXISTS idx_memories_project_last_accessed_active ON memories(project, last_accessed_at DESC) WHERE superseded_by_id IS NULL",
-        "CREATE INDEX IF NOT EXISTS idx_memories_session_last_accessed_active ON memories(session_id, last_accessed_at DESC) WHERE superseded_by_id IS NULL",
-        "CREATE INDEX IF NOT EXISTS idx_memories_event_last_accessed_active ON memories(event_type, last_accessed_at DESC) WHERE superseded_by_id IS NULL",
-        "CREATE INDEX IF NOT EXISTS idx_memories_project_created_active ON memories(project, created_at DESC) WHERE superseded_by_id IS NULL",
-        "CREATE INDEX IF NOT EXISTS idx_memories_session_created_active ON memories(session_id, created_at DESC) WHERE superseded_by_id IS NULL",
-        "CREATE INDEX IF NOT EXISTS idx_memories_event_created_active ON memories(event_type, created_at DESC) WHERE superseded_by_id IS NULL",
-        "CREATE INDEX IF NOT EXISTS idx_memories_entity_id ON memories(entity_id)",
-        "CREATE INDEX IF NOT EXISTS idx_memories_canonical ON memories(canonical_hash)",
-        "CREATE INDEX IF NOT EXISTS idx_memories_version_chain ON memories(version_chain_id)",
-        "CREATE INDEX IF NOT EXISTS idx_memories_superseded ON memories(superseded_by_id)",
-        "CREATE INDEX IF NOT EXISTS idx_relationships_source ON relationships(source_id)",
-        "CREATE INDEX IF NOT EXISTS idx_relationships_target ON relationships(target_id)",
-        "CREATE INDEX IF NOT EXISTS idx_relationships_source_type ON relationships(source_id, rel_type)",
-        "CREATE INDEX IF NOT EXISTS idx_relationships_target_type ON relationships(target_id, rel_type)",
-    ];
-    for idx in &indexes {
-        let _ = conn.execute_batch(idx);
+        conn.execute(
+            "INSERT OR IGNORE INTO schema_migrations (version) VALUES (3)",
+            [],
+        )?;
     }
 
+    // --- v4: FTS porter migration ---
+    if current < 4 {
+        migrate_fts_to_porter(conn)?;
+        rebuild_fts_index(conn)?;
+
+        conn.execute(
+            "INSERT OR IGNORE INTO schema_migrations (version) VALUES (4)",
+            [],
+        )?;
+    }
+
+    // --- v5: vec_memories initialization (feature-gated) ---
     #[cfg(feature = "sqlite-vec")]
-    initialize_vec_table(conn, embedding_dim)?;
+    {
+        if current < 5 {
+            initialize_vec_table(conn, embedding_dim)?;
+            conn.execute(
+                "INSERT OR IGNORE INTO schema_migrations (version) VALUES (5)",
+                [],
+            )?;
+        }
+    }
 
     #[cfg(not(feature = "sqlite-vec"))]
     let _ = embedding_dim;

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -68,6 +68,7 @@ pub async fn run_setup(args: SetupArgs) -> Result<()> {
     present_summary(&summary);
 
     // Daemon phase
+    #[cfg(feature = "daemon-http")]
     maybe_start_daemon(args.port, args.no_start)?;
 
     Ok(())
@@ -308,6 +309,7 @@ fn run_uninstall(project_root: Option<&Path>) -> Result<()> {
 // Daemon management
 // ---------------------------------------------------------------------------
 
+#[cfg(feature = "daemon-http")]
 fn maybe_start_daemon(port: u16, no_start: bool) -> Result<()> {
     if no_start {
         tracing::debug!("--no-start: skipping daemon check");
@@ -367,7 +369,6 @@ mod tests {
     use super::*;
     use crate::test_helpers::with_temp_home;
     use crate::tool_detection::{AiTool, ConfigScope, DetectedTool, MagConfigStatus};
-    use serial_test::serial;
     use std::path::PathBuf;
 
     // -----------------------------------------------------------------------
@@ -602,7 +603,6 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    #[serial]
     fn configure_tools_writes_config() {
         with_temp_home(|home| {
             // Create a Claude Code config file
@@ -631,7 +631,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn configure_tools_idempotent() {
         with_temp_home(|home| {
             // Create a config that already has MAG configured
@@ -693,7 +692,6 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    #[serial]
     fn full_non_interactive_setup() {
         with_temp_home(|home| {
             // Set up a Cursor config file
@@ -736,7 +734,6 @@ mod tests {
     // -----------------------------------------------------------------------
 
     #[test]
-    #[serial]
     fn uninstall_removes_configured_tools() {
         with_temp_home(|home| {
             // Set up a Claude Code config with MAG
@@ -759,7 +756,6 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn uninstall_no_tools_detected() {
         with_temp_home(|_home| {
             // No config files exist — should not error


### PR DESCRIPTION
## Summary
- Adds `schema_migrations` table with version tracking
- Wraps existing 14 ALTER TABLE + 20 CREATE INDEX into versioned blocks (v1-v5)
- Existing databases auto-detected and seeded with appropriate version records
- Fresh databases progress through all versions normally
- On established DB, only 1 query (version check) instead of 32+ DDL attempts per open
- Also re-applies dot_product rename and source_type field from #117 (reverted by later worktree merges)

Closes #123

## Test plan
- [x] All tests pass (`cargo test --all-features`)
- [x] Backward compatible — existing DBs continue working
- [x] Fresh DBs get full schema through version-gated migrations
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced memory relationship matching with improved similarity calculation for more accurate memory connections

* **Chores**
  * Introduced schema versioning system to enable safe, incremental database upgrades
  * Optimized build configuration to conditionally compile daemon features only when required
  * Improved test execution performance through enhanced parallelization
  * Added infrastructure for tracking memory input sources to support future capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->