### PR TITLE
docs(benchmarks): update LoCoMo numbers to validated 10-sample run (#145)

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Any tool that supports MCP can connect to MAG. Windows is untested - [report you
 
 ## Benchmarks
 
-**91.1% retrieval accuracy on the LoCoMo memory benchmark.** Don't trust our number - [run it yourself](docs/benchmarks/methodology.md#running-the-benchmark):
+**90.1% retrieval accuracy on the LoCoMo memory benchmark.** Don't trust our number - [run it yourself](docs/benchmarks/methodology.md#running-the-benchmark):
 
 ```bash
 ./scripts/bench.sh

--- a/docs/benchmarks/methodology.md
+++ b/docs/benchmarks/methodology.md
@@ -4,11 +4,11 @@ This document records the benchmark methodology and the latest measured outputs 
 
 ## Environment
 
-- Date: `2026-03-16`
-- Commit: `4028f4749e2e444110e3cee10e14de83a68b0b4b`
+- Date: `2026-03-28`
+- Commit: `83abccf`
 - Machine: `macOS aarch64, 12 CPU`
 - OS: `macOS 26.3 (25D125)`
-- Note: These published measurements were captured before later PR review follow-up fixes and were not rerun afterward.
+- Embedder: `bge-small-en-v1.5` (ONNX, 384-dim)
 
 ## Dataset Policy
 
@@ -104,39 +104,42 @@ Dataset: [`locomo10.json`](https://raw.githubusercontent.com/snap-research/locom
 
 | Parameter | Value |
 | --- | --- |
-| Commit | `4028f47` |
-| Date | `2026-03-16` |
+| Commit | `83abccf` |
+| Date | `2026-03-28` |
 | Samples evaluated | `10` |
 | Questions evaluated | `1986` |
 | Memories ingested | `5882` |
+| Graph edges | `73002` (5610 PRECEDED_BY, 49806 RELATES_TO, 17586 related) |
 | Top-k | `20` |
-| Total duration | `112.0 s` |
-| Average query time | `13.3 ms` |
-| Peak RSS | `277 MB` |
+| Total duration | `~82 s` |
+| Average query time | `7 ms` |
+| Embedder | `bge-small-en-v1.5` (ONNX, 384-dim) |
 
 ### Results by category (word-overlap)
 
-| Category | Questions | Word Overlap | Substring | Evidence Recall |
-| --- | ---: | ---: | ---: | ---: |
-| Single-Hop QA | 282 | `57.9%` | `14.5%` | `50.9%` |
-| Temporal Reasoning | 321 | `75.5%` | `15.0%` | `80.0%` |
-| Multi-Hop QA | 96 | `32.5%` | `8.3%` | `43.1%` |
-| Open-Domain | 841 | `83.4%` | `45.4%` | `83.3%` |
-| Adversarial | 446 | `78.3%` | `43.0%` | `78.1%` |
-| **Overall** | **1986** | **`74.9%`** | **`33.8%`** | **`75.1%`** |
-
-### Comparison (word-overlap, 2-sample fast run)
-
-| Category | MAG | AutoMem |
+| Category | Questions | Word Overlap |
 | --- | ---: | ---: |
-| Single-Hop QA | `61.4%` | `79.8%` |
-| Temporal Reasoning | `87.8%` | `85.1%` |
-| Multi-Hop QA | `43.7%` | `50.0%` |
-| Open-Domain | `76.5%` | `95.8%` |
-| Adversarial | `72.6%` | `100.0%` |
-| **Overall** | **`74.4%`** | **`90.5%`** |
+| Single-Hop QA | 282 | `86.9%` |
+| Temporal Reasoning | 321 | `85.0%` |
+| Multi-Hop QA | 96 | `56.2%` |
+| Open-Domain | 841 | `95.7%` |
+| Adversarial | 446 | `92.6%` |
+| **Overall** | **1986** | **`90.1%`** |
 
-AutoMem numbers are from the [LoCoMo paper](https://arxiv.org/abs/2402.18180) Table 2 (Recall column, LoCoMo-10 subset). MAG numbers use `--samples 2 --scoring-mode word-overlap --top-k 20`.
+Overall Substring: `39.8%` | Overall Evidence Recall: `92.0%`
+
+### Comparison (word-overlap, 10-sample)
+
+| Category | MAG (10-sample) | AutoMem |
+| --- | ---: | ---: |
+| Single-Hop QA | `86.9%` | `79.8%` |
+| Temporal Reasoning | `85.0%` | `85.1%` |
+| Multi-Hop QA | `56.2%` | `50.0%` |
+| Open-Domain | `95.7%` | `95.8%` |
+| Adversarial | `92.6%` | `100.0%` |
+| **Overall** | **`90.1%`** | **`90.5%`** |
+
+AutoMem numbers are their published figures from the [LoCoMo paper](https://arxiv.org/abs/2402.18180) Table 2 (Recall column, LoCoMo-10 subset). MAG numbers use `--samples 10 --scoring-mode word-overlap --top-k 20`.
 
 This is a retrieval-oriented benchmark, not a full generative evaluation. The README describes it that way intentionally.
 

--- a/scripts/pr-benchmark-gate.sh
+++ b/scripts/pr-benchmark-gate.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# PR Benchmark Gate — runs before PR creation to catch regressions.
+#
+# Runs 2-sample LoCoMo word-overlap benchmark (~15s) and compares against
+# the last 10-sample baseline in benchmark_log.csv.
+#
+# IMPORTANT: 2-sample has inherent variance (~2pp). This gate only WARNS
+# on moderate dips and FAILS on large drops. It never updates 10-sample
+# baseline data — that requires a deliberate full validation run.
+#
+# Exit 0 = pass, Exit 1 = hard fail (definite regression)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LOG_FILE="$REPO_ROOT/docs/benchmarks/benchmark_log.csv"
+
+# 2-sample variance is ~2pp, so:
+WARN_THRESHOLD=2.0   # flag for attention — suggest 10-sample confirmation
+FAIL_THRESHOLD=5.0   # hard fail — definitely a regression, not variance
+
+echo "=== PR Benchmark Gate ==="
+echo ""
+
+# ── Step 1: Get 10-sample baseline from benchmark_log.csv ──
+BASELINE=""
+if [ -f "$LOG_FILE" ]; then
+    # Column 8 = overall_score; find most recent 10-sample bge-small entry
+    BASELINE=$(grep ",10," "$LOG_FILE" | grep "bge-small" | tail -1 | cut -d',' -f8)
+fi
+
+if [ -z "$BASELINE" ]; then
+    echo "WARNING: No 10-sample baseline found in $LOG_FILE"
+    echo "Skipping benchmark comparison (no baseline to compare against)"
+    exit 0
+fi
+
+echo "10-sample baseline: ${BASELINE}%"
+echo ""
+
+# ── Step 2: Run 2-sample benchmark ──
+echo "Running 2-sample LoCoMo benchmark..."
+BENCH_OUTPUT=$(cargo run --release --bin locomo_bench -- --samples 2 --scoring-mode word-overlap 2>&1)
+CURRENT=$(echo "$BENCH_OUTPUT" | grep "WORD OVERLAP" | grep -oE '[0-9]+\.[0-9]+')
+
+if [ -z "$CURRENT" ]; then
+    echo "ERROR: Could not parse benchmark output"
+    echo "$BENCH_OUTPUT" | tail -20
+    exit 1
+fi
+
+echo "2-sample result:    ${CURRENT}%"
+echo ""
+
+# ── Step 3: Compare with tiered thresholds ──
+DIFF=$(echo "$BASELINE - $CURRENT" | bc -l)
+
+HARD_FAIL=$(echo "$DIFF > $FAIL_THRESHOLD" | bc -l)
+SOFT_WARN=$(echo "$DIFF > $WARN_THRESHOLD" | bc -l)
+
+if [ "$HARD_FAIL" = "1" ]; then
+    echo "FAIL: Likely regression: ${CURRENT}% vs ${BASELINE}% baseline (delta: -${DIFF}pp)"
+    echo ""
+    echo "This exceeds the ${FAIL_THRESHOLD}pp hard-fail threshold."
+    echo "The 2-sample run suggests a real regression, not just variance."
+    echo ""
+    echo "Full output:"
+    echo "$BENCH_OUTPUT" | tail -15
+    exit 1
+elif [ "$SOFT_WARN" = "1" ]; then
+    echo "WARNING: Possible regression: ${CURRENT}% vs ${BASELINE}% baseline (delta: -${DIFF}pp)"
+    echo ""
+    echo "This exceeds the ${WARN_THRESHOLD}pp soft threshold but is within 2-sample variance."
+    echo "Before merging, run a full 10-sample validation to confirm:"
+    echo ""
+    echo "  cargo run --release --bin locomo_bench -- --samples 10 --scoring-mode word-overlap"
+    echo ""
+    echo "If the 10-sample result matches the baseline, this is just variance — merge freely."
+    echo "If 10-sample also shows a drop, investigate before merging."
+else
+    echo "PASS: ${CURRENT}% vs ${BASELINE}% baseline (delta: ${DIFF}pp)"
+fi
+
+echo ""
+
+# ── Step 4: Check docs freshness ──
+echo "=== Docs Freshness Check ==="
+
+if [ -f "$REPO_ROOT/docs/benchmarks/methodology.md" ]; then
+    METH_DATE=$(grep -m1 "^- Date:" "$REPO_ROOT/docs/benchmarks/methodology.md" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' || echo "unknown")
+    if [ "$METH_DATE" != "unknown" ]; then
+        METH_EPOCH=$(date -j -f "%Y-%m-%d" "$METH_DATE" "+%s" 2>/dev/null || date -d "$METH_DATE" "+%s" 2>/dev/null || echo "0")
+        NOW_EPOCH=$(date "+%s")
+        DAYS_OLD=$(( (NOW_EPOCH - METH_EPOCH) / 86400 ))
+        if [ "$DAYS_OLD" -gt 7 ]; then
+            echo "WARNING: methodology.md benchmark date is ${DAYS_OLD} days old (${METH_DATE})"
+            echo "  Consider updating with a fresh 10-sample run."
+        else
+            echo "PASS: methodology.md is ${DAYS_OLD} days old"
+        fi
+    fi
+fi
+
+if [ -f "$REPO_ROOT/README.md" ]; then
+    README_PCT=$(grep -oE '[0-9]+\.[0-9]+% retrieval accuracy' "$REPO_ROOT/README.md" | grep -oE '[0-9]+\.[0-9]+' || echo "")
+    if [ -n "$README_PCT" ] && [ -n "$BASELINE" ]; then
+        ABS_DIFF=$(echo "$README_PCT - $BASELINE" | bc -l | tr -d '-')
+        TOO_FAR=$(echo "$ABS_DIFF > 1.5" | bc -l)
+        if [ "$TOO_FAR" = "1" ]; then
+            echo "WARNING: README claims ${README_PCT}% but 10-sample baseline is ${BASELINE}%"
+            echo "  Update README to match the validated baseline."
+        else
+            echo "PASS: README (${README_PCT}%) matches baseline (${BASELINE}%)"
+        fi
+    fi
+fi
+
+echo ""
+echo "=== Gate complete ==="


### PR DESCRIPTION
## Summary

- Update `docs/benchmarks/methodology.md` with validated 10-sample LoCoMo results from commit `83abccf` (2026-03-28)
- Overall word-overlap jumps from 74.9% to **90.1%** across all 5 categories
- Comparison table now shows MAG 10-sample numbers vs AutoMem published figures (was 2-sample)
- Update `README.md` headline benchmark: 91.1% -> 90.1% (validated 10-sample number)
- E2E, LongMemEval, and Scale Benchmark sections intentionally unchanged (not re-run)

### Key improvements reflected

| Category | Old | New |
|---|---:|---:|
| Single-Hop QA | 57.9% | 86.9% |
| Temporal Reasoning | 75.5% | 85.0% |
| Multi-Hop QA | 32.5% | 56.2% |
| Open-Domain | 83.4% | 95.7% |
| Adversarial | 78.3% | 92.6% |
| **Overall** | **74.9%** | **90.1%** |

Closes #145

## Test plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Confirm E2E / LongMemEval / Scale sections are unchanged
- [ ] README benchmark number matches methodology.md overall

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated benchmark results reflecting improved performance metrics with faster query times and reduced memory usage.
  * Updated retrieval accuracy benchmark to 90.1% based on latest measurement run.
  * Enhanced benchmark methodology documentation with current embedder configuration and test parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->