### PR TITLE
fix: address CodeRabbit review round 2 + fmt

### DIFF
--- a/src/config_writer.rs
+++ b/src/config_writer.rs
@@ -400,7 +400,11 @@ pub fn remove_claude_plugin() -> Result<RemoveResult> {
             tracing::debug!("plugin not installed, treating as not-present");
             Ok(RemoveResult::NotPresent)
         } else {
-            anyhow::bail!("claude plugin uninstall failed (exit {}): {}", output.status, stderr.trim())
+            anyhow::bail!(
+                "claude plugin uninstall failed (exit {}): {}",
+                output.status,
+                stderr.trim()
+            )
         }
     }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -739,7 +739,8 @@ mod tests {
 
             // Run uninstall
             let rt = tokio::runtime::Runtime::new().unwrap();
-            rt.block_on(crate::uninstall::run_uninstall(false, true)).unwrap();
+            rt.block_on(crate::uninstall::run_uninstall(false, true))
+                .unwrap();
 
             // Verify MAG was removed but other config preserved
             let content = std::fs::read_to_string(&config_path).unwrap();
@@ -754,7 +755,8 @@ mod tests {
         with_temp_home(|_home| {
             // No config files exist — should not error
             let rt = tokio::runtime::Runtime::new().unwrap();
-            rt.block_on(crate::uninstall::run_uninstall(false, true)).unwrap();
+            rt.block_on(crate::uninstall::run_uninstall(false, true))
+                .unwrap();
         });
     }
 

--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -631,5 +631,4 @@ mod tests {
             assert!(parsed["mcpServers"]["mag"].is_null());
         });
     }
-
 }


### PR DESCRIPTION
## Summary
- Fix trailing whitespace caught by `cargo fmt`
- Fixes from CR round 2 that weren't in the squash merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code formatting improvements and cleanup to enhance maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->