### PR TITLE
ci: add version-consistency check across all manifests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,13 @@ jobs:
 
   version-check:
     name: Version Consistency
+    if: github.actor != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
       - name: Check version consistency
         run: |
           for f in Cargo.toml npm/package.json python/pyproject.toml; do


### PR DESCRIPTION
## Summary
- Add CI job to verify Cargo.toml, package.json, and pyproject.toml declare same version
- Runs on every push/PR to catch drift early
- Clear error message on mismatch

Closes #197

## Test plan
- [ ] CI passes when versions match
- [ ] CI would catch intentional mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated version-consistency validation in CI to ensure Rust, Node, and Python package configs share the same semantic version.
  * CI now verifies required manifest files are present and fails early with clear error output if any are missing.
  * Workflow reports all detected versions and fails the run if versions diverge; prints a success confirmation when they match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->