### PR TITLE
fix(ci): use lightweight tag via GitHub refs API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,18 +36,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           TAG="${{ github.event.inputs.tag }}"
-          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG#v}" >/dev/null 2>&1; then
+          SHA="$(git rev-parse HEAD)"
+          if gh api "repos/${{ github.repository }}/git/ref/tags/${TAG}" >/dev/null 2>&1; then
             echo "Tag $TAG already exists"
           else
-            echo "Creating tag $TAG on $(git rev-parse HEAD)"
-            gh api "repos/${{ github.repository }}/git/tags" \
-              -f tag="$TAG" \
-              -f message="$TAG" \
-              -f object="$(git rev-parse HEAD)" \
-              -f type="commit"
+            echo "Creating lightweight tag $TAG on $SHA"
             gh api "repos/${{ github.repository }}/git/refs" \
               -f ref="refs/tags/$TAG" \
-              -f sha="$(git rev-parse HEAD)"
+              -f sha="$SHA"
           fi
 
   build:


### PR DESCRIPTION
## Summary
- Fixes the `ensure-tag` step failing with "Committer identity unknown"
- Annotated tags (`git tag -a` and `gh api git/tags`) require a tagger identity not configured in CI runners
- Switches to a **lightweight tag** via the `git/refs` API which only needs a SHA — no committer config needed

## Test plan
- [ ] Merge this PR
- [ ] Go to Actions > Release > Run workflow, enter `v0.1.5`
- [ ] Verify the tag is created and all release jobs proceed

https://claude.ai/code/session_01G9KJ8D8R2m6ZMTz5MjVvrt