### PR TITLE
docs: add freshness dates to all docs, add bench.sh --gate for PR regression checks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,5 @@
 # AGENTS.md
+<!-- Last verified: 2026-03-28 | Valid for: v0.1.2+ -->
 
 Universal agent guidance for AI coding assistants working on this repository.
 Vendor-neutral — applies to Claude Code, Cursor, Windsurf, Copilot, and any AI tool.
@@ -38,6 +39,8 @@ cargo run --release --bin locomo_bench -- --llm-judge --samples 2               
 ./scripts/bench.sh --model voyage-nano-int8        # voyage-4-nano INT8 @ 1024-dim
 ./scripts/bench.sh --model bge-small --samples 10  # full validation run
 ./scripts/bench.sh --model voyage-nano-fp32 --notes "after scoring tweak"  # with notes
+./scripts/bench.sh --gate                          # PR gate: run + compare vs 10-sample baseline
+./scripts/bench.sh --gate --notes "pre-merge #142" # PR gate with context
 
 # README update checker (suggests edits, does not modify files)
 ./scripts/check-readme.sh                          # analyze last 3 commits vs README
@@ -112,9 +115,10 @@ Every code change MUST pass before pushing:
 1. **Format**: `cargo fmt --all -- --check`
 2. **Lint**: `cargo clippy --all-targets --all-features -- -D warnings`
 3. **Tests**: `cargo test --all-features`
-4. **Benchmark** (if touching scoring/search/storage): `cargo run --release --bin locomo_bench -- --samples 2 --scoring-mode word-overlap` — no regressions without justification
+4. **Benchmark** (if touching scoring/search/storage): `./scripts/bench.sh --gate` — runs 2-sample, logs to CSV, compares against 10-sample baseline. Warns at >2pp delta, fails at >5pp.
+5. **Full validation** (before merge if gate warned): `./scripts/bench.sh --samples 10 --notes "pre-merge validation"` — authoritative 10-sample run.
 
