### PR TITLE
feat(connectors): add cross-tool connector installer for Codex, Gemini, and OpenCode

### DIFF
--- a/connectors/codex/AGENTS.md
+++ b/connectors/codex/AGENTS.md
@@ -1,0 +1,38 @@
+<!-- MAG_MEMORY_START -->
+# MAG — Persistent Memory
+
+MAG provides persistent memory across sessions. Available commands:
+
+> **Safety:** Do not store secrets, credentials, or large code blocks in MAG memory.
+
+## Store a memory
+
+```bash
+mag process "content to remember" --importance 0.7
+```
+
+## Search memories
+
+```bash
+mag advanced-search "query" --limit 5
+```
+
+## Session context
+
+```bash
+mag welcome --project <project_name>
+```
+
+## Checkpoint current work
+
+```bash
+mag checkpoint "task title" "progress description"
+mag resume-task --task-title "task title"
+```
+
+## Health check
+
+```bash
+mag maintain --action health
+```
+<!-- MAG_MEMORY_END -->

--- a/connectors/gemini/AGENTS.md
+++ b/connectors/gemini/AGENTS.md
@@ -1,0 +1,38 @@
+<!-- MAG_MEMORY_START -->
+# MAG — Persistent Memory
+
+MAG provides persistent memory across sessions. Available commands:
+
+> **Safety:** Do not store secrets, credentials, or large code blocks in MAG memory.
+
+## Store a memory
+
+```bash
+mag process "content to remember" --importance 0.7
+```
+
+## Search memories
+
+```bash
+mag advanced-search "query" --limit 5
+```
+
+## Session context
+
+```bash
+mag welcome --project <project_name>
+```
+
+## Checkpoint current work
+
+```bash
+mag checkpoint "task title" "progress description"
+mag resume-task --task-title "task title"
+```
+
+## Health check
+
+```bash
+mag maintain --action health
+```
+<!-- MAG_MEMORY_END -->

--- a/connectors/opencode/skills/memory-checkpoint/SKILL.md
+++ b/connectors/opencode/skills/memory-checkpoint/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: memory-checkpoint
+description: Save and resume work checkpoints with MAG persistent memory system
+---
+
+# memory-checkpoint
+
+Save progress checkpoints and resume incomplete work across sessions.
+
+## Save a checkpoint
+
+```bash
+mag checkpoint "task title" "progress description" --project <name>
+```
+
+## Resume from checkpoint
+
+```bash
+mag resume-task --task-title "task title" --project <name>
+```
+
+> **Safety:** Do not store secrets, credentials, or large code blocks in MAG memory.
+
+## Options
+
+- `--plan <text>` — overall plan for the task
+- `--next-steps <text>` — what to do next
+- `--session-id <id>` — associate with a session
+- `--project <name>` — associate with a project

--- a/connectors/opencode/skills/memory-health/SKILL.md
+++ b/connectors/opencode/skills/memory-health/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: memory-health
+description: Check MAG persistent memory system health and diagnostics
+---
+
+# memory-health
+
+Check the health and status of the MAG memory system.
+
+## Health check
+
+```bash
+mag maintain --action health
+```
+
+## Session briefing
+
+```bash
+mag welcome --project <project_name>
+```
+
+## Statistics
+
+```bash
+mag stats
+```
+
+## Doctor (full diagnostics)
+
+```bash
+mag doctor --verbose
+```

--- a/connectors/opencode/skills/memory-recall/SKILL.md
+++ b/connectors/opencode/skills/memory-recall/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: memory-recall
+description: Search and recall memories from MAG persistent memory system
+---
+
+# memory-recall
+
+Search stored memories using MAG's multi-phase retrieval pipeline.
+
+## Usage
+
+```bash
+mag advanced-search "query" --limit 5
+```
+
+## Options
+
+- `--limit <n>` — maximum results to return (default: 10)
+- `--project <name>` — filter by project
+- `--importance-min <0.0-1.0>` — minimum importance threshold
+- `--context-tags <tag1,tag2>` — filter by tags
+- `--explain` — show scoring breakdown for each result

--- a/connectors/opencode/skills/memory-store/SKILL.md
+++ b/connectors/opencode/skills/memory-store/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: memory-store
+description: Store a memory with MAG persistent memory system
+---
+
+# memory-store
+
+Store content into MAG persistent memory for retrieval in future sessions.
+
+## Usage
+
+```bash
+mag process "content to remember" --importance 0.7
+```
+
+> **Safety:** Do not store secrets, credentials, or large code blocks in MAG memory.
+
+## Options
+
+- `--importance <0.0-1.0>` — importance weight (default: 0.5)
+- `--tags <tag1,tag2>` — comma-separated context tags
+- `--project <name>` — associate with a project
+- `--event-type <type>` — categorize the memory (e.g., decision, observation, task)
+- `--session-id <id>` — associate with a session

--- a/src/app_paths.rs
+++ b/src/app_paths.rs
@@ -12,6 +12,16 @@ pub struct AppPaths {
     pub benchmark_root: PathBuf,
 }
 
+/// Returns the XDG config home directory, respecting `XDG_CONFIG_HOME` if set
+/// and absolute, otherwise falling back to `$HOME/.config`.
+#[allow(dead_code)] // used by setup and tool_detection; not reachable from the binary target
+pub fn xdg_config_home(home: &Path) -> PathBuf {
+    std::env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .filter(|p| p.is_absolute())
+        .unwrap_or_else(|| home.join(".config"))
+}
+
 pub fn home_dir() -> Result<PathBuf> {
     std::env::var_os("HOME")
         .or_else(|| std::env::var_os("USERPROFILE"))

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -5,12 +5,12 @@
 //! can communicate with the MAG daemon.
 
 use std::io::{self, BufRead, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 
 use crate::config_writer::{self, ConfigWriteResult, TransportMode};
-use crate::tool_detection::{self, DetectedTool, DetectionResult, MagConfigStatus};
+use crate::tool_detection::{self, ContentTier, DetectedTool, DetectionResult, MagConfigStatus};
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -63,8 +63,8 @@ pub async fn run_setup(args: SetupArgs) -> Result<()> {
         return Ok(());
     }
 
-    // Configure phase
-    let summary = configure_tools(&tools_to_configure, args.transport)?;
+    let invocation_scope: Vec<&DetectedTool> = invocation_scoped_tools(&result, &args);
+    let summary = configure_tools(&tools_to_configure, args.transport, &invocation_scope)?;
     present_summary(&summary);
 
     // Daemon phase
@@ -156,12 +156,16 @@ fn present_summary(summary: &ConfigureSummary) {
 // Tool selection
 // ---------------------------------------------------------------------------
 
-fn select_tools<'a>(
+/// Returns the invocation-scoped tool set: all detected tools that match the
+/// `--tools` filter (or all detected tools when no filter is given).  This is
+/// the set used as the connector-content target so that AGENTS.md / SKILL.md
+/// is written only for tools the user explicitly asked about, while still
+/// including already-configured tools within that scope.
+fn invocation_scoped_tools<'a>(
     result: &'a DetectionResult,
     args: &SetupArgs,
-) -> Result<Vec<&'a DetectedTool>> {
-    // Filter by --tools if provided
-    let candidates: Vec<&DetectedTool> = if let Some(ref tool_names) = args.tools {
+) -> Vec<&'a DetectedTool> {
+    if let Some(ref tool_names) = args.tools {
         let lower_names: Vec<String> = tool_names.iter().map(|n| n.to_lowercase()).collect();
         result
             .detected
@@ -176,7 +180,14 @@ fn select_tools<'a>(
             .collect()
     } else {
         result.detected.iter().collect()
-    };
+    }
+}
+
+fn select_tools<'a>(
+    result: &'a DetectionResult,
+    args: &SetupArgs,
+) -> Result<Vec<&'a DetectedTool>> {
+    let candidates = invocation_scoped_tools(result, args);
 
     // In force mode, configure all matched tools regardless of status
     if args.force {
@@ -234,7 +245,11 @@ fn select_tools_interactive<'a>(tools: &[&'a DetectedTool]) -> Result<Vec<&'a De
 // Configuration phase
 // ---------------------------------------------------------------------------
 
