### PR TITLE
feat(plugin): graduate JSONL telemetry to production hooks

### DIFF
--- a/plugin/hooks/hooks.json
+++ b/plugin/hooks/hooks.json
@@ -17,7 +17,7 @@
         {
           "type": "command",
           "command": "${CLAUDE_PLUGIN_ROOT}/scripts/prompt-gate.sh",
-          "timeout": 50
+          "timeout": 100
         }
       ]
     }
@@ -57,6 +57,17 @@
           "type": "command",
           "command": "${CLAUDE_PLUGIN_ROOT}/scripts/error-capture.sh",
           "timeout": 4000
+        }
+      ]
+    }
+  ],
+  "SubagentStop": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": "${CLAUDE_PLUGIN_ROOT}/scripts/subagent-end.sh",
+          "timeout": 5000
         }
       ]
     }

--- a/plugin/scripts/commit-capture.sh
+++ b/plugin/scripts/commit-capture.sh
@@ -4,6 +4,15 @@
 # Receives: $CLAUDE_TOOL_INPUT (JSON), $CLAUDE_TOOL_OUTPUT (JSON)
 set -eu
 
+MAG_DATA_ROOT="${MAG_DATA_ROOT:-$HOME/.mag}"
+export MAG_DATA_ROOT
+
+LOG="$MAG_DATA_ROOT/auto-capture.jsonl"
+# Millisecond-precision timestamp (perl is POSIX-portable; date +%s%N is Linux-only)
+now_ms() {
+  perl -MTime::HiRes=time -e 'printf "%d\n", time*1000' 2>/dev/null || printf '%s000' "$(date +%s)"
+}
+
 # Fast-path rejection — plain string check before any process forks.
 # CLAUDE_TOOL_INPUT is JSON like {"command":"jj commit -m ..."}, so a substring
 # match on the raw string is safe and avoids the cost of jq for ~95% of calls.
@@ -13,7 +22,15 @@ case "$INPUT" in
   *) exit 0 ;;
 esac
 
+START_TS=$(now_ms)
+
 COMMAND="$(printf '%s' "$INPUT" | jq -r '.command // empty' 2>/dev/null || true)"
+
+# Detect VCS tool
+VCS_TOOL="git"
+case "$COMMAND" in
+  *"jj commit"*|*"jj describe"*) VCS_TOOL="jj" ;;
+esac
 
 # Extract commit message from -m flag (quoted, then unquoted fallback)
 MSG="$(printf '%s' "$COMMAND" | sed -nE "s/.*-m[[:space:]]+['\"]([^'\"]*)['\"].*/\1/p" | head -1 || true)"
@@ -30,15 +47,60 @@ fi
 [ -n "$MSG" ] || exit 0
 
 PROJECT="$(basename "$PWD")"
-SESSION_ID="${CLAUDE_SESSION_ID:-unknown}"
+SESSION_ID="${CLAUDE_SESSION_ID:-}"
 
-mkdir -p "$HOME/.mag"
-printf '%s git_commit project=%s session=%s msg=%.80s\n' \
-  "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PROJECT" "$SESSION_ID" "$MSG" \
-  >> "$HOME/.mag/auto-capture.log" 2>/dev/null || true
+mkdir -p "$MAG_DATA_ROOT"
 
+# Invoke mag and capture exit code
+MAG_EXIT=0
 mag process "Commit: $MSG" \
   --event-type git_commit \
   --project "$PROJECT" \
   --session-id "$SESSION_ID" \
-  --importance 0.5 2>/dev/null || true
+  --importance 0.5 2>/dev/null || MAG_EXIT=$?
+
+END_TS=$(now_ms)
+DURATION_MS=$(( END_TS - START_TS ))
+
+HOOK_STATUS="ok"
+HOOK_ERROR="null"
+if [ "$MAG_EXIT" -ne 0 ]; then
+  HOOK_STATUS="error"
+  HOOK_ERROR="\"mag exited $MAG_EXIT\""
+fi
+
+# Emit JSONL
+if command -v jq >/dev/null 2>&1; then
+  # Reflect actual store result: stored:true only when mag exited successfully
+  if [ "$MAG_EXIT" -eq 0 ]; then
+    MEM_BLOCK="$(jq -n --arg content "Commit: $MSG" --arg proj "$PROJECT" \
+      '{stored:true,content:$content,project:$proj,event_type:"git_commit"}' 2>/dev/null || printf 'null')"
+  else
+    MEM_BLOCK="$(jq -n --arg proj "$PROJECT" --arg exit_code "$MAG_EXIT" \
+      '{stored:false,project:$proj,event_type:"git_commit",error:("mag exited " + $exit_code)}' 2>/dev/null || printf 'null')"
+  fi
+  jq -nc \
+    --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg session_id "$SESSION_ID" \
+    --arg proj "$PROJECT" \
+    --arg dur "$DURATION_MS" \
+    --arg status "$HOOK_STATUS" \
+    --argjson err "$HOOK_ERROR" \
+    --argjson mem "$MEM_BLOCK" \
+    --arg commit_msg "$MSG" \
+    --arg vcs "$VCS_TOOL" \
+    '{v:0,ts:$ts,event:"hook.commit_capture",session_id:($session_id | if . == "" then null else . end),project:$proj,agent:{id:null,type:null,tool:"claude_code"},hook:{name:"commit-capture",duration_ms:($dur|tonumber),status:$status,error:$err},memory:$mem,context:{commit_message:$commit_msg,vcs_tool:$vcs}}' \
+    >> "$LOG" 2>/dev/null || true
+else
+  # Degraded output: jq unavailable. Some fields omitted. Install jq for full telemetry.
+  SAFE_ERROR=$(printf '%s' "$HOOK_ERROR" | sed 's/\\/\\\\/g; s/"/\\"/g')
+  if [ "$HOOK_STATUS" = "error" ]; then
+    printf '{"v":0,"ts":"%s","event":"hook.commit_capture","session_id":null,"project":"%s","hook":{"name":"commit-capture","duration_ms":%s,"status":"%s","error":"%s"}}\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PROJECT" "$DURATION_MS" "$HOOK_STATUS" "$SAFE_ERROR" \
+      >> "$LOG" 2>/dev/null || true
+  else
+    printf '{"v":0,"ts":"%s","event":"hook.commit_capture","session_id":null,"project":"%s","hook":{"name":"commit-capture","duration_ms":%s,"status":"%s","error":null}}\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PROJECT" "$DURATION_MS" "$HOOK_STATUS" \
+      >> "$LOG" 2>/dev/null || true
+  fi
+fi

