### PR TITLE
feat(plugin/dev): add isolated test environment and TAP runner

### DIFF
--- a/plugin/dev/run-tests.sh
+++ b/plugin/dev/run-tests.sh
@@ -1,0 +1,138 @@
+#!/bin/sh
+# plugin/dev/run-tests.sh
+# Thin wrapper around tests/hooks/run_all.sh for the dev plugin test suite.
+#
+# Usage:
+#   ./run-tests.sh [--filter <glob>] [--model <name>]
+#
+# Flags:
+#   --filter <glob>   Pass-through glob filter to run_all.sh (e.g. t01)
+#   --model <name>    Claude model to use (default: haiku)
+#
+# Exports to run_all.sh:
+#   MAG_DATA_ROOT                   — points to ~/.dev-mag
+#   CLAUDE_MODEL                    — the chosen model
+#   MAG_PLUGIN_SCRIPTS_OVERRIDE     — redirects hook scripts to plugin/dev/scripts/
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+# Resolve repo root: plugin/dev/ is two levels below the repo root
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+DEV_ROOT="$HOME/.dev-mag"
+FILTER=""
+MODEL="haiku"
+
+# Parse flags
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --filter)
+      if [ -z "${2:-}" ]; then
+        printf 'run-tests.sh: --filter requires an argument\n' >&2
+        exit 1
+      fi
+      FILTER="$2"
+      shift 2
+      ;;
+    --model)
+      if [ -z "${2:-}" ]; then
+        printf 'run-tests.sh: --model requires an argument\n' >&2
+        exit 1
+      fi
+      MODEL="$2"
+      shift 2
+      ;;
+    *)
+      printf 'run-tests.sh: unknown argument: %s\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Pre-flight checks
+# ---------------------------------------------------------------------------
+
+_have() { command -v "$1" >/dev/null 2>&1; }
+_missing=0
+
+if ! _have mag; then
+  printf 'run-tests.sh: ERROR: mag CLI not found in PATH\n' >&2
+  _missing=1
+fi
+
+if ! _have claude; then
+  printf 'run-tests.sh: ERROR: claude CLI not found in PATH\n' >&2
+  _missing=1
+fi
+
+if ! _have jq; then
+  printf 'run-tests.sh: ERROR: jq not found in PATH\n' >&2
+  _missing=1
+fi
+
+if [ "$_missing" -gt 0 ]; then
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Run the test suite
+# ---------------------------------------------------------------------------
+
+RUN_ALL="$REPO_ROOT/tests/hooks/run_all.sh"
+if [ ! -f "$RUN_ALL" ]; then
+  printf 'run-tests.sh: ERROR: run_all.sh not found at %s\n' "$RUN_ALL" >&2
+  exit 1
+fi
+
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+TAP_LOG="$DEV_ROOT/test-results-$TIMESTAMP.tap"
+mkdir -p "$DEV_ROOT"
+
+printf '==> MAG dev plugin test runner\n'
+printf '    Model   : %s\n' "$MODEL"
+printf '    Scripts : %s/scripts\n' "$SCRIPT_DIR"
+printf '    Data    : %s\n' "$DEV_ROOT"
+printf '    Log     : %s\n' "$TAP_LOG"
+if [ -n "$FILTER" ]; then
+  printf '    Filter  : %s\n' "$FILTER"
+fi
+printf '\n'
+
+export MAG_DATA_ROOT="$DEV_ROOT"
+export CLAUDE_MODEL="$MODEL"
+export MAG_PLUGIN_SCRIPTS_OVERRIDE="$SCRIPT_DIR/scripts"
+
+# Build run_all.sh argument list
+_args=""
+if [ -n "$FILTER" ]; then
+  _args="--filter $FILTER"
+fi
+
+# Run, tee to TAP log, capture exit code
+set +e
+if [ -n "$_args" ]; then
+  sh "$RUN_ALL" $_args 2>&1 | tee "$TAP_LOG"
+else
+  sh "$RUN_ALL" 2>&1 | tee "$TAP_LOG"
+fi
+_rc=$?
+set -e
+
+printf '\n==> TAP results saved to: %s\n' "$TAP_LOG"
+
+# Check for failures in the TAP output
+_failures="$(grep -c '^not ok' "$TAP_LOG" 2>/dev/null || true)"
+if [ "${_failures:-0}" -gt 0 ]; then
+  printf '    FAILED: %d test(s) failed\n' "$_failures"
+  exit 1
+fi
+
+if [ "$_rc" -ne 0 ]; then
+  printf '    FAILED: run_all.sh exited with code %d\n' "$_rc"
+  exit "$_rc"
+fi
+
+printf '    All tests passed\n'
+exit 0

