### PR TITLE
chore: bump python __version__ to 0.1.3

### DIFF
--- a/python/mag_memory/__init__.py
+++ b/python/mag_memory/__init__.py
@@ -11,10 +11,10 @@ import subprocess
 import sys
 
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 # Version of the Rust binary to download (kept in sync with __version__)
-_BINARY_VERSION = "0.1.2"
+_BINARY_VERSION = "0.1.3"
 
 
 def _binary_dir():


### PR DESCRIPTION
Missed in #156 — python/mag_memory/__init__.py still had 0.1.2. Needed before v0.1.3 tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version updated to 0.1.3

<!-- end of auto-generated comment: release notes by coderabbit.ai -->