--- a/plugin/scripts/compact-refresh.sh
+++ b/plugin/scripts/compact-refresh.sh
@@ -1,10 +1,18 @@
 #!/bin/sh
-# MAG post-compact — re-inject memories + restore pre-compact state
+# MAG post-compact — re-inject memories + restore pre-compact state, emit JSONL
 set -eu
 
-LOG="$HOME/.mag/auto-capture.log"
-STATE_DIR="$HOME/.mag/state"
-mkdir -p "$HOME/.mag" "$STATE_DIR"
+MAG_DATA_ROOT="${MAG_DATA_ROOT:-$HOME/.mag}"
+export MAG_DATA_ROOT
+
+LOG="$MAG_DATA_ROOT/auto-capture.jsonl"
+STATE_DIR="$MAG_DATA_ROOT/state"
+# Millisecond-precision timestamp (perl is POSIX-portable; date +%s%N is Linux-only)
+now_ms() {
+  perl -MTime::HiRes=time -e 'printf "%d\n", time*1000' 2>/dev/null || printf '%s000' "$(date +%s)"
+}
+START_TS=$(now_ms)
+mkdir -p "$MAG_DATA_ROOT" "$STATE_DIR"
 
 # Read stdin JSON for session context
 INPUT=$(cat 2>/dev/null) || INPUT=""
@@ -14,21 +22,19 @@ if command -v jq >/dev/null 2>&1 && [ -n "$INPUT" ]; then
   CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || CWD=""
   COMPACT_SUMMARY=$(printf '%s' "$INPUT" | jq -r '.compact_summary // empty' 2>/dev/null) || COMPACT_SUMMARY=""
 else
-  SESSION_ID="${CLAUDE_SESSION_ID:-unknown}"
+  SESSION_ID="${CLAUDE_SESSION_ID:-}"
   CWD="$PWD"
   COMPACT_SUMMARY=""
 fi
 
-SESSION_ID="${SESSION_ID:-${CLAUDE_SESSION_ID:-unknown}}"
+SESSION_ID="${SESSION_ID:-${CLAUDE_SESSION_ID:-}}"
 CWD="${CWD:-$PWD}"
 PROJECT="$(basename "$CWD")"
 
-# Log the event
-printf '%s compact_refresh project=%s session=%s\n' \
-  "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PROJECT" "$SESSION_ID" >> "$LOG" 2>/dev/null || true
-
 # Re-inject top memories (full budget — context is smallest after compaction)
-mag welcome --project "$PROJECT" --session-id "$SESSION_ID" --budget-tokens 2000 >/dev/null 2>/dev/null || true
+# Capture output: PostCompact hooks return additionalContext to Claude via stdout
+WELCOME_OUTPUT=""
+WELCOME_OUTPUT=$(mag welcome --project "$PROJECT" --session-id "$SESSION_ID" --budget-tokens 2000 2>/dev/null) || true
 
 # Store compact summary as a memory if available
 if [ -n "$COMPACT_SUMMARY" ]; then
@@ -41,12 +47,12 @@ fi
 
 # Restore pre-compact snapshot if one was saved
 SNAPSHOT="$STATE_DIR/pre-compact-$SESSION_ID.json"
+RESTORE=""
 if [ -f "$SNAPSHOT" ] && command -v jq >/dev/null 2>&1; then
   WD=$(jq -r '.working_directory // empty' "$SNAPSHOT" 2>/dev/null) || WD=""
   RF=$(jq -r '.recent_file // empty' "$SNAPSHOT" 2>/dev/null) || RF=""
   VCS=$(jq -r '.vcs_state // empty' "$SNAPSHOT" 2>/dev/null) || VCS=""
 
-  RESTORE=""
   [ -n "$WD" ] && RESTORE="${RESTORE}Working directory: $WD
 "
   [ -n "$RF" ] && RESTORE="${RESTORE}Recent file: $RF
@@ -54,13 +60,47 @@ if [ -f "$SNAPSHOT" ] && command -v jq >/dev/null 2>&1; then
   [ -n "$VCS" ] && RESTORE="${RESTORE}VCS state: $VCS
 "
 
-  if [ -n "$RESTORE" ]; then
-    jq -n --arg r "<MAG_RESTORE>Pre-compact state recovered:
-${RESTORE}</MAG_RESTORE>" \
-      '{"additionalContext": $r}' 2>/dev/null || true
-  fi
-
   rm -f "$SNAPSHOT"
+fi
+
+# Emit additionalContext to stdout (consumed by Claude Code PostCompact contract)
+# Always emit — even without jq — so compaction recovery is never a silent no-op.
+CONTEXT_PARTS=""
+[ -n "$WELCOME_OUTPUT" ] && CONTEXT_PARTS="$WELCOME_OUTPUT"
+if [ -n "$RESTORE" ]; then
+  CONTEXT_PARTS="${CONTEXT_PARTS:+${CONTEXT_PARTS}
+}<MAG_RESTORE>Pre-compact state recovered:
+${RESTORE}</MAG_RESTORE>"
+fi
+if [ -n "$CONTEXT_PARTS" ]; then
+  if command -v jq >/dev/null 2>&1; then
+    jq -n --arg r "$CONTEXT_PARTS" '{"additionalContext": $r}' 2>/dev/null || true
+  else
+    # Fallback: emit a safe JSON object without jq (strip special chars that break JSON)
+    SAFE_CONTEXT=$(printf '%s' "$CONTEXT_PARTS" | tr -d '\000-\037' | sed 's/\\/\\\\/g; s/"/\\"/g')
+    printf '{"additionalContext":"%s"}\n' "$SAFE_CONTEXT"
+  fi
+fi
+
+END_TS=$(now_ms)
+DURATION_MS=$(( END_TS - START_TS ))
+
+# Emit JSONL — truncate compact_summary preview to 200 chars
+if command -v jq >/dev/null 2>&1; then
+  SUMMARY_PREVIEW="$(printf '%.200s' "$COMPACT_SUMMARY")"
+  jq -nc \
+    --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg session_id "$SESSION_ID" \
+    --arg proj "$PROJECT" \
+    --arg dur "$DURATION_MS" \
+    --arg summary_preview "$SUMMARY_PREVIEW" \
+    '{v:0,ts:$ts,event:"hook.post_compact",session_id:($session_id | if . == "" then null else . end),project:$proj,agent:{id:null,type:null,tool:"claude_code"},hook:{name:"compact-refresh",duration_ms:($dur|tonumber),status:"ok",error:null},memory:null,context:{compact_summary:$summary_preview}}' \
+    >> "$LOG" 2>/dev/null || true
+else
+  # Degraded output: jq unavailable. Some fields omitted. Install jq for full telemetry.
+  printf '{"v":0,"ts":"%s","event":"hook.post_compact","session_id":null,"project":"%s","hook":{"name":"compact-refresh","duration_ms":%s,"status":"ok","error":null}}\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PROJECT" "$DURATION_MS" \
+    >> "$LOG" 2>/dev/null || true
 fi
 
 exit 0