-Run `prek run` for gates 1-3.
+Run `prek run` for gates 1-3. Always use `bench.sh` (not raw `cargo run`) so results are logged to the CSV.
 
 ## Post-Implementation Checklist
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+<!-- Last verified: 2026-03-28 | Valid for: v0.1.2+ -->
 
 Notable changes to MAG. Format follows [Keep a Changelog](https://keepachangelog.com/).
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,4 +1,5 @@
 # Security
+<!-- Last verified: 2026-03-28 | Valid for: v0.1.2+ -->
 
 MAG is a local-first memory system. This document describes the security model.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,4 +1,5 @@
 # How MAG Works
+<!-- Last verified: 2026-03-28 | Valid for: v0.1.2+ -->
 
 Single binary, single SQLite file, hybrid retrieval.
 No external services, no network calls at query time.

--- a/docs/benchmarks/LATEST.md
+++ b/docs/benchmarks/LATEST.md
@@ -1,4 +1,5 @@
 # MAG Benchmark Results
+<!-- Last verified: 2026-03-28 | Valid for: v0.1.2+ -->
 
 Latest benchmark runs. Updated automatically by `./scripts/bench.sh`.
 

--- a/docs/benchmarks/abstention.md
+++ b/docs/benchmarks/abstention.md
@@ -1,4 +1,5 @@
 # Abstention Gate
+<!-- Last verified: 2026-03-28 | Valid for: v0.1.2+ -->
 
 The abstention gate is a collection-level filter in the advanced search pipeline
 that prevents MAG from returning results when no stored memory is

--- a/docs/benchmarks/locomo_gap_analysis.md
+++ b/docs/benchmarks/locomo_gap_analysis.md
@@ -1,4 +1,5 @@
 # LoCoMo Gap Analysis: MAG vs AutoMem
+<!-- Last verified: 2026-03-28 | Valid for: v0.1.2+ | Needs review -->
 
 ## Baseline
 

--- a/docs/benchmarks/methodology.md
+++ b/docs/benchmarks/methodology.md
@@ -1,4 +1,5 @@
 # Benchmark Report
+<!-- Last verified: 2026-03-28 | Valid for: v0.1.2+ -->
 
 This document records the benchmark methodology and the latest measured outputs used by the README.
 

--- a/docs/benchmarks/models.md
+++ b/docs/benchmarks/models.md
@@ -1,4 +1,5 @@
 # Embedding Model Comparison
+<!-- Last verified: 2026-03-28 | Valid for: v0.1.2+ -->
 
 LoCoMo word-overlap scoring, 2 samples. Benchmarked 2026-03-19 on macOS aarch64.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,4 +1,5 @@
 # CLI Reference
+<!-- Last verified: 2026-03-28 | Valid for: v0.1.2+ -->
 
 All commands follow the form `mag <command> [args] [flags]`. Run `mag --help` or `mag <command> --help` for built-in usage.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,4 +1,5 @@
 # Configuration & Tuning
+<!-- Last verified: 2026-03-28 | Valid for: v0.1.2+ -->
 
 ## Data Location
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,5 @@
 # MAG Documentation
+<!-- Last verified: 2026-03-28 | Valid for: v0.1.2+ -->
 
 ## Getting Started
 - [Installation](../README.md#install) — Shell, Homebrew, npm, uv, pip, Cargo

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,4 +1,5 @@
 # MCP Tools Reference
+<!-- Last verified: 2026-03-28 | Valid for: v0.1.2+ -->
 
 MAG exposes 16 tools via the Model Context Protocol. Any MCP-compatible client can use these tools.
 

--- a/docs/setup/claude-code.md
+++ b/docs/setup/claude-code.md
@@ -1,4 +1,5 @@
 # Claude Code Setup
+<!-- Last verified: 2026-03-28 | Valid for: v0.1.2+ -->
 
 Add MAG to your Claude Code MCP configuration.
 

--- a/docs/setup/claude-desktop.md
+++ b/docs/setup/claude-desktop.md
@@ -1,4 +1,5 @@
 # Claude Desktop Setup
+<!-- Last verified: 2026-03-28 | Valid for: v0.1.2+ -->
 
 Add MAG to your Claude Desktop MCP configuration.
 

--- a/docs/setup/cline.md
+++ b/docs/setup/cline.md
@@ -1,4 +1,5 @@
 # Cline Setup
+<!-- Last verified: 2026-03-28 | Valid for: v0.1.2+ -->
 
 Add MAG to your Cline MCP configuration.
 

--- a/docs/setup/cursor.md
+++ b/docs/setup/cursor.md
@@ -1,4 +1,5 @@
 # Cursor Setup
+<!-- Last verified: 2026-03-28 | Valid for: v0.1.2+ -->
 
 Add MAG to your Cursor MCP configuration.
 

--- a/docs/setup/windsurf.md
+++ b/docs/setup/windsurf.md
@@ -1,4 +1,5 @@
 # Windsurf Setup
+<!-- Last verified: 2026-03-28 | Valid for: v0.1.2+ -->
 
 Add MAG to your Windsurf MCP configuration.
 

--- a/docs/shared-socket.md
+++ b/docs/shared-socket.md
@@ -1,4 +1,5 @@
 # Shared Socket — One MAG Instance, All Tools
+<!-- Last verified: 2026-03-28 | Valid for: v0.1.2+ -->
 
 By default, each MCP client starts its own MAG process. This means each tool maintains its own connection to the database. SQLite handles concurrent reads well, but concurrent writes from multiple processes can cause lock contention.
 

--- a/docs/what-to-store.md
+++ b/docs/what-to-store.md
@@ -1,4 +1,5 @@
 # What to Store
+<!-- Last verified: 2026-03-28 | Valid for: v0.1.2+ -->
 
 10 system prompt patterns for building useful memory with MAG. Copy-paste these into your AI tool's system prompt or CLAUDE.md to guide what gets stored.
 

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -29,6 +29,7 @@ DIM=""            # empty = use model default
 SAMPLES=2
 SCORING_MODE="word-overlap"
 NOTES=""
+GATE=false        # --gate: compare against 10-sample baseline, fail on regression
 
 # ── Parse flags ───────────────────────────────────────────────────────────────
 while [[ $# -gt 0 ]]; do
@@ -38,6 +39,7 @@ while [[ $# -gt 0 ]]; do
         --samples)      SAMPLES="$2";      shift 2 ;;
         --scoring-mode) SCORING_MODE="$2"; shift 2 ;;
         --notes)        NOTES="$2";        shift 2 ;;
+        --gate)         GATE=true;         shift ;;
         *) echo "Unknown flag: $1" >&2; exit 1 ;;
     esac
 done
@@ -204,3 +206,68 @@ mkdir -p "$(dirname "${LATEST_MD}")"
     printf "%s\n" "${TABLE}"
 } > "${LATEST_MD}"
 echo "Updated ${LATEST_MD}"
