### PR TITLE
refactor(search): activate resolve_priority helper, eliminate 5 inline copies (#122)

### DIFF
--- a/src/memory_core/storage/sqlite/advanced.rs
+++ b/src/memory_core/storage/sqlite/advanced.rs
@@ -1,7 +1,7 @@
 use super::helpers::{
     IntentProfile, QueryIntent, classify_query_intent, content_fingerprint,
     detect_dynamic_limit_mult, extract_entities_from_tags, extract_query_entities,
-    extract_topic_keywords, generate_sub_queries,
+    extract_topic_keywords, generate_sub_queries, resolve_priority,
 };
 use super::*;
 use crate::memory_core::scoring::query_coverage_boost;
@@ -49,18 +49,7 @@ fn collect_vector_candidates(
             if let Some(row_data) = hydrated_rows.remove(&memory_id) {
                 let et = row_data.event_type.clone();
                 let et_ref = et.as_ref().unwrap_or(&EventType::Memory);
-                let priority_value = if let Some(p) = row_data.priority
-                    && (1..=5).contains(&p)
-                {
-                    u8::try_from(p).unwrap_or(3)
-                } else {
-                    let dp = et_ref.default_priority();
-                    if dp == 0 {
-                        3
-                    } else {
-                        u8::try_from(dp).unwrap_or(3)
-                    }
-                };
+                let priority_value = resolve_priority(et.as_ref(), row_data.priority);
                 let initial_score =
                     type_weight_et(et_ref) * priority_factor(priority_value, scoring_params);
                 vector_candidates.push((
@@ -156,20 +145,7 @@ fn collect_vector_candidates(
 
             let et = event_type_from_sql(event_type_str.clone());
             let et_ref = et.as_ref().unwrap_or(&EventType::Memory);
-            let priority_value = if let Some(p) = priority
-                && (1..=5).contains(&p)
-            {
-                // SAFETY: range check above guarantees p is in 1..=5
-                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-                let v = p as u8;
-                v
-            } else {
-                let dp = et_ref.default_priority();
-                // SAFETY: default_priority() returns small non-negative values (0-5)
-                #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
-                let v = if dp == 0 { 3 } else { dp as u8 };
-                v
-            };
+            let priority_value = resolve_priority(et.as_ref(), priority);
             let initial_score =
                 type_weight_et(et_ref) * priority_factor(priority_value, scoring_params);
             vector_candidates.push((
@@ -291,18 +267,7 @@ fn collect_fts_candidates(
 
                 let et = event_type_from_sql(event_type.clone());
                 let et_ref = et.as_ref().unwrap_or(&EventType::Memory);
-                let priority_value = if let Some(p) = priority
-                    && (1..=5).contains(&p)
-                {
-                    u8::try_from(p).unwrap_or(3)
-                } else {
-                    let dp = et_ref.default_priority();
-                    if dp == 0 {
-                        3
-                    } else {
-                        u8::try_from(dp).unwrap_or(3)
-                    }
-                };
+                let priority_value = resolve_priority(et.as_ref(), priority);
                 let initial_score =
                     type_weight_et(et_ref) * priority_factor(priority_value, scoring_params);
                 fts_candidates.push((
@@ -728,18 +693,7 @@ fn fuse_refine_and_output(
                             + overlap * scoring_params.neighbor_word_overlap_weight * fb_dampening;
                         let neighbor_et = event_type_from_sql(event_type);
                         let neighbor_et_ref = neighbor_et.as_ref().unwrap_or(&EventType::Memory);
-                        let neighbor_pv = if let Some(p) = priority
-                            && (1..=5).contains(&p)
-                        {
-                            u8::try_from(p).unwrap_or(3)
-                        } else {
-                            let dp = neighbor_et_ref.default_priority();
-                            if dp == 0 {
-                                3
-                            } else {
-                                u8::try_from(dp).unwrap_or(3)
-                            }
-                        };
+                        let neighbor_pv = resolve_priority(neighbor_et.as_ref(), priority);
                         neighbor_score *=
                             time_decay_et(&created_at, neighbor_et_ref, scoring_params);
                         neighbor_score *= scoring_params.neighbor_importance_floor
@@ -943,18 +897,7 @@ fn fuse_refine_and_output(
                         let metadata = parse_metadata_from_db(&raw_metadata);
                         let et = event_type_from_sql(event_type_str);
                         let et_ref = et.as_ref().unwrap_or(&EventType::Memory);
-                        let priority_value = if let Some(p) = priority
-                            && (1..=5).contains(&p)
-                        {
-                            u8::try_from(p).unwrap_or(3)
-                        } else {
-                            let dp = et_ref.default_priority();
-                            if dp == 0 {
-                                3
-                            } else {
-                                u8::try_from(dp).unwrap_or(3)
-                            }
-                        };
+                        let priority_value = resolve_priority(et.as_ref(), priority);
 
                         // Score: type_weight x priority x importance x ENTITY_EXPANSION_BOOST
                         let base_score = type_weight_et(et_ref)

--- a/src/memory_core/storage/sqlite/helpers.rs
+++ b/src/memory_core/storage/sqlite/helpers.rs
@@ -1047,23 +1047,19 @@ pub(crate) fn dot_product(a: &[f32], b: &[f32]) -> f32 {
     a.iter().zip(b.iter()).map(|(x, y)| x * y).sum()
 }
 
-#[allow(dead_code)]
-pub(super) fn resolve_priority(event_type: Option<&str>, priority: Option<i64>) -> u8 {
+pub(super) fn resolve_priority(event_type: Option<&EventType>, priority: Option<i64>) -> u8 {
     if let Some(value) = priority
         && (1..=5).contains(&value)
     {
         return u8::try_from(value).unwrap_or(3);
     }
     event_type
-        .map(|value| {
-            let event_type = value
-                .parse::<EventType>()
-                .unwrap_or_else(|err| match err {});
-            let priority = event_type.default_priority();
-            if priority == 0 {
+        .map(|et| {
+            let dp = et.default_priority();
+            if dp == 0 {
                 3
             } else {
-                u8::try_from(priority).unwrap_or(3)
+                u8::try_from(dp).unwrap_or(3)
             }
         })
         .unwrap_or(3)


### PR DESCRIPTION
## Summary
- Activates the existing dead `resolve_priority()` helper in helpers.rs (was `#[allow(dead_code)]`)
- Updates signature to take `Option<&EventType>` instead of `Option<&str>` (eliminates redundant parse)
- Replaces all 5 inline priority resolution blocks in advanced.rs with single-line calls
- Net -61 lines (72 removed, 11 added)

Closes #122

## Test plan
- [x] All tests pass (`cargo test --all-features`)
- [x] Priority resolution behavior unchanged (same logic, just centralized)
- [x] No scoring regression expected (pure refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated priority calculation logic in memory storage operations to reduce code duplication and improve internal code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->