### PR TITLE
feat: add --budget-tokens to session-start and compact-refresh hooks

### DIFF
--- a/plugin/scripts/compact-refresh.sh
+++ b/plugin/scripts/compact-refresh.sh
@@ -1,6 +1,5 @@
 #!/bin/sh
 # MAG post-compact — re-inject top memories after context compaction
-# Budget trimming deferred to Wave 2 (requires --budget-tokens flag, not yet in Rust)
 set -eu
 
 PROJECT="$(basename "$PWD")"
@@ -11,4 +10,4 @@ mkdir -p "$HOME/.mag"
 printf '%s compact_refresh project=%s session=%s\n' \
   "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PROJECT" "$SESSION_ID" >> "$LOG" 2>/dev/null || true
 
-mag welcome --project "$PROJECT" --session-id "$SESSION_ID" 2>/dev/null || true
+mag welcome --project "$PROJECT" --session-id "$SESSION_ID" --budget-tokens 800 2>/dev/null || true

--- a/plugin/scripts/session-start.sh
+++ b/plugin/scripts/session-start.sh
@@ -12,4 +12,4 @@ mkdir -p "$HOME/.mag"
 printf '%s session_start project=%s session=%s\n' \
   "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PROJECT" "$SESSION_ID" >> "$LOG" 2>/dev/null || true
 
-mag welcome --project "$PROJECT" --session-id "$SESSION_ID" 2>/dev/null || true
+mag welcome --project "$PROJECT" --session-id "$SESSION_ID" --budget-tokens 2000 2>/dev/null || true


### PR DESCRIPTION
## Summary
- `session-start.sh`: adds `--budget-tokens 2000` to `mag welcome` call
- `compact-refresh.sh`: adds `--budget-tokens 800` to `mag welcome` call
- Removes stale "deferred to Wave 2" comment from compact-refresh.sh

Budget hierarchy: session-start (2000) > compact-refresh (800)

## Wave 2 Unit G — Issue #165
**Depends on:** #174 (Unit D) ✓ + #176 (Unit E)

## Test plan
- [ ] Session start output fits within ~2000 tokens
- [ ] Post-compact re-injection fits within ~800 tokens
- [ ] Telemetry log still written before mag invocation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated token budget configuration for plugin initialization commands to optimize resource allocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->