### PR TITLE
feat: add mag uninstall command and Claude Code plugin marketplace support

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -352,6 +352,15 @@ pub enum Commands {
         #[arg(long)]
         cross_encoder: bool,
     },
+    /// Completely uninstall MAG: remove tool configs, models, and data.
+    Uninstall {
+        /// Skip interactive prompts and remove everything.
+        #[arg(long, conflicts_with = "configs_only")]
+        all: bool,
+        /// Skip interactive prompts, only remove tool configurations.
+        #[arg(long, conflicts_with = "all")]
+        configs_only: bool,
+    },
     /// Interactive wizard to detect and configure AI tools for MAG.
     Setup {
         /// Skip interactive prompts (auto-configure all unconfigured tools).
@@ -1199,6 +1208,39 @@ mod tests {
                 assert_eq!(days, 7);
             }
             _ => panic!("Expected StatsExtended command"),
+        }
+    }
+
+    #[test]
+    fn test_cli_uninstall_command() {
+        let args = vec!["mag", "uninstall"];
+        let cli = Cli::parse_from(args);
+        match cli.command {
+            Commands::Uninstall { all, configs_only } => {
+                assert!(!all);
+                assert!(!configs_only);
+            }
+            _ => panic!("Expected Uninstall command"),
+        }
+    }
+
+    #[test]
+    fn test_cli_uninstall_all() {
+        let args = vec!["mag", "uninstall", "--all"];
+        let cli = Cli::parse_from(args);
+        match cli.command {
+            Commands::Uninstall { all, .. } => assert!(all),
+            _ => panic!("Expected Uninstall command"),
+        }
+    }
+
+    #[test]
+    fn test_cli_uninstall_configs_only() {
+        let args = vec!["mag", "uninstall", "--configs-only"];
+        let cli = Cli::parse_from(args);
+        match cli.command {
+            Commands::Uninstall { configs_only, .. } => assert!(configs_only),
+            _ => panic!("Expected Uninstall command"),
         }
     }
 }

--- a/src/config_writer.rs
+++ b/src/config_writer.rs
@@ -48,6 +48,8 @@ pub enum ConfigWriteResult {
     /// The tool's config write is deferred because serialization support is
     /// not yet implemented (e.g., TOML for Codex).
     Deferred { tool: AiTool },
+    /// MAG was installed as a Claude Code plugin via the marketplace.
+    Plugin,
 }
 
 /// Outcome of a config remove operation.
@@ -307,6 +309,160 @@ pub fn build_mag_entry(tool: AiTool, mode: TransportMode) -> serde_json::Value {
                 "command": "mag",
                 "args": ["serve", "--stdio"]
             })
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Claude Code plugin (marketplace) API
+// ---------------------------------------------------------------------------
+
+/// Installs MAG as a Claude Code plugin via the marketplace.
+///
+/// Runs:
+/// 1. `claude plugin marketplace add George-RD/mag-plugins`
+/// 2. `claude plugin install mag@mag-plugins --scope user`
+///
+/// Returns `ConfigWriteResult::Plugin` on success.
+/// Falls back to an error if the `claude` CLI is not found or the install fails.
+pub fn install_claude_plugin() -> Result<ConfigWriteResult> {
+    let claude = find_claude_cli()?;
+
+    // Step 1: add the marketplace (ignore "already added" errors)
+    let add_output = std::process::Command::new(&claude)
+        .args(["plugin", "marketplace", "add", "George-RD/mag-plugins"])
+        .output()
+        .with_context(|| format!("running `{} plugin marketplace add`", claude.display()))?;
+
+    tracing::debug!(
+        status = %add_output.status,
+        stdout_len = add_output.stdout.len(),
+        stderr_len = add_output.stderr.len(),
+        "claude plugin marketplace add"
+    );
+
+    // Step 2: install the plugin
+    let install_output = std::process::Command::new(&claude)
+        .args(["plugin", "install", "mag@mag-plugins", "--scope", "user"])
+        .output()
+        .with_context(|| format!("running `{} plugin install`", claude.display()))?;
+
+    tracing::debug!(
+        status = %install_output.status,
+        stdout_len = install_output.stdout.len(),
+        stderr_len = install_output.stderr.len(),
+        "claude plugin install"
+    );
+
+    if !install_output.status.success() {
+        let stderr = String::from_utf8_lossy(&install_output.stderr);
+        let stdout = String::from_utf8_lossy(&install_output.stdout);
+        anyhow::bail!(
+            "claude plugin install failed (exit {}): {}{}",
+            install_output.status,
+            stderr.trim(),
+            if stdout.trim().is_empty() {
+                String::new()
+            } else {
+                format!("\n{}", stdout.trim())
+            }
+        );
+    }
+
+    Ok(ConfigWriteResult::Plugin)
+}
+
+/// Removes the MAG Claude Code plugin.
+///
+/// Runs `claude plugin uninstall mag@mag-plugins --scope user`.
+pub fn remove_claude_plugin() -> Result<RemoveResult> {
+    let claude = find_claude_cli()?;
+
+    let output = std::process::Command::new(&claude)
+        .args(["plugin", "uninstall", "mag@mag-plugins", "--scope", "user"])
+        .output()
+        .with_context(|| format!("running `{} plugin uninstall`", claude.display()))?;
+
+    tracing::debug!(
+        status = %output.status,
+        stdout_len = output.stdout.len(),
+        stderr_len = output.stderr.len(),
+        "claude plugin uninstall"
+    );
+
+    if output.status.success() {
+        Ok(RemoveResult::Removed)
+    } else {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // "not found" means plugin wasn't installed — treat as NotPresent.
+        // Any other failure is a real error.
+        if stderr.contains("not found") {
+            tracing::debug!("plugin not installed, treating as not-present");
+            Ok(RemoveResult::NotPresent)
+        } else {
+            anyhow::bail!("claude plugin uninstall failed (exit {}): {}", output.status, stderr.trim())
+        }
+    }
+}
+
+/// Checks whether the MAG plugin is installed and enabled in Claude Code.
+///
+/// Reads `~/.claude/settings.json` and looks for `"mag@mag-plugins": true`
+/// in the `enabledPlugins` object.
+#[allow(dead_code)] // Used by setup.rs and tests; clippy can't trace cross-module usage
+pub fn verify_claude_plugin() -> Result<bool> {
+    let home = crate::app_paths::home_dir()?;
+    let settings_path = home.join(".claude/settings.json");
+
+    if !settings_path.exists() {
+        return Ok(false);
+    }
+
+    let content = std::fs::read_to_string(&settings_path)
+        .with_context(|| format!("reading {}", settings_path.display()))?;
+    let content = content.strip_prefix('\u{FEFF}').unwrap_or(&content);
+
+    let parsed: serde_json::Value = match serde_json::from_str(content) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::debug!(error = %e, "failed to parse claude settings.json");
+            return Ok(false);
+        }
+    };
+
+    let enabled = parsed
+        .get("enabledPlugins")
+        .and_then(|v| v.get("mag@mag-plugins"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+
+    Ok(enabled)
+}
+
+/// Locates the `claude` CLI binary on the system PATH.
+///
+/// Uses `command -v claude` on Unix (or `where claude` on Windows) to resolve
+/// the binary path without requiring an external crate.
+fn find_claude_cli() -> Result<PathBuf> {
+    let output = if cfg!(target_os = "windows") {
+        std::process::Command::new("where").arg("claude").output()
+    } else {
+        std::process::Command::new("sh")
+            .args(["-c", "command -v claude"])
+            .output()
+    };
+
+    match output {
+        Ok(o) if o.status.success() => {
+            let path_str = String::from_utf8_lossy(&o.stdout);
+            let path = path_str.trim();
+            if path.is_empty() {
+                anyhow::bail!("claude CLI not found on PATH — install Claude Code first");
+            }
+            Ok(PathBuf::from(path))
+        }
+        _ => {
+            anyhow::bail!("claude CLI not found on PATH — install Claude Code first");
         }
     }
 }
@@ -1108,5 +1264,85 @@ mod tests {
             let backup_content = std::fs::read_to_string(&bak_path).expect("read backup");
             assert_eq!(backup_content, initial);
         });