+
+# ── Gate mode: compare against 10-sample baseline ────────────────────────────
+if [[ "${GATE}" == true ]]; then
+    echo ""
+    echo "=== PR Benchmark Gate ==="
+
+    WARN_THRESHOLD=2.0   # suggest 10-sample confirmation
+    FAIL_THRESHOLD=5.0   # hard fail — too large for variance
+
+    BASELINE=$(grep ",10," "${RESULTS_CSV}" | grep "bge-small" | tail -1 | cut -d',' -f8)
+    if [ -z "$BASELINE" ]; then
+        echo "WARNING: No 10-sample baseline found — skipping gate"
+    else
+        echo "10-sample baseline: ${BASELINE}%"
+        echo "Current (${SAMPLES}-sample): ${overall_score}%"
+
+        DIFF=$(echo "$BASELINE - $overall_score" | bc -l)
+        HARD_FAIL=$(echo "$DIFF > $FAIL_THRESHOLD" | bc -l)
+        SOFT_WARN=$(echo "$DIFF > $WARN_THRESHOLD" | bc -l)
+
+        if [ "$HARD_FAIL" = "1" ]; then
+            echo ""
+            echo "FAIL: Likely regression — ${overall_score}% vs ${BASELINE}% (delta: -${DIFF}pp)"
+            echo "Exceeds ${FAIL_THRESHOLD}pp hard-fail threshold."
+            exit 1
+        elif [ "$SOFT_WARN" = "1" ]; then
+            echo ""
+            echo "WARNING: Possible regression — ${overall_score}% vs ${BASELINE}% (delta: -${DIFF}pp)"
+            echo "Within ${SAMPLES}-sample variance but suspicious. Run full validation:"
+            echo "  ./scripts/bench.sh --samples 10 --notes 'pre-merge validation'"
+        else
+            echo "PASS: within ${WARN_THRESHOLD}pp of baseline"
+        fi
+    fi
+
+    # Docs freshness check
+    echo ""
+    if [ -f "${REPO_DIR}/docs/benchmarks/methodology.md" ]; then
+        METH_DATE=$(grep -oE 'Last verified: [0-9]{4}-[0-9]{2}-[0-9]{2}' "${REPO_DIR}/docs/benchmarks/methodology.md" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' || \
+                    grep -m1 "^- Date:" "${REPO_DIR}/docs/benchmarks/methodology.md" | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' || echo "")
+        if [ -n "$METH_DATE" ]; then
+            METH_EPOCH=$(date -j -f "%Y-%m-%d" "$METH_DATE" "+%s" 2>/dev/null || date -d "$METH_DATE" "+%s" 2>/dev/null || echo "0")
+            NOW_EPOCH=$(date "+%s")
+            DAYS_OLD=$(( (NOW_EPOCH - METH_EPOCH) / 86400 ))
+            if [ "$DAYS_OLD" -gt 7 ]; then
+                echo "WARNING: methodology.md is ${DAYS_OLD}d stale (${METH_DATE})"
+            else
+                echo "Docs: methodology.md updated ${DAYS_OLD}d ago"
+            fi
+        fi
+    fi
+    if [ -f "${REPO_DIR}/README.md" ] && [ -n "${BASELINE:-}" ]; then
+        README_PCT=$(grep -oE '[0-9]+\.[0-9]+% retrieval accuracy' "${REPO_DIR}/README.md" | grep -oE '[0-9]+\.[0-9]+' || echo "")
+        if [ -n "$README_PCT" ]; then
+            ABS_DIFF=$(echo "$README_PCT - $BASELINE" | bc -l | tr -d '-')
+            TOO_FAR=$(echo "$ABS_DIFF > 1.5" | bc -l)
+            if [ "$TOO_FAR" = "1" ]; then
+                echo "WARNING: README says ${README_PCT}% but baseline is ${BASELINE}%"
+            fi
+        fi
+    fi
+
+    echo ""
+    echo "=== Gate complete ==="
+fi


### PR DESCRIPTION
## Summary

Two changes bundled:

1. **Freshness dates on all 20 doc files** — adds `<!-- Last verified: 2026-03-28 | Valid for: v0.1.2+ -->` after the title heading in every doc. Makes stale docs immediately obvious. The `bench.sh --gate` checks this date and warns if >7 days old.

2. **`bench.sh --gate` flag** — PR benchmark gate that:
   - Runs 2-sample benchmark (logs to CSV like normal)
   - Compares against the last 10-sample baseline in benchmark_log.csv
   - **Warns** at >2pp delta (suggests running 10-sample to confirm)
   - **Fails** at >5pp delta (definitely a regression)
   - Checks methodology.md freshness and README accuracy
   - Never updates 10-sample baselines from 2-sample data

3. **AGENTS.md quality gates updated** — documents `bench.sh --gate` as gate 4, `bench.sh --samples 10` as gate 5.

## Test plan

- [x] `bench.sh --gate` runs and compares correctly
- [x] Freshness comments render as invisible HTML in GitHub markdown
- [x] All 20 doc files have the comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PR Benchmark Gate (`--gate`) for automated benchmark validation on pull requests, with configurable thresholds for performance regression warnings and failures.

* **Documentation**
  * Updated documentation verification metadata across guides, benchmarking resources, and setup instructions to indicate current validity for v0.1.2+.

* **Chores**
  * Updated agent instructions for standardized benchmark execution workflows using the new gate functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->