-fn configure_tools(tools: &[&DetectedTool], mode: TransportMode) -> Result<ConfigureSummary> {
+fn configure_tools(
+    tools: &[&DetectedTool],
+    mode: TransportMode,
+    all_detected: &[&DetectedTool],
+) -> Result<ConfigureSummary> {
     let mut summary = ConfigureSummary::default();
 
     for tool in tools {
@@ -286,7 +301,381 @@ fn configure_tools(tools: &[&DetectedTool], mode: TransportMode) -> Result<Confi
         }
     }
 
+    // Phase 2: Install connector content (AGENTS.md, SKILL.md, etc.) for the
+    // full invocation scope, not just the newly-configured subset.
+    let (connector_successes, connector_warnings) = install_connector_content(all_detected);
+    summary.written.extend(connector_successes);
+    summary.errors.extend(connector_warnings);
+
     Ok(summary)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers: atomic write, XDG config
+// ---------------------------------------------------------------------------
+
+/// Atomically writes `content` to `path` by writing to a temporary file in the
+/// same directory, flushing, syncing, then renaming. This prevents partial writes
+/// if the process is interrupted.
+///
+/// The temp file includes the process ID in its name to avoid races when
+/// multiple `mag setup` invocations run concurrently. If any step fails, the
+/// temp file is removed before the error is returned.
+fn atomic_write(path: &Path, content: &str) -> Result<()> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating directory {}", parent.display()))?;
+    }
+    let tmp = path.with_extension(format!("mag-tmp.{}", std::process::id()));
+    let result = (|| -> Result<()> {
+        let mut f = std::fs::File::create(&tmp)
+            .with_context(|| format!("creating temp file {}", tmp.display()))?;
+        f.write_all(content.as_bytes())
+            .with_context(|| format!("writing to {}", tmp.display()))?;
+        f.sync_all()
+            .with_context(|| format!("syncing {}", tmp.display()))?;
+        drop(f);
+        std::fs::rename(&tmp, path)
+            .with_context(|| format!("renaming {} -> {}", tmp.display(), path.display()))
+    })();
+    if result.is_err() {
+        let _ = std::fs::remove_file(&tmp);
+    }
+    result
+}
+
+// ---------------------------------------------------------------------------
+// Connector content installation
+// ---------------------------------------------------------------------------
+
+/// Sentinel marking the start of the MAG section in AGENTS.md files.
+const MAG_SENTINEL_START: &str = "<!-- MAG_MEMORY_START -->";
+/// Sentinel marking the end of the MAG section in AGENTS.md files.
+const MAG_SENTINEL_END: &str = "<!-- MAG_MEMORY_END -->";
+
+const CODEX_AGENTS_MD: &str = include_str!("../connectors/codex/AGENTS.md");
+const GEMINI_AGENTS_MD: &str = include_str!("../connectors/gemini/AGENTS.md");
+
+/// OpenCode skill definitions: (directory name, embedded content).
+const OPENCODE_SKILLS: &[(&str, &str)] = &[
+    (
+        "memory-store",
+        include_str!("../connectors/opencode/skills/memory-store/SKILL.md"),
+    ),
+    (
+        "memory-recall",
+        include_str!("../connectors/opencode/skills/memory-recall/SKILL.md"),
+    ),
+    (
+        "memory-checkpoint",
+        include_str!("../connectors/opencode/skills/memory-checkpoint/SKILL.md"),
+    ),
+    (
+        "memory-health",
+        include_str!("../connectors/opencode/skills/memory-health/SKILL.md"),
+    ),
+];
+
+/// Installs connector content (AGENTS.md / SKILL.md) for each tool based on
+/// its content tier. Returns `(successes, warnings)` — human-readable messages
+/// for successful installs and `(tool_label, message)` pairs for any failures.
+fn install_connector_content(tools: &[&DetectedTool]) -> (Vec<String>, Vec<(String, String)>) {
+    let mut successes = Vec::new();
+    let mut warnings: Vec<(String, String)> = Vec::new();
+
+    let home = match crate::app_paths::home_dir() {
+        Ok(h) => h,
+        Err(e) => {
+            let msg = format!("Cannot resolve HOME for connector content: {e}");
+            tracing::warn!("{msg}");
+            warnings.push(("connector".to_string(), msg));
+            return (successes, warnings);
+        }
+    };
+
+    for tool in tools {
+        let name = tool.tool.display_name();
+        match tool.tool.content_tier() {
+            ContentTier::AgentsMd => match install_agents_md(tool.tool, &home) {
+                Ok(true) => {
+                    let msg = format!("Installed AGENTS.md for {name}");
+                    tracing::debug!(tool = %name, "AGENTS.md installed/updated");
+                    successes.push(msg);
+                }
+                Ok(false) => {
+                    tracing::debug!(tool = %name, "AGENTS.md already current");
+                }
+                Err(e) => {
+                    let msg = format!("Failed to install AGENTS.md: {e}");
+                    tracing::warn!(tool = %name, "{msg}");
+                    warnings.push((name.to_string(), msg));
+                }
+            },
+            ContentTier::Skills => match install_skills(tool.tool, &home) {
+                Ok(n) if n > 0 => {
+                    let msg = format!("Installed {n} skill(s) for {name}");
+                    tracing::debug!(tool = %name, count = n, "installed SKILL.md files");
+                    successes.push(msg);
+                }
+                Ok(_) => {
+                    tracing::debug!(tool = %name, "skills already current");
+                }
+                Err(e) => {
+                    let msg = format!("Failed to install SKILL.md files: {e}");
+                    tracing::warn!(tool = %name, "{msg}");
+                    warnings.push((name.to_string(), msg));
+                }
+            },
+            ContentTier::Rules => tracing::debug!(tool = %name, "rules connector deferred"),
+            ContentTier::Mcp | ContentTier::Plugin => {}
+        }
+    }
+
+    (successes, warnings)
+}
+
+/// Returns the embedded content and target path for a tool's AGENTS.md, if applicable.
+pub(crate) fn agents_md_target(
+    tool: tool_detection::AiTool,
+    home: &Path,
+) -> Option<(&'static str, PathBuf)> {
+    match tool {
+        tool_detection::AiTool::Codex => Some((CODEX_AGENTS_MD, home.join(".codex/AGENTS.md"))),
+        tool_detection::AiTool::GeminiCli => {
+            Some((GEMINI_AGENTS_MD, home.join(".gemini/AGENTS.md")))
+        }
+        _ => None,
+    }
+}
+
+/// Appends the MAG section to `existing` content after a blank line separator,
+/// then writes it atomically to `path`. Returns `Ok(true)` (content always changed).
+fn install_agents_md_append(existing: &str, content: &str, path: &Path) -> Result<bool> {
+    let mut result = existing.to_string();
+    if !result.ends_with('\n') {
+        result.push('\n');
+    }
+    result.push('\n');
+    result.push_str(content);
+    if !content.ends_with('\n') {
+        result.push('\n');
+    }
+    atomic_write(path, &result)?;
+    Ok(true)
+}
+
+/// Installs or updates the MAG section in a tool's AGENTS.md file.
+///
+/// Uses sentinel comments (`<!-- MAG_MEMORY_START -->` / `<!-- MAG_MEMORY_END -->`)
+/// for idempotent append/replace.
+///
+/// Returns `Ok(true)` if the file was created or updated, `Ok(false)` if already
+/// up-to-date (identical content).
+pub(crate) fn install_agents_md(tool: tool_detection::AiTool, home: &Path) -> Result<bool> {
+    let Some((content, target_path)) = agents_md_target(tool, home) else {
+        return Ok(false);
+    };
+
+    if let Some(parent) = target_path.parent() {
+        std::fs::create_dir_all(parent)
+            .with_context(|| format!("creating directory {}", parent.display()))?;
+    }
+
+    let existing = match std::fs::read_to_string(&target_path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => String::new(),
+        Err(e) => return Err(e).context("reading existing AGENTS.md"),
+    };
+
+    let has_start = existing.find(MAG_SENTINEL_START);
+    // Search for END only after START to avoid matching an orphan END before a
+    // valid START/END pair.
+    let has_end = has_start
+        .and_then(|si| existing[si..].find(MAG_SENTINEL_END).map(|i| si + i))
+        .or_else(|| existing.find(MAG_SENTINEL_END));
+
+    let new_content = if existing.is_empty() {
+        content.to_string()
+    } else if let Some(start_idx) = has_start {
+        // START sentinel found — END must also be present and after START.
+        let end_raw = match has_end {
+            Some(i) if i >= start_idx => i,
+            Some(_) => {
+                // END appears before START — malformed. Treat as "no sentinel" and append.
+                return install_agents_md_append(&existing, content, &target_path);
+            }
+            None => {
+                anyhow::bail!(
+                    "corrupt AGENTS.md: found MAG_MEMORY_START but no matching MAG_MEMORY_END in {}",
+                    target_path.display()
+                );
+            }
+        };
+
+        // Replace the existing MAG section in place.
+        let end_idx = end_raw + MAG_SENTINEL_END.len();
+        let end_idx = if existing[end_idx..].starts_with('\n') {
+            end_idx + 1
+        } else {
+            end_idx
+        };
+
+        let mut result = String::with_capacity(existing.len());
+        result.push_str(&existing[..start_idx]);
+        result.push_str(content);
+        if !content.ends_with('\n') {
+            result.push('\n');
+        }
+        result.push_str(&existing[end_idx..]);
+        result
+    } else {
+        // No valid START sentinel (either no sentinels, or orphan END only) — append.
+        return install_agents_md_append(&existing, content, &target_path);
+    };
+
+    if new_content == existing {
+        return Ok(false);
+    }
+
+    atomic_write(&target_path, &new_content)?;
+
+    Ok(true)
+}
+
+/// Installs SKILL.md files for OpenCode (ContentTier::Skills tools).
+///
+/// Creates `~/.config/opencode/skills/{skill_name}/SKILL.md` for each skill.
+/// Returns the number of files created or updated, or `0` if this tool does
+/// not use the Skills content tier.
+pub(crate) fn install_skills(tool: tool_detection::AiTool, home: &Path) -> Result<usize> {
+    if tool.content_tier() != ContentTier::Skills {
+        return Ok(0);
+    }
+
+    let skills_root = crate::app_paths::xdg_config_home(home).join("opencode/skills");
+    let mut errors: Vec<String> = Vec::new();
+    let mut count = 0usize;
+
+    for &(skill_name, skill_content) in OPENCODE_SKILLS {
+        let skill_dir = skills_root.join(skill_name);
+        let skill_path = skill_dir.join("SKILL.md");
+
+        if let Ok(existing) = std::fs::read_to_string(&skill_path)
+            && existing == skill_content
+        {
+            continue;
+        }
+
+        if let Err(e) = atomic_write(&skill_path, skill_content) {
+            errors.push(format!("{}: {}", skill_name, e));
+            continue;
+        }
+        count += 1;
+    }
+
+    if !errors.is_empty() {
+        anyhow::bail!(
+            "Failed to install {} skill(s): {}",
+            errors.len(),
+            errors.join("; ")
+        );
+    }
+
+    Ok(count)
+}
+
+/// Removes the MAG sentinel section from an AGENTS.md file at the given path.
+///
+/// Returns `Ok(true)` if the section was removed, `Ok(false)` if not present.
+pub(crate) fn remove_agents_md_section(path: &Path) -> Result<bool> {
+    let existing = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(false),
+        Err(e) => return Err(e).context("reading AGENTS.md for removal"),
+    };
+
+    let Some(start_idx) = existing.find(MAG_SENTINEL_START) else {
+        return Ok(false);
+    };
+
+    // Search for END starting from START to avoid matching an orphan END
+    // that appears before the START sentinel.
+    let Some(end_raw) = existing[start_idx..]
+        .find(MAG_SENTINEL_END)
+        .map(|i| start_idx + i)
+    else {
+        anyhow::bail!(
+            "AGENTS.md has MAG_MEMORY_START but no matching MAG_MEMORY_END: {}",
+            path.display()
+        );
+    };
+
+    let end_idx = end_raw + MAG_SENTINEL_END.len();
+
+    // Consume the newline immediately after the END sentinel.
+    let end_idx = if existing[end_idx..].starts_with('\n') {
+        end_idx + 1
+    } else {
+        end_idx
+    };
+
+    // If the text before the sentinel ends with a blank line (the separator
+    // written by install_agents_md), consume the extra newline.
+    let start_idx = if existing[..start_idx].ends_with("\n\n") {
+        start_idx - 1
+    } else {
+        start_idx
+    };
+
+    let mut result = String::with_capacity(existing.len());
+    result.push_str(&existing[..start_idx]);
+    result.push_str(&existing[end_idx..]);
+
+    if result.trim().is_empty() {
+        std::fs::remove_file(path).with_context(|| format!("removing empty {}", path.display()))?;
+    } else {
+        atomic_write(path, &result)?;
+    }
+
+    Ok(true)
+}
+
+/// Removes OpenCode skill files created by MAG.
+///
+/// Only removes the managed SKILL.md file from each skill directory. The
+/// directory itself is removed only if it is empty afterwards, so any
+/// user-added files are preserved.
+pub(crate) fn remove_opencode_skills(home: &Path) -> Result<usize> {
+    let skills_root = crate::app_paths::xdg_config_home(home).join("opencode/skills");
+    let mut count = 0;
+
+    for &(skill_name, _) in OPENCODE_SKILLS {
+        let skill_dir = skills_root.join(skill_name);
+        let skill_path = skill_dir.join("SKILL.md");
+        match std::fs::remove_file(&skill_path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => {
+                return Err(e).with_context(|| format!("removing {}", skill_path.display()));
+            }
+        }
+        count += 1;
+        // Only remove directory if empty (don't delete user files)
+        if std::fs::read_dir(&skill_dir)
+            .with_context(|| format!("reading {}", skill_dir.display()))?
+            .next()
+            .is_none()
+            && let Err(e) = std::fs::remove_dir(&skill_dir)
+        {
+            tracing::warn!(
+                path = %skill_dir.display(),
+                error = %e,
+                "failed to remove empty skill directory"
+            );
+        }
+    }
+
+    Ok(count)
 }
 
 // ---------------------------------------------------------------------------