--- a/plugin/dev/test-env.sh
+++ b/plugin/dev/test-env.sh
@@ -1,0 +1,178 @@
+#!/bin/sh
+# plugin/dev/test-env.sh
+# Creates an isolated MAG dev plugin test environment.
+#
+# Usage:
+#   ./test-env.sh [--clone] [--no-session] [--teardown]
+#
+# Flags:
+#   --clone       Sync production ~/.mag/memory.db to ~/.dev-mag/ before setup
+#   --no-session  Skip launching the terminal session (just set up the repo)
+#   --teardown    Destroy the test repo and ~/.dev-mag, kill the session
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TEST_REPO="${MAG_TEST_REPO:-/tmp/mag-test-repo}"
+DEV_ROOT="$HOME/.dev-mag"
+SESSION_NAME="mag-test"
+
+CLONE=0
+NO_SESSION=0
+TEARDOWN=0
+
+for _arg in "$@"; do
+  case "$_arg" in
+    --clone)      CLONE=1 ;;
+    --no-session) NO_SESSION=1 ;;
+    --teardown)   TEARDOWN=1 ;;
+    *) printf 'test-env.sh: unknown argument: %s\n' "$_arg" >&2; exit 1 ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_have() { command -v "$1" >/dev/null 2>&1; }
+
+_tmux_kill() {
+  if _have tmux; then
+    tmux kill-session -t "$SESSION_NAME" 2>/dev/null || true
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Teardown
+# ---------------------------------------------------------------------------
+
+if [ "$TEARDOWN" -eq 1 ]; then
+  printf '==> Tearing down test environment\n'
+
+  _tmux_kill
+
+  if [ -d "$TEST_REPO" ]; then
+    printf '    Removing %s ...\n' "$TEST_REPO"
+    rm -rf "$TEST_REPO"
+    printf '    OK\n'
+  else
+    printf '    %s not found — skipping\n' "$TEST_REPO"
+  fi
+
+  if [ -d "$DEV_ROOT" ]; then
+    printf '    Removing %s ...\n' "$DEV_ROOT"
+    rm -rf "$DEV_ROOT"
+    printf '    OK\n'
+  else
+    printf '    %s not found — skipping\n' "$DEV_ROOT"
+  fi
+
+  printf '==> Teardown complete\n'
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+
+printf '==> MAG dev plugin test environment setup\n'
+printf '    Test repo : %s\n' "$TEST_REPO"
+printf '    Dev root  : %s\n' "$DEV_ROOT"
+printf '\n'
+
+# 1. Create test repo
+printf -- '--> Creating test repo at %s ...\n' "$TEST_REPO"
+mkdir -p "$TEST_REPO"
+if [ ! -d "$TEST_REPO/.git" ]; then
+  git -C "$TEST_REPO" init --quiet
+  printf '    Initialised git repo\n'
+else
+  printf '    Already a git repo — skipping init\n'
+fi
+
+# 2. Run setup.sh (creates ~/.dev-mag, verifies deps, renders .mcp.json)
+printf -- '--> Running setup.sh ...\n'
+if [ "$CLONE" -eq 1 ]; then
+  sh "$SCRIPT_DIR/setup.sh" --clone
+else
+  sh "$SCRIPT_DIR/setup.sh"
+fi
+
+# 3. Write per-repo settings.local.json scoping dev plugin to this test repo only
+printf -- '--> Writing %s/.claude/settings.local.json ...\n' "$TEST_REPO"
+mkdir -p "$TEST_REPO/.claude"
+
+# JSON-escape the absolute plugin path
+_plugin_path_json="$(printf '%s' "$SCRIPT_DIR" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')"
+
+cat > "$TEST_REPO/.claude/settings.local.json" <<EOF
+{
+  "plugins": [
+    {"path": "$_plugin_path_json"}
+  ]
+}
+EOF
+printf '    Written\n'
+
+# ---------------------------------------------------------------------------
+# Session launch
+# ---------------------------------------------------------------------------
+
+if [ "$NO_SESSION" -eq 1 ]; then
+  printf '\n==> Setup complete (--no-session: skipping terminal launch)\n'
+  printf '\n'
+  printf 'To start manually:\n'
+  printf '  cd %s && claude\n' "$TEST_REPO"
+  printf '\n'
+  printf 'To tail telemetry:\n'
+  printf '  tail -f %s/auto-capture.jsonl | jq .\n' "$DEV_ROOT"
+  printf '\n'
+  exit 0
+fi
+
+# Determine terminal multiplexer
+MULTIPLEXER=""
+if _have cmux; then
+  MULTIPLEXER="cmux"
+elif _have tmux; then
+  MULTIPLEXER="tmux"
+fi
+
+# Pane commands
+PANE1_CMD="cd '$TEST_REPO' && exec \$SHELL"
+PANE2_CMD="tail -f '$DEV_ROOT/auto-capture.jsonl' | jq ."
+
+case "$MULTIPLEXER" in
+  cmux|tmux)
+    # Kill any existing session first
+    _tmux_kill
+
+    # Both cmux and tmux share the same session/window/pane API
+    printf -- '--> Launching %s session "%s" ...\n' "$MULTIPLEXER" "$SESSION_NAME"
+
+    # Create detached session with pane 1 in the test repo
+    "$MULTIPLEXER" new-session -d -s "$SESSION_NAME" -x 220 -y 50 \; \
+      send-keys "cd '$TEST_REPO'" Enter \; \
+      split-window -h \; \
+      send-keys "$PANE2_CMD" Enter \; \
+      select-pane -t 0
+
+    printf '    Session "%s" created\n' "$SESSION_NAME"
+    printf '\n'
+    printf 'Attach with:\n'
+    printf '  %s attach -t %s\n' "$MULTIPLEXER" "$SESSION_NAME"
+    ;;
+
+  *)
+    printf '\n==> Setup complete (cmux/tmux not found — run these manually):\n'
+    printf '\n'
+    printf '# Pane 1 — run claude in the test repo:\n'
+    printf '  cd %s && claude\n' "$TEST_REPO"
+    printf '\n'
+    printf '# Pane 2 — watch JSONL telemetry:\n'
+    printf '  tail -f %s/auto-capture.jsonl | jq .\n' "$DEV_ROOT"
+    printf '\n'
+    ;;
+esac
+
+printf '\n==> Done\n'

