### PR TITLE
chore(plugin): bump plugin version to 0.1.1

### DIFF
--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mag",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Persistent local memory for AI coding assistants — store decisions, patterns, and context across sessions",
   "author": {
     "name": "MAG",


### PR DESCRIPTION
Bumps the Claude Code plugin version from \`0.1.0\` to \`0.1.1\` to reflect the MCP transport fix shipped in #237 (switched from HTTP daemon transport to portable \`sh -c\` stdio).

🤖 Generated with [Claude Code](https://claude.com/claude-code)