### PR TITLE
chore: bump version to 0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,7 +1240,7 @@ checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
 name = "mag-memory"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mag-memory"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 autobenches = false
 license = "MIT"


### PR DESCRIPTION
## Summary
Bump version 0.1.2 → 0.1.3 to pick up 20 commits since last release, including:
- fix(storage): restore decode_embedding binary fallback (#148)
- refactor(core): pipeline decomposition (#142)
- fix(auth): constant-time hash comparison (#128)
- fix(mcp): input validation limits (#130)
- perf(search): hoist conn.prepare out of entity loop (#137)
- fix(bench): E2E scoring fixes (#152)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump release (no user-visible changes)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->