@@ -308,6 +697,9 @@ fn maybe_start_daemon(port: u16, no_start: bool) -> Result<()> {
                 info.pid, info.port
             );
             return Ok(());
+        }
+        Err(e) => {
+            tracing::debug!(error = %e, "failed to read daemon info; assuming not running");
         }
         _ => {}
     }
@@ -601,7 +993,7 @@ mod tests {
             };
 
             let tools: Vec<&DetectedTool> = vec![&dt];
-            let summary = configure_tools(&tools, TransportMode::Command).unwrap();
+            let summary = configure_tools(&tools, TransportMode::Command, &tools).unwrap();
 
             assert_eq!(summary.written.len(), 1);
             assert!(summary.errors.is_empty());
@@ -643,7 +1035,7 @@ mod tests {
             };
 
             let tools: Vec<&DetectedTool> = vec![&dt];
-            let summary = configure_tools(&tools, TransportMode::Command).unwrap();
+            let summary = configure_tools(&tools, TransportMode::Command, &tools).unwrap();
 
             assert_eq!(summary.already_current.len(), 1);
             assert!(summary.written.is_empty());
@@ -660,7 +1052,7 @@ mod tests {
         };
 
         let tools: Vec<&DetectedTool> = vec![&dt];
-        let summary = configure_tools(&tools, TransportMode::Command).unwrap();
+        let summary = configure_tools(&tools, TransportMode::Command, &tools).unwrap();
 
         assert_eq!(summary.unsupported.len(), 1);
     }