--- a/plugin/scripts/error-capture.sh
+++ b/plugin/scripts/error-capture.sh
@@ -4,6 +4,15 @@
 # Receives: $CLAUDE_TOOL_INPUT (command JSON), $CLAUDE_TOOL_OUTPUT (output JSON)
 set -eu
 
+MAG_DATA_ROOT="${MAG_DATA_ROOT:-$HOME/.mag}"
+export MAG_DATA_ROOT
+
+LOG="$MAG_DATA_ROOT/auto-capture.jsonl"
+# Millisecond-precision timestamp (perl is POSIX-portable; date +%s%N is Linux-only)
+now_ms() {
+  perl -MTime::HiRes=time -e 'printf "%d\n", time*1000' 2>/dev/null || printf '%s000' "$(date +%s)"
+}
+
 # Fast-path: only process build/test commands
 TOOL_INPUT="${CLAUDE_TOOL_INPUT:-}"
 case "$TOOL_INPUT" in
@@ -23,6 +32,8 @@ case "$TOOL_OUTPUT" in
     exit 0
     ;;
 esac
+
+START_TS=$(now_ms)
 
 # Extract first error line (Rust-style: starts with "error[E0XXX]:" or "error: ")
 ERROR_LINE=$(printf '%s' "$TOOL_OUTPUT" | grep -m1 -E '^error(\[E[0-9]+\])?: ' 2>/dev/null || true)
@@ -45,21 +56,55 @@ ERROR_LINE="$(printf '%.200s' "$ERROR_LINE")"
 
 # Derive project and session (after fast-path so non-build commands skip this)
 PROJECT="$(basename "$PWD")"
-SESSION_ID="${CLAUDE_SESSION_ID:-unknown}"
-LOG="$HOME/.mag/auto-capture.log"
+SESSION_ID="${CLAUDE_SESSION_ID:-}"
 
-# Telemetry: log BEFORE mag invocation
-# Note: hooks in the same array run sequentially, so no flock needed vs commit-capture
-mkdir -p "$HOME/.mag"
-printf '%s [error-capture] project=%s error=%s\n' \
-  "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date +%s)" \
-  "$PROJECT" \
-  "$ERROR_LINE" \
-  >> "$LOG" 2>/dev/null || true
+# Extract command preview for context
+CMD_PREVIEW="$(printf '%s' "$TOOL_INPUT" | jq -r '.command // empty' 2>/dev/null | head -c 100 || true)"
 
+mkdir -p "$MAG_DATA_ROOT"
+
+# Invoke mag and capture exit code
+MAG_EXIT=0
 mag process "Build/test error in $PROJECT: $ERROR_LINE" \
   --event-type error_pattern \
   --project "$PROJECT" \
   --session-id "$SESSION_ID" \
   --importance 0.5 \
-  2>/dev/null || true
+  2>/dev/null || MAG_EXIT=$?
+
+END_TS=$(now_ms)
+DURATION_MS=$(( END_TS - START_TS ))
+
+HOOK_STATUS="ok"
+HOOK_ERROR="null"
+if [ "$MAG_EXIT" -ne 0 ]; then
+  HOOK_STATUS="error"
+  HOOK_ERROR="\"mag exited $MAG_EXIT\""
+fi
+
+# Emit JSONL
+if command -v jq >/dev/null 2>&1; then
+  jq -nc \
+    --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg session_id "$SESSION_ID" \
+    --arg proj "$PROJECT" \
+    --arg dur "$DURATION_MS" \
+    --arg status "$HOOK_STATUS" \
+    --argjson err "$HOOK_ERROR" \
+    --arg error_line "$ERROR_LINE" \
+    --arg cmd_preview "$CMD_PREVIEW" \
+    '{v:0,ts:$ts,event:"hook.error_capture",session_id:($session_id | if . == "" then null else . end),project:$proj,agent:{id:null,type:null,tool:"claude_code"},hook:{name:"error-capture",duration_ms:($dur|tonumber),status:$status,error:$err},memory:null,context:{error_line:$error_line,command_preview:$cmd_preview}}' \
+    >> "$LOG" 2>/dev/null || true
+else
+  # Degraded output: jq unavailable. Some fields omitted. Install jq for full telemetry.
+  SAFE_ERROR=$(printf '%s' "$HOOK_ERROR" | sed 's/\\/\\\\/g; s/"/\\"/g')
+  if [ "$HOOK_STATUS" = "error" ]; then
+    printf '{"v":0,"ts":"%s","event":"hook.error_capture","session_id":null,"project":"%s","hook":{"name":"error-capture","duration_ms":%s,"status":"%s","error":"%s"}}\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PROJECT" "$DURATION_MS" "$HOOK_STATUS" "$SAFE_ERROR" \
+      >> "$LOG" 2>/dev/null || true
+  else
+    printf '{"v":0,"ts":"%s","event":"hook.error_capture","session_id":null,"project":"%s","hook":{"name":"error-capture","duration_ms":%s,"status":"%s","error":null}}\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PROJECT" "$DURATION_MS" "$HOOK_STATUS" \
+      >> "$LOG" 2>/dev/null || true
+  fi
+fi

--- a/plugin/scripts/pre-compact.sh
+++ b/plugin/scripts/pre-compact.sh
@@ -3,9 +3,17 @@
 # Fire-and-forget: no stdout contract, output is ignored by Claude Code
 set -eu
 
-STATE_DIR="$HOME/.mag/state"
-LOG="$HOME/.mag/auto-capture.log"
-mkdir -p "$STATE_DIR" "$HOME/.mag"
+MAG_DATA_ROOT="${MAG_DATA_ROOT:-$HOME/.mag}"
+export MAG_DATA_ROOT
+
+STATE_DIR="$MAG_DATA_ROOT/state"
+LOG="$MAG_DATA_ROOT/auto-capture.jsonl"
+# Millisecond-precision timestamp (perl is POSIX-portable; date +%s%N is Linux-only)
+now_ms() {
+  perl -MTime::HiRes=time -e 'printf "%d\n", time*1000' 2>/dev/null || printf '%s000' "$(date +%s)"
+}
+START_TS=$(now_ms)
+mkdir -p "$MAG_DATA_ROOT" "$STATE_DIR"
 
 # Read stdin JSON for session context
 INPUT=$(cat 2>/dev/null) || INPUT=""
