### PR TITLE
fix(tests): fix hook test harness + subagent event type

### DIFF
--- a/plugin/dev/run-tests.sh
+++ b/plugin/dev/run-tests.sh
@@ -100,6 +100,7 @@ if [ -n "$FILTER" ]; then
 fi
 printf '\n'
 
+export HOOKS_TARGET="dev"
 export MAG_DATA_ROOT="$DEV_ROOT"
 export CLAUDE_MODEL="$MODEL"
 export MAG_PLUGIN_SCRIPTS_OVERRIDE="$SCRIPT_DIR/scripts"

--- a/plugin/dev/scripts/subagent-end.sh
+++ b/plugin/dev/scripts/subagent-end.sh
@@ -51,7 +51,7 @@ fi
 # Store with lower importance than main session (D4: 0.3)
 MAG_EXIT=0
 mag process "$SUMMARY" \
-  --event-type subagent_end \
+  --event-type task_completion \
   --project "$PROJECT" \
   --session-id "$SESSION_ID" \
   --importance 0.3 2>/dev/null || MAG_EXIT=$?

--- a/tests/hooks/helpers/common.sh
+++ b/tests/hooks/helpers/common.sh
@@ -209,20 +209,29 @@ run_claude() {
   _prompt="$1"
   shift || true
 
-  # Build config dir pointing to our plugin hooks
-  _cfg_dir="$(mktemp -d)"
-  "$REPO_ROOT/tests/hooks/helpers/plugin-install.sh" "$_cfg_dir"
+  # Claude Code loads hooks from <cwd>/.claude/settings.json (project settings),
+  # NOT from --settings <file>. The --settings flag merges extra config but does
+  # NOT trigger hook discovery. We must place hooks in .claude/settings.json
+  # inside the working directory we pass to claude.
+  #
+  # Additionally, --max-budget-usd causes claude to exit with a non-zero error
+  # status ("Exceeded USD budget") before the Stop hook fires. Remove it so
+  # the Stop/SubagentStop events are always captured.
+  _run_dir="$(mktemp -d)"
+  mkdir -p "$_run_dir/.claude"
+  "$REPO_ROOT/tests/hooks/helpers/plugin-install.sh" "$_run_dir/.claude"
 
-  claude \
-    --config-dir "$_cfg_dir" \
+  # Rename the generated file to settings.json inside .claude/
+  # plugin-install.sh writes to <DIR>/settings.json, so it's already there.
+
+  ( cd "$_run_dir" && claude \
     -p "$_prompt" \
     --model "$CLAUDE_MODEL" \
     --dangerously-skip-permissions \
     --max-turns 3 \
-    --max-budget-usd 0.05 \
-    "$@" 2>/dev/null || true
+    "$@" 2>/dev/null ) || true
 
-  rm -rf "$_cfg_dir"
+  rm -rf "$_run_dir"
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/hooks/helpers/plugin-install.sh
+++ b/tests/hooks/helpers/plugin-install.sh
@@ -4,7 +4,7 @@
 #
 # Creates a minimal Claude Code configuration directory with hooks pointing
 # to the repo's plugin/scripts/ directory using absolute paths.
-# The generated settings.json is suitable for passing to `claude --config-dir`.
+# The generated settings.json is suitable for passing to `claude --settings`.
 
 set -eu
 


### PR DESCRIPTION
## Summary
- Fix `run_claude()` to write hooks into `<tmpdir>/.claude/settings.json` and `cd` into temp dir (Claude Code only loads hooks from CWD project settings, not via `--settings` flag)
- Add `HOOKS_TARGET=dev` export to `run-tests.sh` so TAP suite targets dev scripts
- Fix `subagent-end.sh`: `--event-type subagent_end` → `task_completion` (valid MAG enum variant)
- Remove `--max-budget-usd 0.05` that killed sessions before `Stop` hook could fire

## Test results
3/6 TAP tests pass (t01 session_start, t05 prompt_gate, t06 subagent_stop).

Remaining 3 failures are test environment constraints, not production bugs:
- t02: `assert_memory_stored` needs dev daemon running against `~/.dev-mag`
- t03/t04: `max_turns=3` too low for Haiku to complete git/cargo ops and trigger PostToolUse hooks

## Test plan
- [x] `./plugin/dev/run-tests.sh` runs with `# hooks target: dev`
- [x] t01 (session_start) passes
- [x] t05 (prompt_gate) passes
- [x] t06 (subagent_stop) passes — was failing before this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development test suite environment configuration
  * Refined plugin hook discovery and configuration handling for tests
  * Improved event classification for task completion tracking
  * Removed early budget termination flag from test execution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->