### PR TITLE
ci: auto-create tag in workflow_dispatch release trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag (e.g. v0.1.3). Must match an existing git tag."
+        description: "Release tag (e.g. v0.1.5). Creates the tag on HEAD if it doesn't exist."
         required: true
         type: string
 
@@ -22,8 +22,30 @@ env:
   RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
 
 jobs:
+  ensure-tag:
+    name: Ensure tag exists
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Create tag if missing
+        run: |
+          TAG="${{ github.event.inputs.tag }}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists"
+          else
+            echo "Creating tag $TAG on HEAD"
+            git tag -a "$TAG" -m "$TAG"
+            git push origin "$TAG"
+          fi
+
   build:
     name: Build ${{ matrix.target }}
+    needs: [ensure-tag]
+    if: ${{ always() && (needs.ensure-tag.result == 'success' || needs.ensure-tag.result == 'skipped') }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- The release workflow now automatically creates the git tag when triggered via `workflow_dispatch`, so you don't need to push tags manually first
- Just type `v0.1.5` in the GitHub Actions UI and it handles everything (tag creation + full release pipeline)

## How it works
- Adds an `ensure-tag` job that runs only on `workflow_dispatch`
- If the tag already exists, it's a no-op
- If the tag doesn't exist, it creates and pushes it
- Build jobs wait for `ensure-tag` to complete (or skip it on tag-push triggers)

## Test plan
- [ ] Merge this PR
- [ ] Go to Actions > Release > Run workflow, enter `v0.1.5`
- [ ] Verify tag is created and all release jobs complete (builds, GitHub Release, crates.io, npm, PyPI, Homebrew)

https://claude.ai/code/session_01G9KJ8D8R2m6ZMTz5MjVvrt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to automatically create and push git tags when they don't already exist, reducing manual steps required during the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->