### PR TITLE
ci: add workflow_dispatch trigger to release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,12 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag (e.g. v0.1.3). Must match an existing git tag."
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -13,6 +19,7 @@ env:
   CARGO_TERM_COLOR: always
   BINARY_NAME: mag
   BUILD_FEATURES: real-embeddings,mimalloc
+  RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
 
 jobs:
   build:
@@ -90,7 +97,7 @@ jobs:
       - name: Detect prerelease
         id: meta
         run: |
-          TAG="${GITHUB_REF#refs/tags/}"
+          TAG="${RELEASE_TAG}"
           if echo "$TAG" | grep -qE '-(rc|alpha|beta|dev)'; then
             echo "prerelease=true" >> "$GITHUB_OUTPUT"
           else
@@ -167,7 +174,7 @@ jobs:
     steps:
       - name: Download checksums from release
         run: |
-          TAG="${GITHUB_REF#refs/tags/}"
+          TAG="${RELEASE_TAG}"
           gh release download "$TAG" --pattern checksums.txt --repo "$GITHUB_REPOSITORY"
           cat checksums.txt
         env:
@@ -182,7 +189,7 @@ jobs:
 
       - name: Update formula
         run: |
-          TAG="${GITHUB_REF#refs/tags/}"
+          TAG="${RELEASE_TAG}"
           VERSION="${TAG#v}"
 
           get_sha() { grep "$1" checksums.txt | awk '{print $1}'; }
@@ -204,7 +211,7 @@ jobs:
 
       - name: Commit and push
         run: |
-          TAG="${GITHUB_REF#refs/tags/}"
+          TAG="${RELEASE_TAG}"
           VERSION="${TAG#v}"
           cd homebrew-tap
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary
Add `workflow_dispatch` trigger to the release workflow so releases can be triggered from the GitHub UI or `gh workflow run` without needing to push a git tag.

This is needed because jj (Jujutsu) can create tags (`jj tag set`) but cannot push them (`jj git push` only supports bookmarks). With this change, future releases can be done via:

```bash
jj tag set vX.Y.Z -r main
gh workflow run release.yml -f tag=vX.Y.Z
```

Changes:
- Added `workflow_dispatch` input with `tag` parameter
- Added `RELEASE_TAG` env var that resolves from either the input or `github.ref_name`
- Replaced all `GITHUB_REF` tag extraction with `RELEASE_TAG`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow to support manual releases with custom tags via workflow dispatch, allowing more flexible control over the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->