### PR TITLE
chore: bump version to 0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,7 +1240,7 @@ checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
 name = "mag-memory"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mag-memory"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2024"
 autobenches = false
 license = "MIT"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mag-memory",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "MAG — Memory Augmented Generation. Local MCP memory server with ONNX embeddings.",
   "license": "MIT",
   "repository": {

--- a/python/mag_memory/__init__.py
+++ b/python/mag_memory/__init__.py
@@ -11,10 +11,10 @@ import subprocess
 import sys
 
 
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 
 # Version of the Rust binary to download (kept in sync with __version__)
-_BINARY_VERSION = "0.1.3"
+_BINARY_VERSION = "0.1.4"
 
 
 def _binary_dir():

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mag-memory"
-version = "0.1.3"
+version = "0.1.4"
 description = "PyPI wrapper for the mag MCP memory server (Rust binary)"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Bump version to 0.1.4 across Cargo.toml, npm/package.json, python/pyproject.toml, and python __init__.py

Follows #160 (mag uninstall + Claude Code plugin marketplace support).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.1.4 across all package distributions (Rust, npm, and Python).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->