@@ -675,7 +1067,7 @@ mod tests {
         };
 
         let tools: Vec<&DetectedTool> = vec![&dt];
-        let summary = configure_tools(&tools, TransportMode::Command).unwrap();
+        let summary = configure_tools(&tools, TransportMode::Command, &tools).unwrap();
 
         assert_eq!(summary.deferred.len(), 1);
     }
@@ -713,8 +1105,9 @@ mod tests {
             let selected = select_tools(&result, &args).unwrap();
             assert!(!selected.is_empty(), "expected at least one tool selected");
 
-            // Configure
-            let summary = configure_tools(&selected, TransportMode::Command).unwrap();
+            // Configure — pass invocation-scoped tools for connector content
+            let scope = invocation_scoped_tools(&result, &args);
+            let summary = configure_tools(&selected, TransportMode::Command, &scope).unwrap();
             assert!(
                 !summary.written.is_empty() || !summary.already_current.is_empty(),
                 "expected at least one tool configured"
@@ -890,5 +1283,389 @@ mod tests {
         };
         // Smoke test — should not panic
         present_summary(&summary);
+    }
+
+    // -----------------------------------------------------------------------
+    // Connector: install_agents_md
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn install_agents_md_creates_file_for_codex() {
+        with_temp_home(|home| {
+            let result = install_agents_md(AiTool::Codex, home).unwrap();
+            assert!(result, "expected file to be created");
+
+            let path = home.join(".codex/AGENTS.md");
+            assert!(path.exists());
+            let content = std::fs::read_to_string(&path).unwrap();
+            assert!(content.contains("<!-- MAG_MEMORY_START -->"));
+            assert!(content.contains("<!-- MAG_MEMORY_END -->"));
+            assert!(content.contains("mag process"));
+        });
+    }
+
+    #[test]
+    fn install_agents_md_creates_file_for_gemini() {
+        with_temp_home(|home| {
+            let result = install_agents_md(AiTool::GeminiCli, home).unwrap();
+            assert!(result, "expected file to be created");
+
+            let path = home.join(".gemini/AGENTS.md");
+            assert!(path.exists());
+            let content = std::fs::read_to_string(&path).unwrap();
+            assert!(content.contains("<!-- MAG_MEMORY_START -->"));
+            assert!(content.contains("<!-- MAG_MEMORY_END -->"));
+        });
+    }
+
+    #[test]
+    fn install_agents_md_is_idempotent() {
+        with_temp_home(|home| {
+            // First install
+            let first = install_agents_md(AiTool::Codex, home).unwrap();
+            assert!(first, "first install should return true");
+
+            // Second install — content is identical
+            let second = install_agents_md(AiTool::Codex, home).unwrap();
+            assert!(
+                !second,
+                "second install should return false (already current)"
+            );
+        });
+    }
+
+    #[test]
+    fn install_agents_md_replaces_existing_section() {
+        with_temp_home(|home| {
+            let path = home.join(".codex/AGENTS.md");
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+
+            // Write a file with existing user content + old MAG section
+            std::fs::write(
+                &path,
+                "# My Agent\n\nSome user content.\n\n<!-- MAG_MEMORY_START -->\nOLD MAG CONTENT\n<!-- MAG_MEMORY_END -->\n",
+            ).unwrap();
+
+            let result = install_agents_md(AiTool::Codex, home).unwrap();
+            assert!(result, "should update the MAG section");
+
+            let content = std::fs::read_to_string(&path).unwrap();
+            // User content should be preserved
+            assert!(content.contains("# My Agent"));
+            assert!(content.contains("Some user content."));
+            // Old content should be gone
+            assert!(!content.contains("OLD MAG CONTENT"));
+            // New content should be present
+            assert!(content.contains("mag process"));
+        });
+    }
+
+    #[test]
+    fn install_agents_md_appends_to_existing_file() {
+        with_temp_home(|home| {
+            let path = home.join(".codex/AGENTS.md");
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(&path, "# Existing AGENTS.md\n\nSome guidance.\n").unwrap();
+
+            let result = install_agents_md(AiTool::Codex, home).unwrap();
+            assert!(result, "should append MAG section");
+
+            let content = std::fs::read_to_string(&path).unwrap();
+            assert!(content.starts_with("# Existing AGENTS.md"));
+            assert!(content.contains("<!-- MAG_MEMORY_START -->"));
+            assert!(content.contains("<!-- MAG_MEMORY_END -->"));
+        });
+    }
+
+    #[test]
+    fn install_agents_md_returns_false_for_non_agents_md_tool() {
+        with_temp_home(|home| {
+            let result = install_agents_md(AiTool::Cursor, home).unwrap();
+            assert!(!result, "Cursor is not an AgentsMd tier tool");
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // Connector: install_skills
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn install_skills_returns_zero_for_non_skills_tier() {
+        with_temp_home(|home| {
+            // Codex is AgentsMd, not Skills
+            let count = install_skills(AiTool::Codex, home).unwrap();
+            assert_eq!(count, 0);
+
+            // ClaudeCode is Plugin, not Skills
+            let count = install_skills(AiTool::ClaudeCode, home).unwrap();
+            assert_eq!(count, 0);
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // Connector: remove_agents_md_section
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn remove_agents_md_section_removes_mag_content() {
+        with_temp_home(|home| {
+            // Install first
+            install_agents_md(AiTool::Codex, home).unwrap();
+            let path = home.join(".codex/AGENTS.md");
+            assert!(path.exists());
+
+            // Remove
+            let removed = remove_agents_md_section(&path).unwrap();
+            assert!(removed, "should return true when section is removed");
+
+            // File should be gone (was MAG-only content)
+            assert!(!path.exists(), "empty file should be deleted");
+        });
+    }
+
+    #[test]
+    fn remove_agents_md_section_preserves_other_content() {
+        with_temp_home(|home| {
+            let path = home.join(".codex/AGENTS.md");
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(
+                &path,
+                "# User content\n\n<!-- MAG_MEMORY_START -->\nMAG stuff\n<!-- MAG_MEMORY_END -->\n",
+            )
+            .unwrap();
+
+            let removed = remove_agents_md_section(&path).unwrap();
+            assert!(removed);
+
+            let content = std::fs::read_to_string(&path).unwrap();
+            assert!(content.contains("# User content"));
+            assert!(!content.contains("MAG_MEMORY_START"));
+        });
+    }
+
+    #[test]
+    fn remove_agents_md_section_returns_false_when_no_sentinel() {
+        with_temp_home(|home| {
+            let path = home.join(".codex/AGENTS.md");
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(&path, "# No MAG content here\n").unwrap();
+
+            let removed = remove_agents_md_section(&path).unwrap();
+            assert!(!removed);
+        });
+    }
+
+    #[test]
+    fn remove_agents_md_section_returns_false_for_missing_file() {
+        with_temp_home(|home| {
+            let path = home.join(".codex/AGENTS.md");
+            let removed = remove_agents_md_section(&path).unwrap();
+            assert!(!removed);
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // Connector: remove_opencode_skills
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn remove_opencode_skills_returns_zero_when_none_exist() {
+        with_temp_home(|home| {
+            let count = remove_opencode_skills(home).unwrap();
+            assert_eq!(count, 0);
+        });
+    }
+
+    #[test]
+    fn remove_opencode_skills_removes_existing_dirs() {
+        with_temp_home(|home| {
+            // Create some skill directories
+            let skills_root = home.join(".config/opencode/skills");
+            let skill_dir = skills_root.join("memory-store");
+            std::fs::create_dir_all(&skill_dir).unwrap();
+            std::fs::write(skill_dir.join("SKILL.md"), "test").unwrap();
+
+            let skill_dir2 = skills_root.join("memory-health");
+            std::fs::create_dir_all(&skill_dir2).unwrap();
+            std::fs::write(skill_dir2.join("SKILL.md"), "test").unwrap();
+
+            let count = remove_opencode_skills(home).unwrap();
+            assert_eq!(count, 2);
+            assert!(!skills_root.join("memory-store").exists());
+            assert!(!skills_root.join("memory-health").exists());
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // Connector: uninstall integration
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn uninstall_removes_agents_md_sections() {
+        with_temp_home(|home| {
+            // Install MAG AGENTS.md for Codex
+            install_agents_md(AiTool::Codex, home).unwrap();
+            let codex_path = home.join(".codex/AGENTS.md");
+            assert!(codex_path.exists());
+
+            // Also create a Codex config.toml so it's detected
+            std::fs::write(
+                home.join(".codex/config.toml"),
+                "[mcp_servers.mag]\ncommand = \"mag\"\n",
+            )
+            .unwrap();
+
+            // Run uninstall
+            let rt = tokio::runtime::Runtime::new().unwrap();
+            rt.block_on(crate::uninstall::run_uninstall(false, true))
+                .unwrap();
+
+            // The AGENTS.md should be cleaned up (file removed since MAG-only)
+            assert!(
+                !codex_path.exists(),
+                "MAG-only AGENTS.md should be removed by uninstall"
+            );
+        });
+    }
+
+    // -----------------------------------------------------------------------
+    // FIX 5: Additional tests for review findings
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn install_agents_md_append_then_idempotent() {
+        with_temp_home(|home| {
+            // Create an existing file with non-MAG content
+            let path = home.join(".codex/AGENTS.md");
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(&path, "# Pre-existing content\n\nSome other guidance.\n").unwrap();
+
+            // First call: should append MAG section
+            let first = install_agents_md(AiTool::Codex, home).unwrap();
+            assert!(first, "first install should return true (content changed)");
+
+            let content = std::fs::read_to_string(&path).unwrap();
+            assert!(content.contains("# Pre-existing content"));
+            assert!(content.contains("<!-- MAG_MEMORY_START -->"));
+            assert!(content.contains("<!-- MAG_MEMORY_END -->"));
+
+            // Second call: content is identical, should return false
+            let second = install_agents_md(AiTool::Codex, home).unwrap();
+            assert!(
+                !second,
+                "second install should return false (already current)"
+            );
+        });
+    }
+
+    #[test]
+    fn install_skills_creates_skill_files_for_opencode() {
+        with_temp_home(|home| {
+            let count = install_skills(AiTool::OpenCode, home).unwrap();
+            assert_eq!(count, 4, "expected 4 SKILL.md files to be created");
+
+            let skills_root = home.join(".config/opencode/skills");
+            for dir_name in &[
+                "memory-store",
+                "memory-recall",
+                "memory-checkpoint",
+                "memory-health",
+            ] {
+                let skill_path = skills_root.join(dir_name).join("SKILL.md");
+                assert!(skill_path.exists(), "expected {dir_name}/SKILL.md to exist");
+                let content = std::fs::read_to_string(&skill_path).unwrap();
+                assert!(!content.is_empty(), "SKILL.md for {dir_name} is empty");
+            }
+
+            // Idempotent: second call should create 0 new files
+            let count2 = install_skills(AiTool::OpenCode, home).unwrap();
+            assert_eq!(count2, 0, "second install should be idempotent");
+        });
+    }
+
+    #[test]
+    fn install_agents_md_errors_on_start_without_end_sentinel() {
+        with_temp_home(|home| {
+            let path = home.join(".codex/AGENTS.md");
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            // Write a file with START but no END sentinel — corrupt state
+            std::fs::write(
+                &path,
+                "# Content\n\n<!-- MAG_MEMORY_START -->\nOrphaned content\n",
+            )
+            .unwrap();
+
+            let result = install_agents_md(AiTool::Codex, home);
+            assert!(result.is_err(), "expected error for missing END sentinel");
+            let err_msg = result.unwrap_err().to_string();
+            assert!(
+                err_msg.contains("MAG_MEMORY_START") && err_msg.contains("MAG_MEMORY_END"),
+                "error message should mention both sentinels: {err_msg}"
+            );
+        });
+    }
+
+    #[test]
+    fn remove_agents_md_returns_error_when_start_without_end_sentinel() {
+        with_temp_home(|home| {
+            let path = home.join(".codex/AGENTS.md");
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            std::fs::write(
+                &path,
+                "# Content\n\n<!-- MAG_MEMORY_START -->\nOrphaned content\n",
+            )
+            .unwrap();
+
+            // START without END is malformed — returns an error so the user
+            // knows the file needs manual repair (mirrors install-path behaviour).
+            let result = remove_agents_md_section(&path);
+            assert!(result.is_err(), "expected error for missing END sentinel");
+            let err_msg = result.unwrap_err().to_string();
+            assert!(
+                err_msg.contains("MAG_MEMORY_START") && err_msg.contains("MAG_MEMORY_END"),
+                "error message should mention both sentinels: {err_msg}"
+            );
+        });
+    }
+
+    #[test]
+    fn install_agents_md_appends_when_end_before_start() {
+        with_temp_home(|home| {
+            let path = home.join(".codex/AGENTS.md");
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            // Malformed: END before START
+            std::fs::write(
+                &path,
+                "# Content\n<!-- MAG_MEMORY_END -->\n<!-- MAG_MEMORY_START -->\n",
+            )
+            .unwrap();
+
+            // Should treat as "no sentinel" and append
+            let result = install_agents_md(AiTool::Codex, home).unwrap();
+            assert!(result, "should append when sentinels are reversed");
+        });
+    }
+
+    #[test]
+    fn remove_agents_md_returns_error_when_end_before_start() {
+        with_temp_home(|home| {
+            let path = home.join(".codex/AGENTS.md");
+            std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+            // Malformed: END before START — START exists but END is not found
+            // after START, so the same "no matching END" error fires.
+            std::fs::write(
+                &path,
+                "# Content\n<!-- MAG_MEMORY_END -->\n<!-- MAG_MEMORY_START -->\n",
+            )
+            .unwrap();
+
+            let result = remove_agents_md_section(&path);
+            assert!(result.is_err(), "expected error for reversed sentinels");
+            let err_msg = result.unwrap_err().to_string();
+            assert!(
+                err_msg.contains("MAG_MEMORY_START") && err_msg.contains("MAG_MEMORY_END"),
+                "error message should mention both sentinels: {err_msg}"
+            );
+        });
     }
 }

--- a/src/test_helpers.rs
+++ b/src/test_helpers.rs
@@ -28,21 +28,31 @@ where
     let _guard = HOME_MUTEX.lock().unwrap_or_else(|e| e.into_inner());
     let dir = std::env::temp_dir().join(format!("mag-test-{}", uuid::Uuid::new_v4()));
     std::fs::create_dir_all(&dir).expect("failed to create temp home directory for test");
-    let prev = std::env::var_os("HOME");
+    let prev_home = std::env::var_os("HOME");
+    let prev_xdg = std::env::var_os("XDG_CONFIG_HOME");
 
     // SAFETY: Tests are serialized by HOME_MUTEX, ensuring no concurrent
-    // access to the HOME environment variable. This is required because
-    // tool detection resolves paths relative to HOME.
-    unsafe { std::env::set_var("HOME", &dir) };
+    // access to these environment variables. This is required because
+    // tool detection resolves paths relative to HOME and XDG_CONFIG_HOME.
+    unsafe {
+        std::env::set_var("HOME", &dir);
+        // Unset XDG_CONFIG_HOME so xdg_config_home() falls back to $HOME/.config,
+        // giving tests a predictable path within the temp directory.
+        std::env::remove_var("XDG_CONFIG_HOME");
+    }
 
     let result = f(&dir);
 
-    match prev {
-        // SAFETY: Same as above — restoring the original HOME value
-        // under the same mutex guard.
-        Some(val) => unsafe { std::env::set_var("HOME", val) },
-        // SAFETY: Same as above — removing HOME if it was not previously set.
-        None => unsafe { std::env::remove_var("HOME") },
+    // SAFETY: Restoring original values under the same mutex guard.
+    unsafe {
+        match prev_home {
+            Some(val) => std::env::set_var("HOME", val),
+            None => std::env::remove_var("HOME"),
+        }
+        match prev_xdg {
+            Some(val) => std::env::set_var("XDG_CONFIG_HOME", val),
+            None => std::env::remove_var("XDG_CONFIG_HOME"),
+        }
     }
     let _ = std::fs::remove_dir_all(&dir);
     result

--- a/src/tool_detection.rs
+++ b/src/tool_detection.rs
@@ -29,6 +29,7 @@ pub enum AiTool {
     Zed,
     Codex,
     GeminiCli,
+    OpenCode,
 }
 
 impl AiTool {
@@ -44,12 +45,13 @@ impl AiTool {
             Self::Zed => "Zed",
             Self::Codex => "Codex",
             Self::GeminiCli => "Gemini CLI",
+            Self::OpenCode => "OpenCode",
         }
     }
 
     /// Returns all known tool variants.
     pub fn all() -> &'static [AiTool] {
-        static ALL_TOOLS: [AiTool; 9] = [
+        static ALL_TOOLS: [AiTool; 10] = [
             AiTool::ClaudeCode,
             AiTool::ClaudeDesktop,
             AiTool::Cursor,
@@ -59,6 +61,7 @@ impl AiTool {
             AiTool::Zed,
             AiTool::Codex,
             AiTool::GeminiCli,
+            AiTool::OpenCode,
         ];
         &ALL_TOOLS
     }
@@ -68,6 +71,20 @@ impl AiTool {
         match self {
             Self::Codex => ConfigFormat::Toml,
             _ => ConfigFormat::Json,
+        }
+    }
+
+    /// Returns the content tier — what kind of guidance content this tool accepts
+    /// beyond raw MCP config.
+    pub fn content_tier(&self) -> ContentTier {
+        match self {
+            Self::ClaudeCode => ContentTier::Plugin,
+            Self::Codex | Self::GeminiCli => ContentTier::AgentsMd,
+            Self::OpenCode => ContentTier::Skills,
+            Self::Cursor | Self::Windsurf => ContentTier::Rules,
+            // Explicit list so that adding a new AiTool variant causes a compile
+            // error rather than silently inheriting ContentTier::Mcp.
+            Self::ClaudeDesktop | Self::VSCodeCopilot | Self::Cline | Self::Zed => ContentTier::Mcp,
         }
     }
 }
@@ -83,6 +100,21 @@ impl fmt::Display for AiTool {
 pub enum ConfigFormat {
     Json,
     Toml,
+}
+
+/// Classification of what guidance content a tool accepts beyond raw MCP config.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ContentTier {
+    /// MCP config only (Claude Desktop, VS Code Copilot, Cline, Zed).
+    Mcp,
+    /// MCP + global AGENTS.md file (Codex, GeminiCli).
+    AgentsMd,
+    /// MCP + per-skill SKILL.md files (OpenCode).
+    Skills,
+    /// MCP + project-scoped rules files (Cursor, Windsurf) — Wave 3B, deferred.
+    Rules,
+    /// MCP + full plugin system (Claude Code) — already implemented.
+    Plugin,
 }
 
 /// The scope (global vs project-local) of a detected config file.
@@ -233,6 +265,8 @@ pub(crate) fn mcp_key_for_tool(tool: AiTool) -> &'static str {
         // Codex uses TOML — this key is not used in the detection path,
         // but we return a sensible value for config_writer consumers.
         AiTool::Codex => "mcp_servers",
+        // OpenCode uses JSON with mcpServers key in ~/.config/opencode/config.json
+        AiTool::OpenCode => "mcpServers",
     }
 }
 
@@ -422,6 +456,9 @@ fn global_config_paths(tool: AiTool, home: &Path) -> Vec<PathBuf> {
         AiTool::GeminiCli => {
             vec![home.join(".gemini/settings.json")]
         }
+        AiTool::OpenCode => {
+            vec![crate::app_paths::xdg_config_home(home).join("opencode/config.json")]
+        }
     }
 }
 
@@ -447,7 +484,7 @@ fn project_config_paths(tool: AiTool, project_root: &Path) -> Vec<PathBuf> {
             vec![project_root.join(".gemini/settings.json")]
         }
         // These tools have no project-level config
-        AiTool::ClaudeDesktop | AiTool::Cline | AiTool::Codex => vec![],
+        AiTool::ClaudeDesktop | AiTool::Cline | AiTool::Codex | AiTool::OpenCode => vec![],
     }
 }
 
@@ -593,12 +630,12 @@ mod tests {
     // -- AiTool basics --
 
     #[test]
-    fn all_tools_returns_nine_variants() {
+    fn all_tools_returns_ten_variants() {
         let all = AiTool::all();
-        assert_eq!(all.len(), 9);
+        assert_eq!(all.len(), 10);
         // Each variant appears exactly once
         let set: std::collections::HashSet<AiTool> = all.iter().copied().collect();
-        assert_eq!(set.len(), 9);
+        assert_eq!(set.len(), 10);
     }
 
     #[test]
@@ -606,6 +643,7 @@ mod tests {
         assert_eq!(AiTool::ClaudeCode.display_name(), "Claude Code");
         assert_eq!(AiTool::VSCodeCopilot.display_name(), "VS Code + Copilot");
         assert_eq!(AiTool::GeminiCli.display_name(), "Gemini CLI");
+        assert_eq!(AiTool::OpenCode.display_name(), "OpenCode");
     }
 
     #[test]
@@ -1045,6 +1083,50 @@ mod tests {
         });
     }
 
+    // -- Detection: OpenCode via XDG_CONFIG_HOME --
+
+    #[test]
+    #[serial]
+    fn detects_opencode_via_xdg_config_home() {
+        with_temp_home(|_home| {
+            let xdg_dir = std::env::temp_dir().join(format!("mag-xdg-{}", uuid::Uuid::new_v4()));
+            let opencode_dir = xdg_dir.join("opencode");
+            std::fs::create_dir_all(&opencode_dir).unwrap();
+            std::fs::write(
+                opencode_dir.join("config.json"),
+                r#"{"mcpServers": {"mag": {"command": "mag", "args": ["serve"]}}}"#,
+            )
+            .unwrap();
+
+            // Save the previous XDG_CONFIG_HOME so we can restore it afterwards
+            // regardless of how the test exits, preventing pollution of other tests.
+            let prev_xdg = std::env::var("XDG_CONFIG_HOME").ok();
+
+            // SAFETY: Serialized by HOME_MUTEX (held by with_temp_home).
+            unsafe { std::env::set_var("XDG_CONFIG_HOME", &xdg_dir) };
+
+            let result = detect_tool(AiTool::OpenCode, None);
+
+            // SAFETY: Restoring XDG_CONFIG_HOME to its pre-test value under the same
+            // mutex guard that protects all env-var mutations in this test suite.
+            unsafe {
+                match prev_xdg {
+                    Some(v) => std::env::set_var("XDG_CONFIG_HOME", v),
+                    None => std::env::remove_var("XDG_CONFIG_HOME"),
+                }
+            }
+
+            let _ = std::fs::remove_dir_all(&xdg_dir);
+
+            assert!(
+                !result.is_empty(),
+                "expected OpenCode to be detected via XDG_CONFIG_HOME"
+            );
+            assert_eq!(result[0].tool, AiTool::OpenCode);
+            assert_eq!(result[0].mag_status, MagConfigStatus::Configured);
+        });
+    }
+
     // -- DetectionResult helpers --
 
     #[test]
@@ -1112,6 +1194,7 @@ mod tests {
         assert_eq!(mcp_key_for_tool(AiTool::Zed), "context_servers");
         assert_eq!(mcp_key_for_tool(AiTool::Codex), "mcp_servers");
         assert_eq!(mcp_key_for_tool(AiTool::GeminiCli), "mcpServers");
+        assert_eq!(mcp_key_for_tool(AiTool::OpenCode), "mcpServers");
     }
 
     // -- config_format --
@@ -1229,5 +1312,84 @@ mod tests {
         let status = MagConfigStatus::InstalledAsPlugin;
         let serialized = serde_json::to_string(&status).unwrap();
         assert!(serialized.contains("InstalledAsPlugin"));
+    }
+
+    // -- content_tier --
+
+    #[test]
+    fn content_tier_plugin_for_claude_code() {
+        assert_eq!(AiTool::ClaudeCode.content_tier(), ContentTier::Plugin);
+    }
+
+    #[test]
+    fn content_tier_agents_md_for_codex_and_gemini() {
+        assert_eq!(AiTool::Codex.content_tier(), ContentTier::AgentsMd);
+        assert_eq!(AiTool::GeminiCli.content_tier(), ContentTier::AgentsMd);
+    }
+
+    #[test]
+    fn content_tier_rules_for_cursor_and_windsurf() {
+        assert_eq!(AiTool::Cursor.content_tier(), ContentTier::Rules);
+        assert_eq!(AiTool::Windsurf.content_tier(), ContentTier::Rules);
+    }
+
+    #[test]
+    fn content_tier_skills_for_opencode() {
+        assert_eq!(AiTool::OpenCode.content_tier(), ContentTier::Skills);
+    }
+
+    #[test]
+    fn content_tier_mcp_for_remaining_tools() {
+        assert_eq!(AiTool::ClaudeDesktop.content_tier(), ContentTier::Mcp);
+        assert_eq!(AiTool::VSCodeCopilot.content_tier(), ContentTier::Mcp);
+        assert_eq!(AiTool::Cline.content_tier(), ContentTier::Mcp);
+        assert_eq!(AiTool::Zed.content_tier(), ContentTier::Mcp);
+    }
+
+    #[test]
+    fn content_tier_covers_all_variants() {
+        for &tool in AiTool::all() {
+            let _ = tool.content_tier();
+        }
+    }
+
+    // -- Detection: OpenCode --
+
+    #[test]
+    #[serial]
+    fn detects_opencode_global_config() {
+        with_temp_home(|home| {
+            let oc_dir = home.join(".config/opencode");
+            std::fs::create_dir_all(&oc_dir).unwrap();
+            std::fs::write(oc_dir.join("config.json"), r#"{"mcpServers": {}}"#).unwrap();
+
+            let result = detect_tool(AiTool::OpenCode, None);
+            assert!(!result.is_empty());
+            assert_eq!(result[0].tool, AiTool::OpenCode);
+            assert_eq!(result[0].mag_status, MagConfigStatus::NotConfigured);
+        });
+    }
+
+    #[test]
+    #[serial]
+    fn detects_opencode_with_mag_configured() {
+        with_temp_home(|home| {
+            let oc_dir = home.join(".config/opencode");
+            std::fs::create_dir_all(&oc_dir).unwrap();
+            std::fs::write(
+                oc_dir.join("config.json"),
+                r#"{"mcpServers": {"mag": {"command": "mag", "args": ["serve"]}}}"#,
+            )
+            .unwrap();
+
+            let result = detect_tool(AiTool::OpenCode, None);
+            assert!(!result.is_empty());
+            assert_eq!(result[0].mag_status, MagConfigStatus::Configured);
+        });
+    }
+
+    #[test]
+    fn opencode_uses_json_format() {
+        assert_eq!(AiTool::OpenCode.config_format(), ConfigFormat::Json);
     }
 }

--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -79,7 +79,12 @@ pub async fn run_uninstall(all: bool, configs_only: bool) -> Result<()> {
 
     if let Some(ref tc) = summary.tool_configs {
         match tc {
-            ToolConfigResult::Removed { count, errors } => {
+            ToolConfigResult::Removed {
+                count,
+                errors,
+                connector_count,
+                connector_errors,
+            } => {
                 if *count > 0 {
                     println!(
                         "    \u{2713} Tool configurations \u{2014} removed from {count} tool{}",
@@ -88,6 +93,15 @@ pub async fn run_uninstall(all: bool, configs_only: bool) -> Result<()> {
                 }
                 for (name, err) in errors {
                     println!("    \u{2717} {name} \u{2014} error: {err}");
+                }
+                if *connector_count > 0 {
+                    println!(
+                        "    \u{2713} Connector content \u{2014} removed {connector_count} item{}",
+                        if *connector_count == 1 { "" } else { "s" }
+                    );
+                }
+                for (name, err) in connector_errors {
+                    println!("    \u{2717} Connector {name} \u{2014} error: {err}");
                 }
             }
             ToolConfigResult::NoneFound => {
@@ -140,6 +154,8 @@ enum ToolConfigResult {
     Removed {
         count: usize,
         errors: Vec<(String, String)>,
+        connector_count: usize,
+        connector_errors: Vec<(String, String)>,
     },
     NoneFound,
 }
@@ -260,7 +276,22 @@ fn confirm_database_deletion() -> Result<bool> {
 fn remove_tool_configs() -> ToolConfigResult {
     let result = tool_detection::detect_all_tools(None);
 
+    // Always attempt to remove connector content (AGENTS.md sections,
+    // OpenCode skills) regardless of whether any tool configs were detected.
+    // The files may exist even if configs were manually removed.
+    let (connector_count, connector_errors) = remove_connector_content();
+
     if result.detected.is_empty() {
+        // If connector content was cleaned up even though no tool configs were
+        // found, surface that so the user sees something was done.
+        if connector_count > 0 || !connector_errors.is_empty() {
+            return ToolConfigResult::Removed {
+                count: 0,
+                errors: vec![],
+                connector_count,
+                connector_errors,
+            };
+        }
         return ToolConfigResult::NoneFound;
     }
 
@@ -279,7 +310,7 @@ fn remove_tool_configs() -> ToolConfigResult {
                     tracing::debug!("claude plugin was not installed");
                 }
                 Err(e) => {
-                    tracing::debug!(error = %e, "claude plugin removal failed (claude CLI may not be installed)");
+                    tracing::warn!(error = %e, "claude plugin removal failed");
                 }
             }
         }
@@ -303,14 +334,73 @@ fn remove_tool_configs() -> ToolConfigResult {
         }
     }
 
-    if removed_count == 0 && errors.is_empty() {
+    if removed_count == 0
+        && errors.is_empty()
+        && connector_count == 0
+        && connector_errors.is_empty()
+    {
         ToolConfigResult::NoneFound
     } else {
         ToolConfigResult::Removed {
             count: removed_count,
             errors,
+            connector_count,
+            connector_errors,
         }
     }
+}
+
+/// Removes connector content installed by `mag setup`: MAG sections in
+/// AGENTS.md files and OpenCode skill directories.
+///
+/// Returns `(count, errors)` where `count` is the number of items removed and
+/// `errors` is a list of `(label, error_message)` pairs for any failures.
+fn remove_connector_content() -> (usize, Vec<(String, String)>) {
+    let home = match app_paths::home_dir() {
+        Ok(h) => h,
+        Err(e) => {
+            tracing::warn!(error = %e, "cannot resolve HOME for connector content removal");
+            return (0, vec![("home".to_string(), format!("{e:#}"))]);
+        }
+    };
+
+    let mut count = 0usize;
+    let mut errors: Vec<(String, String)> = Vec::new();
+
+    // Use agents_md_target to derive paths rather than hardcoding them.
+    for &tool in &[
+        tool_detection::AiTool::Codex,
+        tool_detection::AiTool::GeminiCli,
+    ] {
+        if let Some((_, path)) = crate::setup::agents_md_target(tool, &home) {
+            let label = format!("{} AGENTS.md", tool.display_name());
+            match crate::setup::remove_agents_md_section(&path) {
+                Ok(true) => {
+                    tracing::info!(path = %path.display(), "removed MAG section");
+                    count += 1;
+                }
+                Ok(false) => {}
+                Err(e) => {
+                    tracing::warn!(path = %path.display(), error = %e, "failed to clean AGENTS.md");
+                    errors.push((label, format!("{e:#}")));
+                }
+            }
+        }
+    }
+
+    match crate::setup::remove_opencode_skills(&home) {
+        Ok(n) if n > 0 => {
+            tracing::info!(count = n, "removed OpenCode skill directories");
+            count += n;
+        }
+        Ok(_) => {}
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to remove OpenCode skills");
+            errors.push(("OpenCode skills".to_string(), format!("{e:#}")));
+        }
+    }
+
+    (count, errors)
 }
 
 fn remove_directory(path: &Path) -> RemoveOutcome {
@@ -338,10 +428,32 @@ fn try_remove_empty_dir(path: &Path) -> bool {
         return false;
     }
     if is_dir_effectively_empty(path) {
-        std::fs::remove_dir_all(path).is_ok()
+        // Use recursive remove_dir (not remove_dir_all) so that if a concurrent
+        // process creates files after the emptiness check, remove_dir fails safely
+        // with "directory not empty" instead of deleting the new content.
+        match remove_empty_tree(path) {
+            Ok(()) => true,
+            Err(e) => {
+                tracing::warn!(path = %path.display(), error = %e, "failed to remove directory");
+                false
+            }
+        }
     } else {
         false
     }
+}
+
+/// Recursively removes a directory tree that should only contain empty subdirectories.
+/// Uses `remove_dir` (not `remove_dir_all`) at each level so that if a concurrent
+/// process creates files after the emptiness check, the operation fails safely.
+fn remove_empty_tree(path: &Path) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(path)? {
+        let entry = entry?;
+        if entry.file_type()?.is_dir() {
+            remove_empty_tree(&entry.path())?;
+        }
+    }
+    std::fs::remove_dir(path)
 }
 
 /// Returns `true` if a directory is empty or contains only empty subdirectories.
@@ -555,7 +667,7 @@ mod tests {
 
             let result = remove_tool_configs();
             match result {
-                ToolConfigResult::Removed { count, errors } => {
+                ToolConfigResult::Removed { count, errors, .. } => {
                     assert!(count >= 1, "expected at least 1 removal");
                     assert!(errors.is_empty(), "expected no errors: {errors:?}");
                 }


### PR DESCRIPTION
## Summary
- Introduces Wave 3 cross-tool connector system with ContentTier-based content injection
- Installs MAG memory sections into Codex (AGENTS.md), Gemini CLI (AGENTS.md), and OpenCode (skill files)
- Adds connector cleanup to `mag uninstall`
- Includes 30+ tests for connector install/remove logic

## Changes
- **connectors/**: Template content files for each supported AI tool
- **src/tool_detection.rs**: ContentTier enum mapping tools to their content injection strategy
- **src/app_paths.rs**: XDG config path helper
- **src/setup.rs**: Connector content installer with atomic writes and section management
- **src/uninstall.rs**: Cleanup wiring for connector content on uninstall

## Test plan
- [x] Unit tests for section injection/removal
- [x] Unit tests for skill file installation/removal
- [x] Integration tests for ContentTier mapping
- [ ] `prek run` (fmt + clippy + tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OpenCode connector support and MAG CLI workflows for storing, searching, session context, checkpoint/resume, and maintenance.

* **Documentation**
  * Added user-facing docs and skill guides for storing, recalling, checkpointing/resuming, and health/diagnostics; includes safety guidance against storing secrets or large code blocks.

* **Bug Fixes / Chores**
  * Improved install/uninstall behavior for connector content: idempotency, sentinel handling, atomic writes, and clearer removal reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->