### PR TITLE
chore: bump npm and PyPI package versions to 0.1.5

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mag-memory",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "MAG — Memory Augmented Generation. Local MCP memory server with ONNX embeddings.",
   "license": "MIT",
   "repository": {

--- a/python/mag_memory/__init__.py
+++ b/python/mag_memory/__init__.py
@@ -11,10 +11,10 @@ import subprocess
 import sys
 
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"
 
 # Version of the Rust binary to download (kept in sync with __version__)
-_BINARY_VERSION = "0.1.4"
+_BINARY_VERSION = "0.1.5"
 
 
 def _binary_dir():

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mag-memory"
-version = "0.1.4"
+version = "0.1.5"
 description = "PyPI wrapper for the mag MCP memory server (Rust binary)"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
The v0.1.5 version bump only updated Cargo.toml but missed the npm and
Python package manifests. This aligns them before creating the release tag.

https://claude.ai/code/session_01G9KJ8D8R2m6ZMTz5MjVvrt