@@ -17,27 +25,25 @@ if command -v jq >/dev/null 2>&1 && [ -n "$INPUT" ]; then
   TRIGGER=$(printf '%s' "$INPUT" | jq -r '.trigger // empty' 2>/dev/null) || TRIGGER=""
 else
   # Graceful degradation without jq
-  SESSION_ID="${CLAUDE_SESSION_ID:-unknown}"
+  SESSION_ID="${CLAUDE_SESSION_ID:-}"
   TRANSCRIPT_PATH=""
   CWD="$PWD"
   TRIGGER=""
 fi
 
-# Fallbacks
-SESSION_ID="${SESSION_ID:-${CLAUDE_SESSION_ID:-unknown}}"
+# Fallbacks — explicit defaults for all variables used under set -u
+SESSION_ID="${SESSION_ID:-${CLAUDE_SESSION_ID:-}}"
 CWD="${CWD:-$PWD}"
+TRIGGER="${TRIGGER:-}"
+TRANSCRIPT_PATH="${TRANSCRIPT_PATH:-}"
 PROJECT="$(basename "$CWD")"
-
-# Log the event
-printf '%s pre_compact project=%s session=%s trigger=%s\n' \
-  "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PROJECT" "$SESSION_ID" "$TRIGGER" >> "$LOG" 2>/dev/null || true
 
 # Collect VCS state (run in the project CWD parsed from the hook payload)
 VCS_STATE=""
 if [ -d "$CWD" ] && command -v jj >/dev/null 2>&1 && (cd "$CWD" && jj root >/dev/null 2>&1); then
   VCS_STATE=$(cd "$CWD" && jj log --no-graph -r '@' -T 'change_id.shortest(8) ++ " " ++ description.first_line()' 2>/dev/null) || VCS_STATE=""
-elif [ -d "$CWD" ] && command -v git >/dev/null 2>&1 && (cd "$CWD" && git rev-parse --git-dir >/dev/null 2>&1); then
-  VCS_STATE=$(cd "$CWD" && git log --oneline -1 2>/dev/null) || VCS_STATE=""
+elif [ -d "$CWD" ] && command -v jj >/dev/null 2>&1; then
+  VCS_STATE=$(cd "$CWD" && jj log --oneline -1 2>/dev/null) || VCS_STATE=""
 fi
 
 # Collect recent file from transcript
@@ -59,24 +65,37 @@ if command -v jq >/dev/null 2>&1; then
     --arg vcs "$VCS_STATE" \
     --arg rf "$RECENT_FILE" \
     '{session_id: $sid, timestamp: $ts, project: $proj, working_directory: $cwd, trigger: $trigger, vcs_state: $vcs, recent_file: $rf}' \
-    > "$STATE_DIR/pre-compact-$SESSION_ID.json" 2>/dev/null || {
-    printf '%s pre_compact_write_failed session=%s\n' \
-      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$SESSION_ID" >> "$LOG" 2>/dev/null || true
-  }
+    > "$STATE_DIR/pre-compact-$SESSION_ID.json" 2>/dev/null || true
 else
-  # Minimal fallback without jq — only safe fields (UUIDs, dirnames, timestamps)
-  # vcs_state and recent_file are omitted: they can contain arbitrary characters unsafe for printf JSON
-  # Sanitize CWD for safe printf JSON (remove double-quotes and backslashes)
-  SAFE_CWD=$(printf '%s' "$CWD" | tr -d '"\\')
+  # Minimal fallback without jq
+  SAFE_CWD=$(printf '%s' "$CWD" | sed 's/\\/\\\\/g; s/"/\\"/g')
   printf '{"session_id":"%s","timestamp":"%s","project":"%s","working_directory":"%s","trigger":"%s"}\n' \
     "$SESSION_ID" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PROJECT" "$SAFE_CWD" "$TRIGGER" \
-    > "$STATE_DIR/pre-compact-$SESSION_ID.json" 2>/dev/null || {
-    printf '%s pre_compact_write_failed session=%s\n' \
-      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$SESSION_ID" >> "$LOG" 2>/dev/null || true
-  }
+    > "$STATE_DIR/pre-compact-$SESSION_ID.json" 2>/dev/null || true
 fi
 
-# Reap stale snapshots older than ~1 day
-find "$STATE_DIR" -name 'pre-compact-*.json' -mtime +1 -delete 2>/dev/null || true
+END_TS=$(now_ms)
+DURATION_MS=$(( END_TS - START_TS ))
+
+# Emit JSONL — schema v:0 (campaign decision D1)
+if command -v jq >/dev/null 2>&1; then
+  jq -nc \
+    --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg session_id "$SESSION_ID" \
+    --arg proj "$PROJECT" \
+    --arg dur "$DURATION_MS" \
+    --arg vcs "${VCS_STATE:-}" \
+    --arg rf "${RECENT_FILE:-}" \
+    --arg trigger "${TRIGGER:-}" \
+    --arg transcript "${TRANSCRIPT_PATH:-}" \
+    '{v:0,ts:$ts,event:"hook.pre_compact",session_id:($session_id | if . == "" then null else . end),project:$proj,agent:{id:null,type:null,tool:"claude_code"},hook:{name:"pre-compact",duration_ms:($dur|tonumber),status:"ok",error:null},memory:null,context:{vcs_state:$vcs,recent_file:$rf,trigger:$trigger,transcript_path:$transcript}}' \
+    >> "$LOG" 2>/dev/null || true
+else
+  # Degraded output: jq unavailable. Some fields omitted. Install jq for full telemetry.
+  printf '{"v":0,"ts":"%s","event":"hook.pre_compact","session_id":null,"project":"%s","hook":{"name":"pre-compact","duration_ms":%s,"status":"ok","error":null}}\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PROJECT" "$DURATION_MS" \
+    >> "$LOG" 2>/dev/null || true
+fi
+
 
 exit 0

--- a/plugin/scripts/prompt-gate.sh
+++ b/plugin/scripts/prompt-gate.sh
@@ -1,25 +1,72 @@
-#!/bin/sh
+#\!/bin/sh
 # MAG prompt gate — pure regex, NO daemon call, <1ms
 # Outputs a hint only when the prompt suggests memory would help
