### PR TITLE
feat(bench): add Hit@1/3/5 metrics to LoCoMo benchmark suite

### DIFF
--- a/benches/locomo/scoring.rs
+++ b/benches/locomo/scoring.rs
@@ -937,4 +937,42 @@ mod tests {
             "retrieval-only adversarial always 1.0, got {score}"
         );
     }
+
+    // ── hit_at_k tests ──────────────────────────────────────────────────
+
+    fn make_hit(dia_id: &str) -> RetrievalHit {
+        RetrievalHit {
+            content: "c".to_string(),
+            score: 0.5,
+            metadata: serde_json::json!({"dia_id": dia_id}),
+        }
+    }
+
+    #[test]
+    fn test_hit_at_k_top1() {
+        let hits = vec![make_hit("d1"), make_hit("d2"), make_hit("d3")];
+        let gold = vec!["d1".to_string()];
+        assert!(hit_at_k(&hits, &gold, 1));
+    }
+
+    #[test]
+    fn test_hit_at_k_miss_at_1_hit_at_5() {
+        let hits = vec![make_hit("a"), make_hit("b"), make_hit("c"), make_hit("d1")];
+        let gold = vec!["d1".to_string()];
+        assert!(!hit_at_k(&hits, &gold, 3));
+        assert!(hit_at_k(&hits, &gold, 5));
+    }
+
+    #[test]
+    fn test_hit_at_k_empty_gold_is_true() {
+        let hits = vec![make_hit("a")];
+        assert!(hit_at_k(&hits, &[], 1));
+    }
+
+    #[test]
+    fn test_hit_at_k_k_exceeds_hits_len() {
+        let hits = vec![make_hit("d1")];
+        let gold = vec!["d1".to_string()];
+        assert!(hit_at_k(&hits, &gold, 100));
+    }
 }


### PR DESCRIPTION
## Summary
- Adds `hit_at_k()` function to `benches/locomo/scoring.rs` — checks if top-K retrieved results match gold evidence
- Adds Hit@1, Hit@3, Hit@5 counters to `CategoryResult` and fractions to `LoCoMoSummary`
- Computes and displays Hit@K alongside existing metrics in benchmark output

## Wave 2 Unit H — Issue #165

## Test plan
- [ ] `cargo check` passes for benchmark code
- [ ] `cargo run --release --bin locomo_bench -- --samples 2` outputs Hit@1/3/5 metrics
- [ ] Existing retrieval metric unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for scoring evaluation metrics, covering top-result matching at various thresholds, empty dataset handling, boundary conditions, and edge cases with large retrieval limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->