### PR TITLE
feat: add PostToolUse error-capture hook for build/test failures

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -41,6 +41,11 @@
             "type": "command",
             "command": "${CLAUDE_PLUGIN_ROOT}/scripts/commit-capture.sh",
             "timeout": 4000
+          },
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/scripts/error-capture.sh",
+            "timeout": 4000
           }
         ]
       }

--- a/plugin/scripts/error-capture.sh
+++ b/plugin/scripts/error-capture.sh
@@ -1,0 +1,65 @@
+#!/bin/sh
+# MAG error-capture — auto-capture build/test failures as error_pattern memories
+# PostToolUse(Bash) hook. MUST exit fast (<50ms) for non-matching commands.
+# Receives: $CLAUDE_TOOL_INPUT (command JSON), $CLAUDE_TOOL_OUTPUT (output JSON)
+set -eu
+
+# Fast-path: only process build/test commands
+TOOL_INPUT="${CLAUDE_TOOL_INPUT:-}"
+case "$TOOL_INPUT" in
+  *"cargo test"*|*"cargo build"*|*"cargo check"*|*"cargo clippy"*|*"npm test"*|*"npm run"*|*"prek run"*)
+    ;; # fall through to failure detection
+  *)
+    exit 0
+    ;;
+esac
+
+# Check output for failure signals
+TOOL_OUTPUT="${CLAUDE_TOOL_OUTPUT:-}"
+case "$TOOL_OUTPUT" in
+  *"FAILED"*|*"error["*|*"error: "*|*"npm ERR!"*)
+    ;; # fall through to error extraction
+  *)
+    exit 0
+    ;;
+esac
+
+# Extract first error line (Rust-style: starts with "error[E0XXX]:" or "error: ")
+ERROR_LINE=$(printf '%s' "$TOOL_OUTPUT" | grep -m1 -E '^error(\[E[0-9]+\])?: ' 2>/dev/null || true)
+
+# Fallback: npm-style errors
+if [ -z "$ERROR_LINE" ]; then
+  ERROR_LINE=$(printf '%s' "$TOOL_OUTPUT" | grep -m1 'npm ERR!' 2>/dev/null || true)
+fi
+
+# Fallback: first line containing FAILED
+if [ -z "$ERROR_LINE" ]; then
+  ERROR_LINE=$(printf '%s' "$TOOL_OUTPUT" | grep -m1 'FAILED' 2>/dev/null || true)
+fi
+
+# Nothing extracted — bail
+[ -n "$ERROR_LINE" ] || exit 0
+
+# Truncate to avoid oversized memory content
+ERROR_LINE="$(printf '%.200s' "$ERROR_LINE")"
+
+# Derive project and session (after fast-path so non-build commands skip this)
+PROJECT="$(basename "$PWD")"
+SESSION_ID="${CLAUDE_SESSION_ID:-unknown}"
+LOG="$HOME/.mag/auto-capture.log"
+
+# Telemetry: log BEFORE mag invocation
+# Note: hooks in the same array run sequentially, so no flock needed vs commit-capture
+mkdir -p "$HOME/.mag"
+printf '%s [error-capture] project=%s error=%s\n' \
+  "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date +%s)" \
+  "$PROJECT" \
+  "$ERROR_LINE" \
+  >> "$LOG" 2>/dev/null || true
+
+mag process "Build/test error in $PROJECT: $ERROR_LINE" \
+  --event-type error_pattern \
+  --project "$PROJECT" \
+  --session-id "$SESSION_ID" \
+  --importance 0.5 \
+  2>/dev/null || true

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -323,6 +323,12 @@ pub enum Commands {
         session_id: Option<String>,
         #[arg(long)]
         project: Option<String>,
+        #[arg(long)]
+        budget_tokens: Option<usize>,
+        #[arg(long)]
+        agent_type: Option<String>,
+        #[arg(long)]
+        entity_id: Option<String>,
     },
     /// Show available tools and operational guidelines.
     Protocol {


### PR DESCRIPTION
## Summary
- Adds `error-capture.sh` as a second entry in the existing PostToolUse Bash hooks array (alongside `commit-capture.sh` from #170)
- Auto-captures `cargo test/build/check/clippy` and `npm test/run` failures as `error_pattern` memories
- Fast-path exit (<50ms) for non-build Bash commands
- Only stores on failure signals (`FAILED`, `error[E0XXX]`, `error:`) — passing builds are ignored
- `error_pattern` type has permanent TTL and type_weight 2.0 — errors persist and rank well
- Telemetry logged to `~/.mag/auto-capture.log` before `mag` invocation

## Wave 1 Unit C — Issue #164
**Depends on:** #170 (Unit B: commit-capture hook)

## Test plan
- [ ] Failing `cargo test` → `mag search "error"` returns `error_pattern` memory
- [ ] Passing `cargo test` → no new memory stored
- [ ] Non-build Bash calls fast-exit without storage
- [ ] `cat ~/.mag/auto-capture.log` shows `error_pattern` entries on failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic error capture for build/test commands: first failure lines are truncated, timestamped, and recorded with project/session metadata for later processing.

* **Chores**
  * Hook configuration updated to invoke the new error-capture action alongside existing commit tracking for Bash tool runs.

* **Documentation**
  * CLI examples and prompt hints updated to use mag process, mag advanced-search (with limits), mag recent, and mag checkpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->