-# Silence (empty stdout) is the default for ~95% of prompts
+# Emits JSONL to log only when a hint is emitted (keeps log clean)
+set -eu
 
-read -r PROMPT || true
+MAG_DATA_ROOT="${MAG_DATA_ROOT:-$HOME/.mag}"
+export MAG_DATA_ROOT
+
+LOG="$MAG_DATA_ROOT/auto-capture.jsonl"
+
+# Read stdin JSON (UserPromptSubmit provides prompt field)
+INPUT=$(cat 2>/dev/null) || INPUT=""
+
+if command -v jq >/dev/null 2>&1 && [ -n "$INPUT" ]; then
+  PROMPT=$(printf '%s' "$INPUT" | jq -r '.prompt // empty' 2>/dev/null) || PROMPT=""
+  SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null) || SESSION_ID=""
+else
+  # Fallback: read first line as raw text (legacy behavior)
+  PROMPT=$(printf '%s' "$INPUT" | head -1 || true)
+  SESSION_ID=""
+fi
+
+SESSION_ID="${SESSION_ID:-}"
 
 # Check for memory-relevant signals
+HINT=""
+HINT_TYPE=""
 case "$PROMPT" in
   *remember*|*"don't forget"*|*"store this"*|*"note that"*|*"save this"*)
-    echo '{"additionalContext":"<MAG_HINT>User wants to store something. Use: mag process \"content\" --event-type TYPE --project PROJECT --importance 0.8</MAG_HINT>"}'
-    exit 0
+    HINT='{"additionalContext":"<MAG_HINT>User wants to store something. Use: mag process \"content\" --event-type TYPE --project PROJECT --importance 0.8</MAG_HINT>"}'
+    HINT_TYPE="store"
     ;;
   *"last time"*|*previously*|*"we discussed"*|*"what did we"*|*"we decided"*|*recall*)
-    echo '{"additionalContext":"<MAG_HINT>User references prior context. Use: mag advanced-search \"query\" --project PROJECT --limit 10</MAG_HINT>"}'
-    exit 0
+    HINT='{"additionalContext":"<MAG_HINT>User references prior context. Use: mag advanced-search \"query\" --project PROJECT --limit 10</MAG_HINT>"}'
+    HINT_TYPE="recall"
     ;;
   *checkpoint*|*handoff*|*"wrap up"*|*"pick up where"*)
-    echo '{"additionalContext":"<MAG_HINT>User wants checkpoint/handoff. Consider using mag checkpoint \"title\" \"progress\" --project PROJECT</MAG_HINT>"}'
+    HINT='{"additionalContext":"<MAG_HINT>User wants checkpoint/handoff. Consider using mag checkpoint \"title\" \"progress\" --project PROJECT</MAG_HINT>"}'
+    HINT_TYPE="checkpoint"
+    ;;
+  *)
+    # Default: silence. No memory injection needed.
     exit 0
     ;;
 esac
 
-# Default: silence. No memory injection needed.
+# Emit the additionalContext for Claude Code
+printf '%s\n' "$HINT"
+
+# Log JSONL event (only when hint emitted)
+mkdir -p "$MAG_DATA_ROOT"
+PROJECT="$(basename "$PWD")"
+PROMPT_PREVIEW="$(printf '%.80s' "$PROMPT")"
+if command -v jq >/dev/null 2>&1; then
+  # Use --arg for session_id (not --argjson) so special chars in session IDs are safe
+  jq -nc \
+    --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg session_id "$SESSION_ID" \
+    --arg proj "$PROJECT" \
+    --arg prompt_preview "$PROMPT_PREVIEW" \
+    --arg hint_type "$HINT_TYPE" \
+    '{v:0,ts:$ts,event:"hook.prompt_gate",session_id:($session_id | if . == "" then null else . end),project:$proj,agent:{id:null,type:null,tool:"claude_code"},hook:{name:"prompt-gate",duration_ms:0,status:"ok",error:null},memory:null,context:{prompt_preview:$prompt_preview,hint_type:$hint_type}}' \
+    >> "$LOG" 2>/dev/null || true
+else
+  # Degraded output: jq unavailable. Some fields omitted. Install jq for full telemetry.
+  printf '{"v":0,"ts":"%s","event":"hook.prompt_gate","session_id":null,"project":"%s","hook":{"name":"prompt-gate","duration_ms":0,"status":"ok","error":null}}\n' \
+    "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PROJECT" \
+    >> "$LOG" 2>/dev/null || true
+fi
+
 exit 0

--- a/plugin/scripts/session-end.sh
+++ b/plugin/scripts/session-end.sh
@@ -1,30 +1,98 @@
-#!/bin/sh
-# MAG session end — store lightweight session summary
-# Stop hook: $CLAUDE_TRANSCRIPT may be set by Claude Code
+#\!/bin/sh
+# MAG session end — store lightweight session summary, emit JSONL telemetry
+# Stop hook: reads stdin JSON from Claude Code
 set -eu
 
-PROJECT="$(basename "$PWD")"
-SESSION_ID="${CLAUDE_SESSION_ID:-unknown}"
-LOG="$HOME/.mag/auto-capture.log"
+MAG_DATA_ROOT="${MAG_DATA_ROOT:-$HOME/.mag}"
+export MAG_DATA_ROOT
 
