### PR TITLE
chore: bump version to v0.1.8-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1242,7 +1242,7 @@ checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
 name = "mag-memory"
-version = "0.1.7"
+version = "0.1.8-dev"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mag-memory"
-version = "0.1.7"
+version = "0.1.8-dev"
 edition = "2024"
 autobenches = false
 license = "MIT"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mag-memory",
-  "version": "0.1.7",
+  "version": "0.1.8-dev",
   "description": "MAG — Memory Augmented Generation. Local MCP memory server with ONNX embeddings.",
   "license": "MIT",
   "repository": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mag-memory"
-version = "0.1.7"
+version = "0.1.8-dev"
 description = "PyPI wrapper for the mag MCP memory server (Rust binary)"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Post-release dev bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Package version updated to 0.1.8-dev for development across Rust, npm, and Python packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->