+    }
+
+    // -----------------------------------------------------------------------
+    // Plugin verification tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    #[serial]
+    fn verify_claude_plugin_returns_false_when_no_settings() {
+        with_temp_home(|_home| {
+            let result = verify_claude_plugin().expect("verify should not error");
+            assert!(!result);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn verify_claude_plugin_returns_false_when_no_enabled_plugins() {
+        with_temp_home(|home| {
+            let claude_dir = home.join(".claude");
+            std::fs::create_dir_all(&claude_dir).unwrap();
+            std::fs::write(claude_dir.join("settings.json"), r#"{"theme": "dark"}"#).unwrap();
+
+            let result = verify_claude_plugin().expect("verify should not error");
+            assert!(!result);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn verify_claude_plugin_returns_true_when_enabled() {
+        with_temp_home(|home| {
+            let claude_dir = home.join(".claude");
+            std::fs::create_dir_all(&claude_dir).unwrap();
+            std::fs::write(
+                claude_dir.join("settings.json"),
+                r#"{"enabledPlugins": {"mag@mag-plugins": true}}"#,
+            )
+            .unwrap();
+
+            let result = verify_claude_plugin().expect("verify should not error");
+            assert!(result);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn verify_claude_plugin_returns_false_when_disabled() {
+        with_temp_home(|home| {
+            let claude_dir = home.join(".claude");
+            std::fs::create_dir_all(&claude_dir).unwrap();
+            std::fs::write(
+                claude_dir.join("settings.json"),
+                r#"{"enabledPlugins": {"mag@mag-plugins": false}}"#,
+            )
+            .unwrap();
+
+            let result = verify_claude_plugin().expect("verify should not error");
+            assert!(!result);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn verify_claude_plugin_handles_malformed_json() {
+        with_temp_home(|home| {
+            let claude_dir = home.join(".claude");
+            std::fs::create_dir_all(&claude_dir).unwrap();
+            std::fs::write(claude_dir.join("settings.json"), "not valid json{{{").unwrap();
+
+            let result = verify_claude_plugin().expect("verify should not error");
+            assert!(!result);
+        });
+    }
+
+    #[test]
+    fn config_write_result_plugin_variant() {
+        let result = ConfigWriteResult::Plugin;
+        // Verify the variant exists and Debug works
+        assert_eq!(format!("{result:?}"), "Plugin");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod daemon;
 pub mod memory_core;
 pub mod setup;
 pub(crate) mod tool_detection;
+pub mod uninstall;
 
 #[cfg(test)]
 pub(crate) mod test_helpers;

--- a/src/main.rs
+++ b/src/main.rs
@@ -119,6 +119,10 @@ async fn main() -> anyhow::Result<()> {
         .await;
     }
 
+    if let Commands::Uninstall { all, configs_only } = cli.command {
+        return mag::uninstall::run_uninstall(all, configs_only).await;
+    }
+
     if matches!(cli.command, Commands::Paths) {
         let paths = app_paths::resolve_app_paths()?;
         println!(
@@ -941,6 +945,9 @@ async fn main() -> anyhow::Result<()> {
         }
         Commands::Setup { .. } => {
             unreachable!("setup is handled before storage initialization")
+        }
+        Commands::Uninstall { .. } => {
+            unreachable!("uninstall is handled before storage initialization")
         }
         Commands::DownloadModel => {
             unreachable!("download-model is handled before storage initialization")

--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -42,6 +42,53 @@ fn require_finite(name: &str, value: f64) -> Result<(), McpError> {
     Ok(())
 }
 
+// ──────────────────────── MCP Instructions ────────────────────────
+
+/// Instructions returned in the MCP `initialize` handshake.
+///
+/// These guide AI clients that connect via MCP-only (no CLI/hooks).
+/// The 9-prefix system indicates priority:
+///   99999 = critical session behaviour
+///   9999  = important per-interaction behaviour
+///   999   = recommended practices
+const MCP_INSTRUCTIONS: &str = "\
+MAG — persistent memory for AI agents. Stores, searches, and recalls context across sessions.\n\
+\n\
+## 99999 — SESSION START (do this FIRST, every session)\n\
+Call memory_session_info(mode=\"welcome\") BEFORE your first substantive response.\n\
+This returns recalled context, active project, and session state.\n\
+Do NOT skip this. Without it you are operating without memory.\n\
+\n\
+## 99999 — STORE DECISIONS AND LESSONS\n\
+After completing non-trivial work, call memory_store to persist:\n\
+- Architectural decisions with rationale\n\
+- Bug root causes and fixes\n\
+- User preferences and corrections\n\
+- Workflow patterns that worked\n\
+You are the ONLY mechanism that stores memories in MCP-only mode. If you don't store, nothing is remembered.\n\
+\n\
+## 9999 — SEARCH BEFORE DECIDING\n\
+Before making architectural choices or debugging recurring issues,\n\
+call memory_search to check for prior context. Past-you may have solved this already.\n\
+\n\
+## 9999 — DO NOT ANNOUNCE MEMORY OPERATIONS\n\
+Never say \"let me check my memory\" or \"I'll store that\". Just do it silently.\n\
+Weave recalled context naturally into your responses as if you simply know it.\n\
+\n\
+## 999 — TOOL REFERENCE\n\
+Call memory_session_info(mode=\"protocol\") for the full tool inventory.\n\
+\n\
+## 999 — DIAGNOSTICS\n\
+If tool calls fail, ask the user to run: mag doctor\n\
+\n\
+## 999 — UPGRADE AVAILABLE\n\
+MAG works best with the CLI + hooks plugin, which provides automatic memory\n\
+at session start/end, after compaction, and on every prompt — no manual tool calls needed.\n\
+If this is a coding environment (Claude Code, Cursor, etc.), mention this once per session:\n\
+  \"Tip: install the MAG plugin for automatic memory. Run: mag setup --plugin\"\n\
+Do not repeat after the first mention.\
+";
+
 // ──────────────────────── Tool Registry ────────────────────────
 
 /// Metadata for a single MCP tool, used to generate protocol docs and CLI output.
@@ -1564,13 +1611,7 @@ impl McpMemoryServer {
 impl ServerHandler for McpMemoryServer {
     fn get_info(&self) -> ServerInfo {
         ServerInfo {
-            instructions: Some(
-                "MAG -- local memory server for AI agents.\n\n\
-                 STARTUP: Call memory_session_info(mode=\"welcome\") first to get session context.\n\
-                 REFERENCE: Call memory_session_info(mode=\"protocol\") for tool inventory.\n\
-                 DIAGNOSTICS: If issues occur, run CLI: mag doctor"
-                    .to_string(),
-            ),
+            instructions: Some(MCP_INSTRUCTIONS.to_string()),
             capabilities: ServerCapabilities::builder().enable_tools().build(),
             ..Default::default()
         }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -9,7 +9,7 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 
-use crate::config_writer::{self, ConfigWriteResult, RemoveResult, TransportMode};
+use crate::config_writer::{self, ConfigWriteResult, TransportMode};
 use crate::tool_detection::{self, DetectedTool, DetectionResult, MagConfigStatus};
 
 // ---------------------------------------------------------------------------
@@ -44,7 +44,7 @@ struct ConfigureSummary {
 /// Main entry point for `mag setup`.
 pub async fn run_setup(args: SetupArgs) -> Result<()> {
     if args.uninstall {
-        return run_uninstall(None);
+        return crate::uninstall::run_uninstall(false, true).await;
     }
 
     // Detect phase
@@ -95,13 +95,15 @@ fn present_detection(result: &DetectionResult) {
     println!("  Detected tools:\n");
     for dt in &result.detected {
         let status_icon = match &dt.mag_status {
-            MagConfigStatus::Configured => "\u{2713}",    // check mark
+            MagConfigStatus::Configured => "\u{2713}", // check mark
+            MagConfigStatus::InstalledAsPlugin => "\u{2713}", // check mark
             MagConfigStatus::NotConfigured => "\u{2717}", // X mark
             MagConfigStatus::Misconfigured(_) => "\u{26a0}", // warning
             MagConfigStatus::Unreadable(_) => "\u{26a0}", // warning
         };
         let status_label = match &dt.mag_status {
             MagConfigStatus::Configured => "configured",
+            MagConfigStatus::InstalledAsPlugin => "installed as plugin",
             MagConfigStatus::NotConfigured => "not configured",
             MagConfigStatus::Misconfigured(reason) => reason.as_str(),
             MagConfigStatus::Unreadable(reason) => reason.as_str(),
@@ -184,7 +186,12 @@ fn select_tools<'a>(
     // Filter to only unconfigured/misconfigured tools
     let actionable: Vec<&DetectedTool> = candidates
         .into_iter()
-        .filter(|dt| !matches!(dt.mag_status, MagConfigStatus::Configured))
+        .filter(|dt| {
+            !matches!(
+                dt.mag_status,
+                MagConfigStatus::Configured | MagConfigStatus::InstalledAsPlugin
+            )
+        })
         .collect();
 
     if actionable.is_empty() {
@@ -232,6 +239,26 @@ fn configure_tools(tools: &[&DetectedTool], mode: TransportMode) -> Result<Confi
 
     for tool in tools {
         let name = tool.tool.display_name().to_string();
+
+        // For Claude Code, prefer the plugin marketplace install.
+        // Fall back to MCP config if `claude` CLI is not available.
+        if tool.tool == tool_detection::AiTool::ClaudeCode {
+            match config_writer::install_claude_plugin() {
+                Ok(ConfigWriteResult::Plugin) => {
+                    summary.written.push(format!("{name} (plugin)"));
+                    continue;
+                }
+                Err(e) => {
+                    tracing::debug!(error = %e, "plugin install failed, falling back to MCP config");
+                    // Fall through to regular write_config below
+                }
+                Ok(other) => {
+                    tracing::debug!(result = ?other, "unexpected plugin install result, falling back");
+                    // Fall through
+                }
+            }
+        }
+
         match config_writer::write_config(tool, mode) {
             Ok(ConfigWriteResult::Written { backup_path }) => {
                 if let Some(ref bak) = backup_path {
@@ -249,6 +276,10 @@ fn configure_tools(tools: &[&DetectedTool], mode: TransportMode) -> Result<Confi
             Ok(ConfigWriteResult::Deferred { tool: ai_tool }) => {
                 summary.deferred.push(ai_tool.display_name().to_string());
             }
+            Ok(ConfigWriteResult::Plugin) => {
+                // Shouldn't reach here for non-Claude tools, but handle it
+                summary.written.push(format!("{name} (plugin)"));
+            }
             Err(e) => {
                 summary.errors.push((name, format!("{e:#}")));
             }
@@ -256,53 +287,6 @@ fn configure_tools(tools: &[&DetectedTool], mode: TransportMode) -> Result<Confi
     }
 
     Ok(summary)
-}
-
-// ---------------------------------------------------------------------------
-// Uninstall
-// ---------------------------------------------------------------------------
-
-fn run_uninstall(project_root: Option<&Path>) -> Result<()> {
-    println!("\n  Removing MAG from all detected tools...\n");
-
-    let result = detect_phase(project_root);
-
-    if result.detected.is_empty() {
-        println!("  No tools detected — nothing to remove.");
-        return Ok(());
-    }
-
-    let mut removed = Vec::new();
-    let mut not_present = Vec::new();
-    let mut errors = Vec::new();
-
-    for dt in &result.detected {
-        let name = dt.tool.display_name().to_string();
-        match config_writer::remove_config(dt) {
-            Ok(RemoveResult::Removed) => removed.push(name),
-            Ok(RemoveResult::NotPresent | RemoveResult::NoConfigFile) => {
-                not_present.push(name);
-            }
-            Ok(RemoveResult::UnsupportedFormat { reason }) => {
-                not_present.push(format!("{name} (skipped: {reason})"));
-            }
-            Err(e) => errors.push((name, format!("{e:#}"))),
-        }
-    }
-
-    println!("  Uninstall summary:\n");
-    for name in &removed {
-        println!("    \u{2713} {name} — removed");
-    }
-    for name in &not_present {
-        println!("    - {name} — was not configured");
-    }
-    for (name, err) in &errors {
-        println!("    \u{2717} {name} — error: {err}");
-    }
-    println!();
-
-    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -620,13 +604,22 @@ mod tests {
             let summary = configure_tools(&tools, TransportMode::Command).unwrap();
 
             assert_eq!(summary.written.len(), 1);
-            assert_eq!(summary.written[0], "Claude Code");
             assert!(summary.errors.is_empty());
 
-            // Verify the config was written
-            let content = std::fs::read_to_string(&config_path).unwrap();
-            let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
-            assert!(parsed["mcpServers"]["mag"].is_object());
+            // Claude Code may be configured via plugin (if `claude` CLI is available)
+            // or via MCP config (if not). Both are valid outcomes.
+            let name = &summary.written[0];
+            assert!(
+                name == "Claude Code" || name == "Claude Code (plugin)",
+                "unexpected written entry: {name}"
+            );
+
+            if name == "Claude Code" {
+                // Verify the MCP config was written (fallback path)
+                let content = std::fs::read_to_string(&config_path).unwrap();
+                let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+                assert!(parsed["mcpServers"]["mag"].is_object());
+            }
         });
     }
 
@@ -745,7 +738,8 @@ mod tests {
             .unwrap();
 
             // Run uninstall
-            run_uninstall(None).unwrap();
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            rt.block_on(crate::uninstall::run_uninstall(false, true)).unwrap();
 
             // Verify MAG was removed but other config preserved
             let content = std::fs::read_to_string(&config_path).unwrap();
@@ -759,7 +753,8 @@ mod tests {
     fn uninstall_no_tools_detected() {
         with_temp_home(|_home| {
             // No config files exist — should not error
-            run_uninstall(None).unwrap();
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            rt.block_on(crate::uninstall::run_uninstall(false, true)).unwrap();
         });
     }
 
@@ -816,5 +811,82 @@ mod tests {
         let tool_names: Vec<_> = selected.iter().map(|d| d.tool).collect();
         assert!(tool_names.contains(&AiTool::Cursor));
         assert!(tool_names.contains(&AiTool::Windsurf));
+    }
+
+    // -----------------------------------------------------------------------
+    // Plugin-related tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn select_tools_skips_installed_as_plugin() {
+        let result = DetectionResult {
+            detected: vec![
+                make_detected(AiTool::ClaudeCode, MagConfigStatus::InstalledAsPlugin),
+                make_detected(AiTool::Cursor, MagConfigStatus::NotConfigured),
+            ],
+            not_found: vec![],
+        };
+        let args = SetupArgs {
+            non_interactive: true,
+            tools: None,
+            transport: TransportMode::Command,
+            port: 4242,
+            no_start: true,
+            uninstall: false,
+            force: false,
+        };
+
+        let selected = select_tools(&result, &args).unwrap();
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].tool, AiTool::Cursor);
+    }
+
+    #[test]
+    fn select_tools_force_includes_plugin_installed() {
+        let result = DetectionResult {
+            detected: vec![make_detected(
+                AiTool::ClaudeCode,
+                MagConfigStatus::InstalledAsPlugin,
+            )],
+            not_found: vec![],
+        };
+        let args = SetupArgs {
+            non_interactive: true,
+            tools: None,
+            transport: TransportMode::Command,
+            port: 4242,
+            no_start: true,
+            uninstall: false,
+            force: true,
+        };
+
+        let selected = select_tools(&result, &args).unwrap();
+        assert_eq!(selected.len(), 1);
+    }
+
+    #[test]
+    fn present_detection_shows_plugin_status() {
+        let result = DetectionResult {
+            detected: vec![
+                make_detected(AiTool::ClaudeCode, MagConfigStatus::InstalledAsPlugin),
+                make_detected(AiTool::Cursor, MagConfigStatus::NotConfigured),
+            ],
+            not_found: vec![],
+        };
+        // Smoke test — should not panic
+        present_detection(&result);
+    }
+
+    #[test]
+    fn present_summary_with_plugin_entry() {
+        let summary = ConfigureSummary {
+            written: vec!["Claude Code (plugin)".to_string()],
+            already_current: vec![],
+            unsupported: vec![],
+            deferred: vec![],
+            errors: vec![],
+        };
+        // Smoke test — should not panic
+        present_summary(&summary);
     }
 }

--- a/src/tool_detection.rs
+++ b/src/tool_detection.rs
@@ -106,6 +106,8 @@ pub enum MagConfigStatus {
     Misconfigured(String),
     /// Config file exists but could not be read or parsed.
     Unreadable(String),
+    /// MAG is installed as a native plugin (not just MCP config).
+    InstalledAsPlugin,
 }
 
 /// Information about a single detected AI tool installation.
@@ -247,6 +249,13 @@ fn detect_tool_with_home(
     let paths = config_paths_for_tool(tool, home, project_root);
     let mut results = Vec::new();
 
+    // For Claude Code, check if the plugin is installed (takes priority over MCP config).
+    let plugin_installed = if tool == AiTool::ClaudeCode {
+        check_claude_plugin_installed(home)
+    } else {
+        false
+    };
+
     for (path, scope) in paths {
         tracing::debug!(tool = %tool.display_name(), path = %path.display(), "checking config path");
 
@@ -254,13 +263,17 @@ fn detect_tool_with_home(
             continue;
         }
 
-        let mag_status = match tool.config_format() {
-            ConfigFormat::Json => {
-                let parent_key = mcp_key_for_tool(tool);
-                let server_names = server_names_for_tool(tool);
-                check_mag_in_json(&path, server_names, parent_key, tool == AiTool::Zed)
+        let mag_status = if plugin_installed {
+            MagConfigStatus::InstalledAsPlugin
+        } else {
+            match tool.config_format() {
+                ConfigFormat::Json => {
+                    let parent_key = mcp_key_for_tool(tool);
+                    let server_names = server_names_for_tool(tool);
+                    check_mag_in_json(&path, server_names, parent_key, tool == AiTool::Zed)
+                }
+                ConfigFormat::Toml => check_mag_in_toml(&path),
             }
-            ConfigFormat::Toml => check_mag_in_toml(&path),
         };
 
         results.push(DetectedTool {
@@ -271,11 +284,57 @@ fn detect_tool_with_home(
         });
     }
 
+    // If the plugin is installed but no config file was found, still report
+    // Claude Code as detected with InstalledAsPlugin status.
+    if results.is_empty() && plugin_installed {
+        let fallback_path = home.join(".claude/settings.json");
+        results.push(DetectedTool {
+            tool,
+            config_path: fallback_path,
+            scope: ConfigScope::Global,
+            mag_status: MagConfigStatus::InstalledAsPlugin,
+        });
+    }
+
     if results.is_empty() {
         tracing::debug!(tool = %tool.display_name(), "not found at any known path");
     }
 
     results
+}
+
+/// Checks whether the MAG plugin is installed in Claude Code by reading
+/// `~/.claude/settings.json` and looking for `"mag@mag-plugins": true` in
+/// the `enabledPlugins` object.
+fn check_claude_plugin_installed(home: &Path) -> bool {
+    let settings_path = home.join(".claude/settings.json");
+    if !settings_path.exists() {
+        return false;
+    }
+
+    let content = match std::fs::read_to_string(&settings_path) {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::debug!(path = %settings_path.display(), error = %e, "failed to read claude settings");
+            return false;
+        }
+    };
+
+    let content = content.strip_prefix('\u{FEFF}').unwrap_or(&content);
+
+    let parsed: serde_json::Value = match serde_json::from_str(content) {
+        Ok(v) => v,
+        Err(e) => {
+            tracing::debug!(error = %e, "failed to parse claude settings.json");
+            return false;
+        }
+    };
+
+    parsed
+        .get("enabledPlugins")
+        .and_then(|v| v.get("mag@mag-plugins"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
 }
 
 /// Returns the candidate server names to look for in a tool's config.
@@ -1067,5 +1126,108 @@ mod tests {
             };
             assert_eq!(tool.config_format(), expected);
         }
+    }
+
+    // -- Plugin detection (InstalledAsPlugin) --
+
+    #[test]
+    #[serial]
+    fn detects_claude_code_installed_as_plugin() {
+        with_temp_home(|home| {
+            // Create the .claude.json config file (so Claude Code is "detected")
+            std::fs::write(home.join(".claude.json"), r#"{"mcpServers": {}}"#).unwrap();
+
+            // Create the settings.json with plugin enabled
+            let claude_dir = home.join(".claude");
+            std::fs::create_dir_all(&claude_dir).unwrap();
+            std::fs::write(
+                claude_dir.join("settings.json"),
+                r#"{"enabledPlugins": {"mag@mag-plugins": true}}"#,
+            )
+            .unwrap();
+
+            let result = detect_tool(AiTool::ClaudeCode, None);
+            assert!(!result.is_empty());
+            assert_eq!(result[0].mag_status, MagConfigStatus::InstalledAsPlugin);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn plugin_status_takes_priority_over_mcp_config() {
+        with_temp_home(|home| {
+            // Both MCP config AND plugin are set up
+            std::fs::write(
+                home.join(".claude.json"),
+                r#"{"mcpServers": {"mag": {"command": "mag", "args": ["serve"]}}}"#,
+            )
+            .unwrap();
+
+            let claude_dir = home.join(".claude");
+            std::fs::create_dir_all(&claude_dir).unwrap();
+            std::fs::write(
+                claude_dir.join("settings.json"),
+                r#"{"enabledPlugins": {"mag@mag-plugins": true}}"#,
+            )
+            .unwrap();
+
+            let result = detect_tool(AiTool::ClaudeCode, None);
+            assert!(!result.is_empty());
+            // Plugin should take priority
+            assert_eq!(result[0].mag_status, MagConfigStatus::InstalledAsPlugin);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn disabled_plugin_falls_back_to_mcp_check() {
+        with_temp_home(|home| {
+            std::fs::write(home.join(".claude.json"), r#"{"mcpServers": {}}"#).unwrap();
+
+            let claude_dir = home.join(".claude");
+            std::fs::create_dir_all(&claude_dir).unwrap();
+            std::fs::write(
+                claude_dir.join("settings.json"),
+                r#"{"enabledPlugins": {"mag@mag-plugins": false}}"#,
+            )
+            .unwrap();
+
+            let result = detect_tool(AiTool::ClaudeCode, None);
+            assert!(!result.is_empty());
+            // Plugin is disabled, so falls back to MCP check
+            assert_eq!(result[0].mag_status, MagConfigStatus::NotConfigured);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn non_claude_tool_ignores_plugin_settings() {
+        with_temp_home(|home| {
+            // Set up Cursor config
+            let cursor_dir = home.join(".cursor");
+            std::fs::create_dir_all(&cursor_dir).unwrap();
+            std::fs::write(cursor_dir.join("mcp.json"), r#"{"mcpServers": {}}"#).unwrap();
+
+            // Also set up a plugin settings file (should be ignored for Cursor)
+            let claude_dir = home.join(".claude");
+            std::fs::create_dir_all(&claude_dir).unwrap();
+            std::fs::write(
+                claude_dir.join("settings.json"),
+                r#"{"enabledPlugins": {"mag@mag-plugins": true}}"#,
+            )
+            .unwrap();
+
+            let result = detect_tool(AiTool::Cursor, None);
+            assert!(!result.is_empty());
+            // Cursor should not be affected by Claude Code plugin settings
+            assert_eq!(result[0].mag_status, MagConfigStatus::NotConfigured);
+        });
+    }
+
+    #[test]
+    fn installed_as_plugin_variant_serializes() {
+        let status = MagConfigStatus::InstalledAsPlugin;
+        let serialized = serde_json::to_string(&status).unwrap();
+        assert!(serialized.contains("InstalledAsPlugin"));
     }
 }

--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -1,0 +1,635 @@
+//! Comprehensive uninstall command for MAG.
+//!
+//! Removes tool configurations, downloaded models, the database, and
+//! the `~/.mag` data directory. Supports interactive, `--all`, and
+//! `--configs-only` modes.
+
+use std::io::{self, BufRead, IsTerminal, Write};
+use std::path::Path;
+
+use anyhow::{Context, Result};
+
+use crate::app_paths;
+use crate::config_writer::{self, RemoveResult};
+use crate::tool_detection;
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Runs the uninstall flow.
+///
+/// * `all` — skip prompts and remove everything including the database.
+/// * `configs_only` — skip prompts and only remove tool configurations.
+pub async fn run_uninstall(all: bool, configs_only: bool) -> Result<()> {
+    let paths = app_paths::resolve_app_paths()?;
+
+    let mut choices = if configs_only {
+        UninstallChoices {
+            tool_configs: true,
+            models: false,
+            database: false,
+        }
+    } else if all || is_non_interactive() {
+        UninstallChoices {
+            tool_configs: true,
+            models: true,
+            database: all, // non-TTY without --all refuses database deletion
+        }
+    } else {
+        prompt_choices(&paths)?
+    };
+
+    if choices.database && !all && !confirm_database_deletion()? {
+        println!("\n  Database deletion cancelled. Other selected items will still be removed.\n");
+        choices.database = false;
+    }
+
+    let mut summary = UninstallSummary::default();
+
+    if choices.tool_configs {
+        summary.tool_configs = Some(remove_tool_configs());
+    }
+    if choices.models {
+        summary.models = Some(remove_directory(&paths.model_root));
+    }
+    if choices.database {
+        summary.database = Some(remove_file(&paths.database_path));
+        // WAL/SHM sidecars left by SQLite
+        for ext in &["db-wal", "db-shm"] {
+            let p = paths.database_path.with_extension(ext);
+            if let Err(e) = std::fs::remove_file(&p)
+                && e.kind() != io::ErrorKind::NotFound
+            {
+                tracing::warn!(path = %p.display(), err = %e, "failed to remove sidecar");
+            }
+        }
+    }
+    if choices.models || choices.database {
+        summary.benchmarks = Some(remove_directory(&paths.benchmark_root));
+    }
+
+    let data_root_removed = if choices.models || choices.database {
+        try_remove_empty_dir(&paths.data_root)
+    } else {
+        false
+    };
+
+    println!("\n  Uninstall summary:\n");
+
+    if let Some(ref tc) = summary.tool_configs {
+        match tc {
+            ToolConfigResult::Removed { count, errors } => {
+                if *count > 0 {
+                    println!(
+                        "    \u{2713} Tool configurations \u{2014} removed from {count} tool{}",
+                        if *count == 1 { "" } else { "s" }
+                    );
+                }
+                for (name, err) in errors {
+                    println!("    \u{2717} {name} \u{2014} error: {err}");
+                }
+            }
+            ToolConfigResult::NoneFound => {
+                println!("    - Tool configurations \u{2014} none detected");
+            }
+        }
+    }
+
+    if let Some(ref r) = summary.models {
+        print_remove_outcome("Models directory", r);
+    }
+    if let Some(ref r) = summary.database {
+        print_remove_outcome("Database", r);
+    }
+    if let Some(ref r) = summary.benchmarks {
+        print_remove_outcome("Benchmarks cache", r);
+    }
+
+    println!();
+    if data_root_removed {
+        println!(
+            "  MAG data directory {} has been removed.",
+            paths.data_root.display()
+        );
+    }
+    println!("  To reinstall, run: cargo install mag-memory\n");
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+struct UninstallChoices {
+    tool_configs: bool,
+    models: bool,
+    database: bool,
+}
+
+#[derive(Default)]
+struct UninstallSummary {
+    tool_configs: Option<ToolConfigResult>,
+    models: Option<RemoveOutcome>,
+    database: Option<RemoveOutcome>,
+    benchmarks: Option<RemoveOutcome>,
+}
+
+enum ToolConfigResult {
+    Removed {
+        count: usize,
+        errors: Vec<(String, String)>,
+    },
+    NoneFound,
+}
+
+#[derive(Debug)]
+enum RemoveOutcome {
+    Removed { size: u64 },
+    NotFound,
+    Error(String),
+}
+
+fn print_remove_outcome(label: &str, outcome: &RemoveOutcome) {
+    match outcome {
+        RemoveOutcome::Removed { size } => {
+            println!(
+                "    \u{2713} {label} \u{2014} removed ({} freed)",
+                format_size(*size)
+            );
+        }
+        RemoveOutcome::NotFound => {
+            println!("    - {label} \u{2014} not found");
+        }
+        RemoveOutcome::Error(e) => {
+            println!("    \u{2717} {label} \u{2014} error: {e}");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Interactive prompts
+// ---------------------------------------------------------------------------
+
+fn read_line() -> Result<String> {
+    let mut line = String::new();
+    io::stdin()
+        .lock()
+        .read_line(&mut line)
+        .context("reading user input")?;
+    Ok(line)
+}
+
+fn prompt_choices(paths: &app_paths::AppPaths) -> Result<UninstallChoices> {
+    println!("\n  MAG Uninstall\n");
+    println!("  What would you like to remove?\n");
+
+    println!("    [1] Tool configurations (Claude Code, Cursor, VS Code, ...)");
+
+    let models_label = path_size_label(&paths.model_root);
+    println!("    [2] Downloaded models (~/.mag/models/, {models_label})");
+
+    let db_label = path_size_label(&paths.database_path);
+    println!("    [3] Database and all memories (~/.mag/memory.db, {db_label})");
+    println!(
+        "        \u{26a0}  This permanently deletes all stored memories, sessions, and relationships."
+    );
+
+    println!();
+    println!("    [A] All of the above");
+    println!();
+
+    print!("  Enter choices (comma-separated, e.g. 1,2 or A): ");
+    io::stdout().flush().context("flushing stdout")?;
+
+    let trimmed = read_line()?.trim().to_lowercase();
+
+    if trimmed.is_empty() {
+        println!("  No choices selected. Nothing to do.");
+        return Ok(UninstallChoices {
+            tool_configs: false,
+            models: false,
+            database: false,
+        });
+    }
+
+    if trimmed == "a" || trimmed == "all" {
+        return Ok(UninstallChoices {
+            tool_configs: true,
+            models: true,
+            database: true,
+        });
+    }
+
+    let mut choices = UninstallChoices {
+        tool_configs: false,
+        models: false,
+        database: false,
+    };
+
+    for part in trimmed.split(',') {
+        match part.trim() {
+            "1" => choices.tool_configs = true,
+            "2" => choices.models = true,
+            "3" => choices.database = true,
+            other => {
+                println!("  Unknown choice: {other}");
+            }
+        }
+    }
+
+    Ok(choices)
+}
+
+fn confirm_database_deletion() -> Result<bool> {
+    println!();
+    println!("  \u{26a0}  WARNING: This will permanently delete your MAG database containing all");
+    println!("  memories, sessions, and relationships. This cannot be undone.");
+    println!();
+    print!("  Type \"delete my memories\" to confirm: ");
+    io::stdout().flush().context("flushing stdout")?;
+
+    Ok(read_line()?.trim() == "delete my memories")
+}
+
+// ---------------------------------------------------------------------------
+// Removal helpers
+// ---------------------------------------------------------------------------
+
+fn remove_tool_configs() -> ToolConfigResult {
+    let result = tool_detection::detect_all_tools(None);
+
+    if result.detected.is_empty() {
+        return ToolConfigResult::NoneFound;
+    }
+
+    let mut removed_count: usize = 0;
+    let mut errors: Vec<(String, String)> = Vec::new();
+    for dt in &result.detected {
+        let name = dt.tool.display_name().to_string();
+
+        // For Claude Code, also try to remove the plugin.
+        if dt.tool == tool_detection::AiTool::ClaudeCode {
+            match config_writer::remove_claude_plugin() {
+                Ok(RemoveResult::Removed) => {
+                    tracing::debug!("claude plugin removed");
+                }
+                Ok(_) => {
+                    tracing::debug!("claude plugin was not installed");
+                }
+                Err(e) => {
+                    tracing::debug!(error = %e, "claude plugin removal failed (claude CLI may not be installed)");
+                }
+            }
+        }
+
+        match config_writer::remove_config(dt) {
+            Ok(RemoveResult::Removed) => {
+                tracing::debug!(tool = %name, "removed config");
+                removed_count += 1;
+            }
+            Ok(RemoveResult::UnsupportedFormat { reason }) => {
+                tracing::warn!(tool = %name, reason = %reason, "unsupported config format");
+                errors.push((name, format!("unsupported format: {reason}")));
+            }
+            Ok(_) => {
+                tracing::debug!(tool = %name, "config not present");
+            }
+            Err(e) => {
+                tracing::warn!(tool = %name, err = %e, "failed to remove config");
+                errors.push((name, format!("{e:#}")));
+            }
+        }
+    }
+
+    if removed_count == 0 && errors.is_empty() {
+        ToolConfigResult::NoneFound
+    } else {
+        ToolConfigResult::Removed {
+            count: removed_count,
+            errors,
+        }
+    }
+}
+
+fn remove_directory(path: &Path) -> RemoveOutcome {
+    let size = dir_size(path);
+    match std::fs::remove_dir_all(path) {
+        Ok(()) => RemoveOutcome::Removed { size },
+        Err(e) if e.kind() == io::ErrorKind::NotFound => RemoveOutcome::NotFound,
+        Err(e) => RemoveOutcome::Error(format!("{e:#}")),
+    }
+}
+
+fn remove_file(path: &Path) -> RemoveOutcome {
+    let size = path.metadata().map(|m| m.len()).unwrap_or(0);
+    match std::fs::remove_file(path) {
+        Ok(()) => RemoveOutcome::Removed { size },
+        Err(e) if e.kind() == io::ErrorKind::NotFound => RemoveOutcome::NotFound,
+        Err(e) => RemoveOutcome::Error(format!("{e:#}")),
+    }
+}
+
+/// Attempts to remove a directory only if it is empty (or contains only empty
+/// subdirectories). Returns `true` if the directory was removed.
+fn try_remove_empty_dir(path: &Path) -> bool {
+    if !path.exists() {
+        return false;
+    }
+    if is_dir_effectively_empty(path) {
+        std::fs::remove_dir_all(path).is_ok()
+    } else {
+        false
+    }
+}
+
+/// Returns `true` if a directory is empty or contains only empty subdirectories.
+/// Treats unreadable entries as non-empty (safe default — won't delete what we can't inspect).
+fn is_dir_effectively_empty(path: &Path) -> bool {
+    let entries = match std::fs::read_dir(path) {
+        Ok(e) => e,
+        Err(_) => return false,
+    };
+    for entry in entries {
+        let Ok(entry) = entry else { return false };
+        let ft = match entry.file_type() {
+            Ok(ft) => ft,
+            Err(_) => return false,
+        };
+        if ft.is_file() || ft.is_symlink() {
+            return false;
+        }
+        if ft.is_dir() && !is_dir_effectively_empty(&entry.path()) {
+            return false;
+        }
+    }
+    true
+}
+
+// ---------------------------------------------------------------------------
+// Size helpers
+// ---------------------------------------------------------------------------
+
+fn dir_size(path: &Path) -> u64 {
+    let Ok(entries) = std::fs::read_dir(path) else {
+        return 0;
+    };
+    let mut total: u64 = 0;
+    for entry in entries.flatten() {
+        let Ok(ft) = entry.file_type() else { continue };
+        if ft.is_file() {
+            total += entry.metadata().map(|m| m.len()).unwrap_or(0);
+        } else if ft.is_dir() {
+            total += dir_size(&entry.path());
+        }
+    }
+    total
+}
+
+#[allow(clippy::cast_precision_loss)] // display-only formatting; precision loss is negligible
+fn format_size(bytes: u64) -> String {
+    const KB: u64 = 1024;
+    const MB: u64 = 1024 * KB;
+    const GB: u64 = 1024 * MB;
+
+    if bytes >= GB {
+        format!("{:.1} GB", bytes as f64 / GB as f64)
+    } else if bytes >= MB {
+        format!("{:.1} MB", bytes as f64 / MB as f64)
+    } else if bytes >= KB {
+        format!("{} KB", bytes / KB)
+    } else {
+        format!("{bytes} B")
+    }
+}
+
+fn path_size_label(path: &Path) -> String {
+    if !path.exists() {
+        return "(not found)".to_string();
+    }
+    if path.is_dir() {
+        format_size(dir_size(path))
+    } else {
+        format_size(path.metadata().map(|m| m.len()).unwrap_or(0))
+    }
+}
+
+fn is_non_interactive() -> bool {
+    !io::stdin().is_terminal()
+        || std::env::var_os("CI").is_some()
+        || std::env::var_os("GITHUB_ACTIONS").is_some()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_helpers::with_temp_home;
+
+    // -----------------------------------------------------------------------
+    // format_size
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn format_size_bytes() {
+        assert_eq!(format_size(0), "0 B");
+        assert_eq!(format_size(512), "512 B");
+        assert_eq!(format_size(1023), "1023 B");
+    }
+
+    #[test]
+    fn format_size_kilobytes() {
+        assert_eq!(format_size(1024), "1 KB");
+        assert_eq!(format_size(340 * 1024), "340 KB");
+    }
+
+    #[test]
+    fn format_size_megabytes() {
+        assert_eq!(format_size(1024 * 1024), "1.0 MB");
+        assert_eq!(format_size(2_200_000), "2.1 MB");
+    }
+
+    #[test]
+    fn format_size_gigabytes() {
+        assert_eq!(format_size(1024 * 1024 * 1024), "1.0 GB");
+    }
+
+    // -----------------------------------------------------------------------
+    // dir_size
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn dir_size_empty() {
+        let dir = std::env::temp_dir().join(format!("mag-dirsize-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        assert_eq!(dir_size(&dir), 0);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn dir_size_with_files() {
+        let dir = std::env::temp_dir().join(format!("mag-dirsize-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(dir.join("sub")).unwrap();
+        std::fs::write(dir.join("a.txt"), "hello").unwrap(); // 5 bytes
+        std::fs::write(dir.join("sub/b.txt"), "world!").unwrap(); // 6 bytes
+        assert_eq!(dir_size(&dir), 11);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn dir_size_nonexistent() {
+        let dir = std::env::temp_dir().join("mag-dirsize-nonexistent");
+        assert_eq!(dir_size(&dir), 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // path_size_label
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn path_size_label_not_found() {
+        let p = std::env::temp_dir().join("mag-label-nonexistent");
+        assert_eq!(path_size_label(&p), "(not found)");
+    }
+
+    // -----------------------------------------------------------------------
+    // remove_directory / remove_file
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn remove_directory_not_found() {
+        let p = std::env::temp_dir().join("mag-rm-nonexistent");
+        assert!(matches!(remove_directory(&p), RemoveOutcome::NotFound));
+    }
+
+    #[test]
+    fn remove_directory_success() {
+        let dir = std::env::temp_dir().join(format!("mag-rmdir-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("f.txt"), "data").unwrap();
+        match remove_directory(&dir) {
+            RemoveOutcome::Removed { size } => assert_eq!(size, 4),
+            other => panic!("Expected Removed, got {other:?}"),
+        }
+        assert!(!dir.exists());
+    }
+
+    #[test]
+    fn remove_file_not_found() {
+        let p = std::env::temp_dir().join("mag-rmfile-nonexistent");
+        assert!(matches!(remove_file(&p), RemoveOutcome::NotFound));
+    }
+
+    #[test]
+    fn remove_file_success() {
+        let dir = std::env::temp_dir().join(format!("mag-rmfile-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let f = dir.join("test.db");
+        std::fs::write(&f, "database").unwrap();
+        match remove_file(&f) {
+            RemoveOutcome::Removed { size } => assert_eq!(size, 8),
+            other => panic!("Expected Removed, got {other:?}"),
+        }
+        assert!(!f.exists());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // -----------------------------------------------------------------------
+    // remove_tool_configs
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn remove_tool_configs_with_configured_tool() {
+        with_temp_home(|home| {
+            // Create a Claude Code config with MAG
+            let config_path = home.join(".claude.json");
+            std::fs::write(
+                &config_path,
+                r#"{"mcpServers":{"mag":{"command":"mag","args":["serve"]},"other":{}}}"#,
+            )
+            .unwrap();
+
+            let result = remove_tool_configs();
+            match result {
+                ToolConfigResult::Removed { count, errors } => {
+                    assert!(count >= 1, "expected at least 1 removal");
+                    assert!(errors.is_empty(), "expected no errors: {errors:?}");
+                }
+                ToolConfigResult::NoneFound => panic!("expected tool config removal"),
+            }
+
+            // Verify MAG was removed but other config preserved
+            let content = std::fs::read_to_string(&config_path).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+            assert!(parsed["mcpServers"]["mag"].is_null());
+            assert!(parsed["mcpServers"]["other"].is_object());
+        });
+    }
+
+    #[test]
+    fn remove_tool_configs_no_tools() {
+        with_temp_home(|_home| {
+            let result = remove_tool_configs();
+            assert!(matches!(result, ToolConfigResult::NoneFound));
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // try_remove_empty_dir
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn try_remove_empty_dir_removes_empty() {
+        let dir = std::env::temp_dir().join(format!("mag-tryrmdir-{}", uuid::Uuid::new_v4()));
+        std::fs::create_dir_all(&dir).unwrap();
+        assert!(try_remove_empty_dir(&dir));
+        assert!(!dir.exists());
+    }
+
+    #[test]
+    fn try_remove_empty_dir_nonexistent() {
+        let dir = std::env::temp_dir().join("mag-tryrmdir-nonexistent");
+        assert!(!try_remove_empty_dir(&dir));
+    }
+
+    // -----------------------------------------------------------------------
+    // Integration: full uninstall with temp home
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn integration_configs_only_preserves_data() {
+        with_temp_home(|home| {
+            // Create fake data
+            let mag_dir = home.join(".mag");
+            std::fs::create_dir_all(mag_dir.join("models")).unwrap();
+            std::fs::write(mag_dir.join("models/model.onnx"), "model data").unwrap();
+            std::fs::write(mag_dir.join("memory.db"), "database").unwrap();
+
+            // Create a Claude Code config with MAG
+            let config_path = home.join(".claude.json");
+            std::fs::write(
+                &config_path,
+                r#"{"mcpServers":{"mag":{"command":"mag","args":["serve"]}}}"#,
+            )
+            .unwrap();
+
+            // Run configs_only
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            rt.block_on(run_uninstall(false, true)).unwrap();
+
+            // Data should still exist
+            assert!(mag_dir.join("models/model.onnx").exists());
+            assert!(mag_dir.join("memory.db").exists());
+
+            // MAG config should be removed
+            let content = std::fs::read_to_string(&config_path).unwrap();
+            let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+            assert!(parsed["mcpServers"]["mag"].is_null());
+        });
+    }
+
+}


### PR DESCRIPTION
## Summary

- **`mag uninstall`**: New command with interactive mode, `--all`, and `--configs-only` flags. Removes tool configs, models, database, and WAL sidecars. Database deletion requires typing "delete my memories" for safety (bypassed with `--all`).
- **Claude Code plugin marketplace**: `mag setup` now installs MAG as a proper Claude Code plugin via `claude plugin marketplace add George-RD/mag-plugins` + `claude plugin install mag@mag-plugins`, falling back to MCP config if `claude` CLI not found.
- **Plugin detection**: New `InstalledAsPlugin` status in tool detection — takes priority over MCP config check.
- **Unified uninstall**: `setup --uninstall` now delegates to the uninstall module (single code path).

### Review fixes (from /simplify)
- `--all` now bypasses database confirmation prompt in CI/non-TTY environments
- Per-tool removal errors surfaced in uninstall summary (previously swallowed)
- TOCTOU fix: `remove_directory` operates directly instead of check-then-act
- `is_dir_effectively_empty` treats unreadable entries as non-empty (safe default)

## Test plan
- [ ] Run `mag setup` — verify Claude Code shows "installed as plugin" when plugin is present
- [ ] Run `mag setup` without `claude` CLI — verify fallback to MCP config
- [ ] Run `mag uninstall --configs-only` — verify only tool configs removed, data preserved
- [ ] Run `mag uninstall --all` in non-TTY — verify database deletion proceeds without prompt
- [ ] Run `mag uninstall` interactively — verify prompt flow and "delete my memories" confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an uninstall command with --all and --configs-only options, interactive prompts, and a clear human-readable uninstall summary.
  * Added Claude Code plugin support so MAG can be installed/recognized as a native plugin.
  * Improved tool detection to treat plugin-installed MAG as already configured.

* **Tests**
  * Expanded tests for uninstall flows, plugin detection, and related presentation/summary behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->