-# Build summary from transcript tail if available; fall back to minimal marker
-if [ -n "${CLAUDE_TRANSCRIPT:-}" ]; then
-  # Truncate to 500 bytes to keep memory concise and avoid storing secrets
-  TAIL="$(printf '%.500s' "$CLAUDE_TRANSCRIPT")"
-  SUMMARY="Session ended. Project: $PROJECT. Recent context: $TAIL"
+LOG="$MAG_DATA_ROOT/auto-capture.jsonl"
+# Millisecond-precision timestamp (perl is POSIX-portable; date +%s%N is Linux-only)
+now_ms() {
+  perl -MTime::HiRes=time -e 'printf "%d\n", time*1000' 2>/dev/null || printf '%s000' "$(date +%s)"
+}
+START_TS=$(now_ms)
+
+# Read stdin JSON (Stop hook provides session_id, last_assistant_message, transcript_path, etc.)
+INPUT=$(cat 2>/dev/null) || INPUT=""
+
+if command -v jq >/dev/null 2>&1 && [ -n "$INPUT" ]; then
+  SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null) || SESSION_ID=""
+  CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || CWD=""
+  LAST_MSG=$(printf '%s' "$INPUT" | jq -r '.last_assistant_message // empty' 2>/dev/null) || LAST_MSG=""
+  TRANSCRIPT_PATH=$(printf '%s' "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null) || TRANSCRIPT_PATH=""
+  HOOK_EVENT=$(printf '%s' "$INPUT" | jq -r '.hook_event_name // empty' 2>/dev/null) || HOOK_EVENT=""
+else
+  SESSION_ID=""
+  CWD=""
+  LAST_MSG=""
+  TRANSCRIPT_PATH=""
+  HOOK_EVENT=""
+fi
+
+SESSION_ID="${SESSION_ID:-}"
+CWD="${CWD:-$PWD}"
+LAST_MSG="${LAST_MSG:-}"
+TRANSCRIPT_PATH="${TRANSCRIPT_PATH:-}"
+PROJECT="$(basename "$CWD")"
+
+# SubagentStop events are handled by subagent-end.sh — skip here
+if [ "$HOOK_EVENT" = "SubagentStop" ]; then
+  exit 0
+fi
+
+mkdir -p "$MAG_DATA_ROOT"
+
+# Truncate last_assistant_message to 200 chars for summary
+MSG_PREVIEW=""
+if [ -n "$LAST_MSG" ]; then
+  MSG_PREVIEW="$(printf '%.200s' "$LAST_MSG")"
+  SUMMARY="Session ended. Project: $PROJECT. Last assistant message: $MSG_PREVIEW"
 else
   SUMMARY="Session ended. Project: $PROJECT."
 fi
 
-# Log BEFORE invocation
-mkdir -p "$HOME/.mag"
-printf '%s session_end project=%s session=%s\n' \
-  "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PROJECT" "$SESSION_ID" >> "$LOG" 2>/dev/null || true
-
-# Use session_end event type (TTL_LONG_TERM = 14 days).
-# Do NOT use session_summary: that maps to TTL_EPHEMERAL (1 hour) and self-destructs.
+# Invoke mag and capture exit code
+MAG_EXIT=0
 mag process "$SUMMARY" \
   --event-type session_end \
   --project "$PROJECT" \
   --session-id "$SESSION_ID" \
-  --importance 0.4 2>/dev/null || true
+  --importance 0.4 2>/dev/null || MAG_EXIT=$?
+
+END_TS=$(now_ms)
+DURATION_MS=$(( END_TS - START_TS ))
+
+HOOK_STATUS="ok"
+HOOK_ERROR="null"
+if [ "$MAG_EXIT" -ne 0 ]; then
+  HOOK_STATUS="error"
+  HOOK_ERROR="\"mag exited $MAG_EXIT\""
+fi
+
+# Emit JSONL
+if command -v jq >/dev/null 2>&1; then
+  jq -nc \
+    --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg session_id "$SESSION_ID" \
+    --arg proj "$PROJECT" \
+    --arg dur "$DURATION_MS" \
+    --arg status "$HOOK_STATUS" \
+    --argjson err "$HOOK_ERROR" \
+    --arg msg_preview "${MSG_PREVIEW:-}" \
+    --arg transcript "${TRANSCRIPT_PATH:-}" \
+    '{v:0,ts:$ts,event:"hook.session_end",session_id:($session_id | if . == "" then null else . end),project:$proj,agent:{id:null,type:null,tool:"claude_code"},hook:{name:"session-end",duration_ms:($dur|tonumber),status:$status,error:$err},memory:null,context:{last_assistant_message:$msg_preview,transcript_path:$transcript}}' \
+    >> "$LOG" 2>/dev/null || true
+else
+  # Degraded output: jq unavailable. Some fields omitted. Install jq for full telemetry.
+  SAFE_ERROR=$(printf '%s' "$HOOK_ERROR" | sed 's/\\/\\\\/g; s/"/\\"/g')
+  if [ "$HOOK_STATUS" = "error" ]; then
+    printf '{"v":0,"ts":"%s","event":"hook.session_end","session_id":null,"project":"%s","hook":{"name":"session-end","duration_ms":%s,"status":"%s","error":"%s"}}\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PROJECT" "$DURATION_MS" "$HOOK_STATUS" "$SAFE_ERROR" \
+      >> "$LOG" 2>/dev/null || true
+  else
+    printf '{"v":0,"ts":"%s","event":"hook.session_end","session_id":null,"project":"%s","hook":{"name":"session-end","duration_ms":%s,"status":"%s","error":null}}\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PROJECT" "$DURATION_MS" "$HOOK_STATUS" \
+      >> "$LOG" 2>/dev/null || true
+  fi
+fi

--- a/plugin/scripts/session-start.sh
+++ b/plugin/scripts/session-start.sh
@@ -1,15 +1,79 @@
-#!/bin/sh
-# MAG session start — recall project context
+#\!/bin/sh
+# MAG session start — recall project context, emit JSONL telemetry
 # Outputs memory context for Claude Code injection
 set -eu
 
-PROJECT="$(basename "$PWD")"
-SESSION_ID="${CLAUDE_SESSION_ID:-unknown}"
-LOG="$HOME/.mag/auto-capture.log"
+MAG_DATA_ROOT="${MAG_DATA_ROOT:-$HOME/.mag}"
+export MAG_DATA_ROOT
 
-# Log BEFORE invocation so failed mag calls are still recorded
-mkdir -p "$HOME/.mag"
-printf '%s session_start project=%s session=%s\n' \
-  "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PROJECT" "$SESSION_ID" >> "$LOG" 2>/dev/null || true
+LOG="$MAG_DATA_ROOT/auto-capture.jsonl"
+# Millisecond-precision timestamp (perl is POSIX-portable; date +%s%N is Linux-only)
+now_ms() {
+  perl -MTime::HiRes=time -e 'printf "%d\n", time*1000' 2>/dev/null || printf '%s000' "$(date +%s)"
+}
+START_TS=$(now_ms)
 
-mag welcome --project "$PROJECT" --session-id "$SESSION_ID" --budget-tokens 2000 2>/dev/null || true
+# Read stdin JSON (SessionStart provides session_id, cwd, etc.)
+INPUT=$(cat 2>/dev/null) || INPUT=""
+
+if command -v jq >/dev/null 2>&1 && [ -n "$INPUT" ]; then
+  SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null) || SESSION_ID=""
+  CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || CWD=""
+else
+  SESSION_ID=""
+  CWD=""
+fi
+
+SESSION_ID="${SESSION_ID:-}"
+CWD="${CWD:-$PWD}"
+PROJECT="$(basename "$CWD")"
+
+mkdir -p "$MAG_DATA_ROOT"
+
+# Reap stale pre-compact snapshots (moved here from pre-compact.sh where timing is critical)
+STATE_DIR="$MAG_DATA_ROOT/state"
+if [ -d "$STATE_DIR" ]; then
+  STALE_COUNT=$(ls "$STATE_DIR"/pre-compact-*.json 2>/dev/null | wc -l)
+  if [ "$STALE_COUNT" -gt 10 ]; then
+    find "$STATE_DIR" -name 'pre-compact-*.json' -mtime +1 -delete 2>/dev/null || true
+  fi
+fi
+
+# Invoke mag and capture exit code
+MAG_EXIT=0
+mag welcome --project "$PROJECT" --session-id "$SESSION_ID" --budget-tokens 2000 2>/dev/null || MAG_EXIT=$?
+
+END_TS=$(now_ms)
+DURATION_MS=$(( END_TS - START_TS ))
+
+HOOK_STATUS="ok"
+HOOK_ERROR="null"
+if [ "$MAG_EXIT" -ne 0 ]; then
+  HOOK_STATUS="error"
+  HOOK_ERROR="\"mag exited $MAG_EXIT\""
+fi
+
+# Emit JSONL
+if command -v jq >/dev/null 2>&1; then
+  jq -nc \
+    --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg session_id "$SESSION_ID" \
+    --arg proj "$PROJECT" \
+    --arg dur "$DURATION_MS" \
+    --arg status "$HOOK_STATUS" \
+    --argjson err "$HOOK_ERROR" \
+    '{v:0,ts:$ts,event:"hook.session_start",session_id:($session_id | if . == "" then null else . end),project:$proj,agent:{id:null,type:null,tool:"claude_code"},hook:{name:"session-start",duration_ms:($dur|tonumber),status:$status,error:$err},memory:null,context:{}}' \
+    >> "$LOG" 2>/dev/null || true
+else
+  # Degraded output: jq unavailable. Some fields omitted. Install jq for full telemetry.
+  SAFE_ERROR=$(printf '%s' "$HOOK_ERROR" | sed 's/\\/\\\\/g; s/"/\\"/g')
+  if [ "$HOOK_STATUS" = "error" ]; then
+    printf '{"v":0,"ts":"%s","event":"hook.session_start","session_id":null,"project":"%s","hook":{"name":"session-start","duration_ms":%s,"status":"%s","error":"%s"}}\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PROJECT" "$DURATION_MS" "$HOOK_STATUS" "$SAFE_ERROR" \
+      >> "$LOG" 2>/dev/null || true
+  else
+    printf '{"v":0,"ts":"%s","event":"hook.session_start","session_id":null,"project":"%s","hook":{"name":"session-start","duration_ms":%s,"status":"%s","error":null}}\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PROJECT" "$DURATION_MS" "$HOOK_STATUS" \
+      >> "$LOG" 2>/dev/null || true
+  fi
+fi