--- a/tests/hooks/helpers/plugin-install.sh
+++ b/tests/hooks/helpers/plugin-install.sh
@@ -14,7 +14,7 @@ CONFIG_DIR="${1:?Usage: plugin-install.sh <CONFIG_DIR>}"
 #   this file lives at <repo>/tests/hooks/helpers/plugin-install.sh
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
-SCRIPTS_DIR="$REPO_ROOT/plugin/scripts"
+SCRIPTS_DIR="${MAG_PLUGIN_SCRIPTS_OVERRIDE:-$REPO_ROOT/plugin/scripts}"
 
 # Sanity-check that the scripts directory exists
 if [ ! -d "$SCRIPTS_DIR" ]; then


### PR DESCRIPTION
## Summary
- Adds `plugin/dev/test-env.sh` — creates isolated test repo with dev plugin scoped via `settings.local.json`
- Adds `plugin/dev/run-tests.sh` — TAP test wrapper targeting dev JSONL hooks
- One-line change to `tests/hooks/helpers/plugin-install.sh` for script path override
- Supports `--clone` for production data sync, `--teardown` for cleanup
- CMUX/tmux dual-pane session for live telemetry observation

Addresses George-RD/mag#268

## Test plan
- [ ] `./plugin/dev/test-env.sh --no-session` creates test repo with correct settings
- [ ] `./plugin/dev/test-env.sh --clone --no-session` syncs production data
- [ ] `./plugin/dev/run-tests.sh` runs TAP suite against dev scripts
- [ ] `./plugin/dev/test-env.sh --teardown` cleans up everything
- [ ] CMUX/tmux session launches with dual panes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added test runner script supporting filtered test execution and configurable AI model selection for dev plugin testing
  * Added isolated test environment provisioning tool with automatic terminal session management and configurable repository paths

* **Chores**
  * Enhanced plugin installation to support environment variable-based script directory override for flexible deployment configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->