### PR TITLE
docs: explicit --non-interactive flag in install.sh + fix quickstart UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,15 @@ MAG fixes this. It gives your AI tools persistent memory that survives across se
 curl -fsSL https://raw.githubusercontent.com/George-RD/mag/main/install.sh | sh
 ```
 
+That's it. The installer auto-detects your AI tools and wires MAG in automatically — no manual JSON editing needed. Open your coding tool and your assistant already has persistent memory.
+
+To store or search memories directly from the CLI:
+
 ```bash
 mag ingest "The retry logic should use exponential backoff with jitter"
 mag search "how should retries work?"
 # → "The retry logic should use exponential backoff with jitter" (score: 0.94)
 ```
-
-That's it. One command to install, one to store, one to recall. The installer auto-detects your AI tools and configures them — no manual JSON editing needed.
 
 ---
 
@@ -62,7 +64,7 @@ That's it. One command to install, one to store, one to recall. The installer au
 | Cline | ✅ | ✅ | `mag setup` |
 | Gemini CLI | ✅ | ✅ | `mag setup` |
 | Zed | ✅ | ✅ | Manual |
-| Codex (OpenAI) | ✅ | ✅ | Manual |
+| Codex (OpenAI) | ✅ | ✅ | `mag setup` |
 
 Any tool that supports MCP can connect to MAG. Windows is untested - [report your results](https://github.com/George-RD/mag/issues).
 

--- a/docs/strongholds/siege-pr233.md
+++ b/docs/strongholds/siege-pr233.md
@@ -1,9 +1,9 @@
 # Siege Stronghold — PR #233
 
 **PR**: https://github.com/George-RD/mag/pull/233
-**Status**: active
+**Status**: merged
 **Round**: 2 / 10 max
-**Action**: CONTINUE
+**Action**: STOP
 **Dispatch**: idle
 **CI_Fail_Streak**: 0
 

--- a/install.sh
+++ b/install.sh
@@ -1,14 +1,17 @@
 #!/bin/sh
 # Install MAG — curl -fsSL https://raw.githubusercontent.com/George-RD/mag/main/install.sh | sh
+#                           (non-interactive: pipe to sh — TTY not required)
+# Or explicitly: curl -fsSL https://raw.githubusercontent.com/George-RD/mag/main/install.sh | sh -s -- --non-interactive
 #
 # Environment variables:
 #   VERSION          — install a specific version (e.g. "0.1.0"); default: latest
 #   MAG_INSTALL_DIR  — destination directory; default: ~/.mag/bin
 #
 # Flags:
-#   --version <VER>  — install a specific version
-#   --uninstall      — remove MAG binary, configs, and optionally data
-#   --help           — show usage
+#   --version <VER>     — install a specific version
+#   --non-interactive   — skip all prompts; configure all detected tools automatically
+#   --uninstall         — remove MAG binary, configs, and optionally data
+#   --help              — show usage
 #
 # Requirements: curl or wget, tar, and optionally sha256sum/shasum for verification.
 
@@ -50,7 +53,14 @@ ${BOLD}Install MAG${RESET} — Local MCP memory server
 
 Usage:
   curl -fsSL https://raw.githubusercontent.com/George-RD/mag/main/install.sh | sh
-  ./install.sh [--version 0.1.0] [--uninstall] [--help]
+  curl -fsSL https://raw.githubusercontent.com/George-RD/mag/main/install.sh | sh -s -- --non-interactive
+  ./install.sh [--version 0.1.0] [--non-interactive] [--uninstall] [--help]
+
+Flags:
+  --non-interactive   Skip all prompts; configure all detected tools automatically
+  --version <VER>     Install a specific version
+  --uninstall         Remove MAG binary, configs, and optionally data
+  --help              Show this message
 
 Environment variables:
   VERSION          Install a specific version (default: latest release)
@@ -69,6 +79,10 @@ parse_args() {
                 [ $# -ge 2 ] || die "--version requires a value"
                 VERSION="$2"
                 shift 2
+                ;;
+            --non-interactive)
+                NON_INTERACTIVE=1
+                shift
                 ;;
             --uninstall)
                 UNINSTALL=1
@@ -122,7 +136,7 @@ do_uninstall() {
     # Prompt to remove data directory if interactive
     MAG_DATA_DIR="${HOME}/.mag"
     if [ -d "$MAG_DATA_DIR" ]; then
-        if [ -t 0 ] && [ -z "${CI:-}" ] && [ -z "${GITHUB_ACTIONS:-}" ]; then
+        if [ "${NON_INTERACTIVE:-0}" != "1" ] && [ -t 0 ] && [ -z "${CI:-}" ] && [ -z "${GITHUB_ACTIONS:-}" ]; then
             printf '\n  Remove MAG data directory (%s)? [y/N] ' "$MAG_DATA_DIR"
             REPLY=""
             read -r REPLY || true
@@ -381,12 +395,12 @@ run_setup() {
     MAG_BIN="${INSTALL_DIR}/mag"
 
     SETUP_EXIT=0
-    if [ -t 0 ] && [ -z "${CI:-}" ] && [ -z "${GITHUB_ACTIONS:-}" ]; then
-        # Interactive: run setup wizard
-        "$MAG_BIN" setup || SETUP_EXIT=$?
-    else
+    if [ "${NON_INTERACTIVE:-0}" = "1" ] || [ ! -t 0 ] || [ -n "${CI:-}" ] || [ -n "${GITHUB_ACTIONS:-}" ]; then
         # Non-interactive: configure all tools silently
         "$MAG_BIN" setup --non-interactive || SETUP_EXIT=$?
+    else
+        # Interactive: run setup wizard
+        "$MAG_BIN" setup || SETUP_EXIT=$?
     fi
 
     case "$SETUP_EXIT" in


### PR DESCRIPTION
## Summary

- **install.sh**: Add `--non-interactive` flag to `parse_args` so `curl ... | sh -s -- --non-interactive` works explicitly (previously only TTY-detected). Update header comment, `usage()`, and `run_setup` to check the flag first.
- **README quickstart**: Rewrite the post-install message so the happy path is "open your coding tool — memory is already wired up", not "run CLI commands manually". Manual `mag ingest`/`mag search` examples are still there but clearly framed as optional direct CLI usage.
- **README Works With table**: Mark Codex (OpenAI) as `mag setup` — TOML config writing was implemented in #233.

## Test plan

- [ ] `curl ... | sh -s -- --non-interactive` installs without prompts and configures all detected tools
- [ ] `./install.sh --non-interactive` works the same way
- [ ] `./install.sh --help` shows updated flags documentation
- [ ] `./install.sh` (interactive TTY) still launches the setup wizard
- [ ] README quickstart reads naturally: install → open tool → memory works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer adds a --non-interactive mode to run setup and suppress prompts for automated installs

* **Documentation**
  * Quick Start updated to describe automatic AI-tool detection and direct CLI usage (mag ingest / mag search)
  * Compatibility table updated to reflect additional tools auto-configured via mag setup
  * Strongholds doc metadata updated (status moved to merged)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->