--- a/plugin/scripts/subagent-end.sh
+++ b/plugin/scripts/subagent-end.sh
@@ -1,0 +1,98 @@
+#!/bin/sh
+# MAG subagent end — store subagent summary, emit JSONL telemetry
+# SubagentStop hook: reads stdin JSON from Claude Code
+set -eu
+
+MAG_DATA_ROOT="${MAG_DATA_ROOT:-$HOME/.mag}"
+export MAG_DATA_ROOT
+
+LOG="$MAG_DATA_ROOT/auto-capture.jsonl"
+# Millisecond-precision timestamp (perl is POSIX-portable; date +%s%N is Linux-only)
+now_ms() {
+  perl -MTime::HiRes=time -e 'printf "%d\n", time*1000' 2>/dev/null || printf '%s000' "$(date +%s)"
+}
+START_TS=$(now_ms)
+
+# Read stdin JSON (SubagentStop provides session_id, agent_id, agent_type, etc.)
+INPUT=$(cat 2>/dev/null) || INPUT=""
+
+if command -v jq >/dev/null 2>&1 && [ -n "$INPUT" ]; then
+  SESSION_ID=$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null) || SESSION_ID=""
+  AGENT_ID=$(printf '%s' "$INPUT" | jq -r '.agent_id // empty' 2>/dev/null) || AGENT_ID=""
+  AGENT_TYPE=$(printf '%s' "$INPUT" | jq -r '.agent_type // empty' 2>/dev/null) || AGENT_TYPE=""
+  LAST_MSG=$(printf '%s' "$INPUT" | jq -r '.last_assistant_message // empty' 2>/dev/null) || LAST_MSG=""
+  CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null) || CWD=""
+else
+  SESSION_ID=""
+  AGENT_ID=""
+  AGENT_TYPE=""
+  LAST_MSG=""
+  CWD=""
+fi
+
+SESSION_ID="${SESSION_ID:-}"
+AGENT_ID="${AGENT_ID:-unknown}"
+AGENT_TYPE="${AGENT_TYPE:-unknown}"
+LAST_MSG="${LAST_MSG:-}"
+CWD="${CWD:-$PWD}"
+PROJECT="$(basename "$CWD")"
+
+mkdir -p "$MAG_DATA_ROOT"
+
+# Truncate last_assistant_message to 200 chars
+MSG_PREVIEW=""
+if [ -n "$LAST_MSG" ]; then
+  MSG_PREVIEW="$(printf '%.200s' "$LAST_MSG")"
+  SUMMARY="Subagent ended. Agent: $AGENT_ID ($AGENT_TYPE). Project: $PROJECT. Last message: $MSG_PREVIEW"
+else
+  SUMMARY="Subagent ended. Agent: $AGENT_ID ($AGENT_TYPE). Project: $PROJECT."
+fi
+
+# Store with lower importance than main session (D4: 0.3)
+MAG_EXIT=0
+mag process "$SUMMARY" \
+  --event-type subagent_end \
+  --project "$PROJECT" \
+  --session-id "$SESSION_ID" \
+  --importance 0.3 2>/dev/null || MAG_EXIT=$?
+
+END_TS=$(now_ms)
+DURATION_MS=$(( END_TS - START_TS ))
+
+HOOK_STATUS="ok"
+HOOK_ERROR="null"
+if [ "$MAG_EXIT" -ne 0 ]; then
+  HOOK_STATUS="error"
+  HOOK_ERROR="\"mag exited $MAG_EXIT\""
+fi
+
+# Emit JSONL
+if command -v jq >/dev/null 2>&1; then
+  jq -nc \
+    --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --arg session_id "$SESSION_ID" \
+    --arg proj "$PROJECT" \
+    --arg agent_id "$AGENT_ID" \
+    --arg agent_type "$AGENT_TYPE" \
+    --arg dur "$DURATION_MS" \
+    --arg status "$HOOK_STATUS" \
+    --argjson err "$HOOK_ERROR" \
+    --arg msg_preview "${MSG_PREVIEW:-}" \
+    '{v:0,ts:$ts,event:"hook.subagent_end",session_id:($session_id | if . == "" then null else . end),project:$proj,agent:{id:$agent_id,type:$agent_type,tool:"claude_code"},hook:{name:"subagent-end",duration_ms:($dur|tonumber),status:$status,error:$err},memory:null,context:{last_assistant_message:$msg_preview}}' \
+    >> "$LOG" 2>/dev/null || true
+else
+  # Degraded output: jq unavailable. Some fields omitted. Install jq for full telemetry.
+  SAFE_AGENT_ID=$(printf '%s' "$AGENT_ID" | sed 's/\\/\\\\/g; s/"/\\"/g')
+  SAFE_AGENT_TYPE=$(printf '%s' "$AGENT_TYPE" | sed 's/\\/\\\\/g; s/"/\\"/g')
+  SAFE_MSG_PREVIEW=$(printf '%s' "${MSG_PREVIEW:-}" | sed 's/\\/\\\\/g; s/"/\\"/g' | head -c 200)
+  SAFE_ERROR=$(printf '%s' "$HOOK_ERROR" | sed 's/\\/\\\\/g; s/"/\\"/g')
+  if [ "$HOOK_STATUS" = "error" ]; then
+    printf '{"v":0,"ts":"%s","event":"hook.subagent_end","session_id":null,"project":"%s","agent":{"id":"%s","type":"%s","tool":"claude_code"},"hook":{"name":"subagent-end","duration_ms":%s,"status":"%s","error":"%s"},"memory":null,"context":{"last_assistant_message":"%s"}}\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PROJECT" "$SAFE_AGENT_ID" "$SAFE_AGENT_TYPE" "$DURATION_MS" "$HOOK_STATUS" "$SAFE_ERROR" "$SAFE_MSG_PREVIEW" \
+      >> "$LOG" 2>/dev/null || true
+  else
+    printf '{"v":0,"ts":"%s","event":"hook.subagent_end","session_id":null,"project":"%s","agent":{"id":"%s","type":"%s","tool":"claude_code"},"hook":{"name":"subagent-end","duration_ms":%s,"status":"%s","error":null},"memory":null,"context":{"last_assistant_message":"%s"}}\n' \
+      "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$PROJECT" "$SAFE_AGENT_ID" "$SAFE_AGENT_TYPE" "$DURATION_MS" "$HOOK_STATUS" "$SAFE_MSG_PREVIEW" \
+      >> "$LOG" 2>/dev/null || true
+  fi
+fi

--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -74,6 +74,23 @@ pub async fn run_uninstall(all: bool, configs_only: bool) -> Result<()> {
         summary.benchmarks = Some(remove_directory(&paths.benchmark_root));
     }
 
+    // Clean up telemetry log files so the data_root directory can be removed
+    if choices.database {
+        for name in &["auto-capture.jsonl", "auto-capture.log"] {
+            let p = paths.data_root.join(name);
+            if let Err(e) = std::fs::remove_file(&p)
+                && e.kind() != io::ErrorKind::NotFound
+            {
+                tracing::warn!(path = %p.display(), err = %e, "failed to remove telemetry log");
+            }
+        }
+        // Remove state directory used by pre-compact snapshots
+        let state_dir = paths.data_root.join("state");
+        if state_dir.exists() {
+            let _ = std::fs::remove_dir_all(&state_dir);
+        }
+    }
+
     let data_root_removed = if choices.models || choices.database {
         try_remove_empty_dir(&paths.data_root)
     } else {


### PR DESCRIPTION
## Summary
- Graduate JSONL telemetry from dev plugin to all 7 production hook scripts
- Add SubagentStop handler (new: `subagent-end.sh` + hooks.json entry)
- JSONL output to `~/.mag/auto-capture.jsonl` (new file, existing `.log` preserved)
- Includes all optimizations from Palantir debate (PR #263): millisecond timing, `--arg` safety, sed escaping, START_TS after guards
- Telemetry log cleanup added to `uninstall.rs` (auto-capture.jsonl, auto-capture.log, state dir)
- prompt-gate timeout bumped 50ms -> 100ms per Palantir fix

## What changed
| Script | Before | After |
|--------|--------|-------|
| session-start.sh | Plain text log | JSONL v0 schema |
| session-end.sh | Plain text log | JSONL v0 schema |
| prompt-gate.sh | Plain text log | JSONL v0 schema |
| commit-capture.sh | Plain text log | JSONL v0 schema |
| error-capture.sh | Plain text log | JSONL v0 schema |
| pre-compact.sh | Plain text log | JSONL v0 schema |
| compact-refresh.sh | Plain text log | JSONL v0 schema |
| subagent-end.sh | (new) | JSONL v0 schema |
| hooks.json | 6 events | 7 events (+SubagentStop) |
| uninstall.rs | No telemetry cleanup | Cleans auto-capture.jsonl/.log + state dir |

## Key design decisions
- `MAG_DATA_ROOT` uses `${MAG_DATA_ROOT:-$HOME/.mag}` (respects env override, defaults to production)
- New `.jsonl` file separate from existing `.log` — no data migration needed
- All scripts use `jq -nc` for compact JSONL with `--arg` (not `--argjson`) for session_id safety
- printf fallbacks use `sed` escaping (not `tr -d`) per Palantir fix
- `now_ms()` via perl Time::HiRes with `date +%s` fallback
- START_TS placed after fast-path guards (commit-capture, error-capture) to avoid timing empty operations

## Test plan
- [ ] Install production plugin, run `claude -p --model haiku`
- [ ] Verify `~/.mag/auto-capture.jsonl` has correct JSONL entries
- [ ] Verify SubagentStop handler fires when subagent spawned
- [ ] Verify existing `auto-capture.log` is not affected
- [ ] Run `cargo check` to verify uninstall.rs compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SubagentStop hook to gracefully finalize subagent sessions.
  * Increased prompt submission timeout to allow longer prompt processing.

* **Bug Fixes**
  * More accurate success/error reporting for hooks and commands (captures exit codes and durations in ms).
  * Improved session start/end and restore behavior to avoid lost context.

* **Chores**
  * Replaced plaintext logs with structured JSONL telemetry (configurable storage).
  * Uninstaller now removes telemetry logs and state files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->