### PR TITLE
feat(plugin/dev): add binary isolation for dev testing

### DIFF
--- a/plugin/dev/mcp.json
+++ b/plugin/dev/mcp.json
@@ -1,7 +1,7 @@
 {
   "mcpServers": {
     "mag-dev": {
-      "command": "mag",
+      "command": "${HOME}/.dev-mag/bin/mag",
       "args": ["serve"],
       "env": {"MAG_DATA_ROOT": "${HOME}/.dev-mag"}
     }

--- a/plugin/dev/scripts/commit-capture.sh
+++ b/plugin/dev/scripts/commit-capture.sh
@@ -7,6 +7,12 @@ set -eu
 MAG_DATA_ROOT="$HOME/.dev-mag"
 export MAG_DATA_ROOT
 
+MAG_BIN="$HOME/.dev-mag/bin/mag"
+if [ ! -x "$MAG_BIN" ]; then
+  echo "mag-dev: ERROR: dev binary not found at $MAG_BIN — run setup.sh --build" >&2
+  exit 1
+fi
+
 LOG="$MAG_DATA_ROOT/auto-capture.jsonl"
 # Millisecond-precision timestamp (perl is POSIX-portable; date +%s%N is Linux-only)
 now_ms() {
@@ -53,7 +59,7 @@ mkdir -p "$MAG_DATA_ROOT"
 
 # Invoke mag and capture exit code
 MAG_EXIT=0
-mag process "Commit: $MSG" \
+"$MAG_BIN" process "Commit: $MSG" \
   --event-type git_commit \
   --project "$PROJECT" \
   --session-id "$SESSION_ID" \

--- a/plugin/dev/scripts/compact-refresh.sh
+++ b/plugin/dev/scripts/compact-refresh.sh
@@ -5,6 +5,12 @@ set -eu
 MAG_DATA_ROOT="$HOME/.dev-mag"
 export MAG_DATA_ROOT
 
+MAG_BIN="$HOME/.dev-mag/bin/mag"
+if [ ! -x "$MAG_BIN" ]; then
+  echo "mag-dev: ERROR: dev binary not found at $MAG_BIN — run setup.sh --build" >&2
+  exit 1
+fi
+
 LOG="$MAG_DATA_ROOT/auto-capture.jsonl"
 STATE_DIR="$MAG_DATA_ROOT/state"
 # Millisecond-precision timestamp (perl is POSIX-portable; date +%s%N is Linux-only)
@@ -34,11 +40,11 @@ PROJECT="$(basename "$CWD")"
 # Re-inject top memories (full budget — context is smallest after compaction)
 # Capture output: PostCompact hooks return additionalContext to Claude via stdout
 WELCOME_OUTPUT=""
-WELCOME_OUTPUT=$(mag welcome --project "$PROJECT" --session-id "$SESSION_ID" --budget-tokens 2000 2>/dev/null) || true
+WELCOME_OUTPUT=$("$MAG_BIN" welcome --project "$PROJECT" --session-id "$SESSION_ID" --budget-tokens 2000 2>/dev/null) || true
 
 # Store compact summary as a memory if available
 if [ -n "$COMPACT_SUMMARY" ]; then
-  mag process "$COMPACT_SUMMARY" \
+  "$MAG_BIN" process "$COMPACT_SUMMARY" \
     --event-type session_end \
     --project "$PROJECT" \
     --session-id "$SESSION_ID" \

--- a/plugin/dev/scripts/error-capture.sh
+++ b/plugin/dev/scripts/error-capture.sh
@@ -7,6 +7,12 @@ set -eu
 MAG_DATA_ROOT="$HOME/.dev-mag"
 export MAG_DATA_ROOT
 
+MAG_BIN="$HOME/.dev-mag/bin/mag"
+if [ ! -x "$MAG_BIN" ]; then
+  echo "mag-dev: ERROR: dev binary not found at $MAG_BIN — run setup.sh --build" >&2
+  exit 1
+fi
+
 LOG="$MAG_DATA_ROOT/auto-capture.jsonl"
 # Millisecond-precision timestamp (perl is POSIX-portable; date +%s%N is Linux-only)
 now_ms() {
@@ -65,7 +71,7 @@ mkdir -p "$MAG_DATA_ROOT"
 
 # Invoke mag and capture exit code
 MAG_EXIT=0
-mag process "Build/test error in $PROJECT: $ERROR_LINE" \
+"$MAG_BIN" process "Build/test error in $PROJECT: $ERROR_LINE" \
   --event-type error_pattern \
   --project "$PROJECT" \
   --session-id "$SESSION_ID" \

--- a/plugin/dev/scripts/session-end.sh
+++ b/plugin/dev/scripts/session-end.sh
@@ -6,6 +6,12 @@ set -eu
 MAG_DATA_ROOT="$HOME/.dev-mag"
 export MAG_DATA_ROOT
 
+MAG_BIN="$HOME/.dev-mag/bin/mag"
+if [ ! -x "$MAG_BIN" ]; then
+  echo "mag-dev: ERROR: dev binary not found at $MAG_BIN — run setup.sh --build" >&2
+  exit 1
+fi
+
 LOG="$MAG_DATA_ROOT/auto-capture.jsonl"
 # Millisecond-precision timestamp (perl is POSIX-portable; date +%s%N is Linux-only)
 now_ms() {
@@ -54,7 +60,7 @@ fi
 
 # Invoke mag and capture exit code
 MAG_EXIT=0
-mag process "$SUMMARY" \
+"$MAG_BIN" process "$SUMMARY" \
   --event-type session_end \
   --project "$PROJECT" \
   --session-id "$SESSION_ID" \

--- a/plugin/dev/scripts/session-start.sh
+++ b/plugin/dev/scripts/session-start.sh
@@ -6,6 +6,12 @@ set -eu
 MAG_DATA_ROOT="$HOME/.dev-mag"
 export MAG_DATA_ROOT
 
+MAG_BIN="$HOME/.dev-mag/bin/mag"
+if [ ! -x "$MAG_BIN" ]; then
+  echo "mag-dev: ERROR: dev binary not found at $MAG_BIN — run setup.sh --build" >&2
+  exit 1
+fi
+
 LOG="$MAG_DATA_ROOT/auto-capture.jsonl"
 # Millisecond-precision timestamp (perl is POSIX-portable; date +%s%N is Linux-only)
 now_ms() {
@@ -41,7 +47,7 @@ fi
 
 # Invoke mag and capture exit code
 MAG_EXIT=0
-mag welcome --project "$PROJECT" --session-id "$SESSION_ID" --budget-tokens 2000 2>/dev/null || MAG_EXIT=$?
+"$MAG_BIN" welcome --project "$PROJECT" --session-id "$SESSION_ID" --budget-tokens 2000 2>/dev/null || MAG_EXIT=$?
 
 END_TS=$(now_ms)
 DURATION_MS=$(( END_TS - START_TS ))

--- a/plugin/dev/scripts/subagent-end.sh
+++ b/plugin/dev/scripts/subagent-end.sh
@@ -6,6 +6,12 @@ set -eu
 MAG_DATA_ROOT="$HOME/.dev-mag"
 export MAG_DATA_ROOT
 
+MAG_BIN="$HOME/.dev-mag/bin/mag"
+if [ ! -x "$MAG_BIN" ]; then
+  echo "mag-dev: ERROR: dev binary not found at $MAG_BIN — run setup.sh --build" >&2
+  exit 1
+fi
+
 LOG="$MAG_DATA_ROOT/auto-capture.jsonl"
 # Millisecond-precision timestamp (perl is POSIX-portable; date +%s%N is Linux-only)
 now_ms() {
@@ -50,7 +56,7 @@ fi
 
 # Store with lower importance than main session (D4: 0.3)
 MAG_EXIT=0
-mag process "$SUMMARY" \
+"$MAG_BIN" process "$SUMMARY" \
   --event-type task_completion \
   --project "$PROJECT" \
   --session-id "$SESSION_ID" \

--- a/plugin/dev/setup.sh
+++ b/plugin/dev/setup.sh
@@ -1,8 +1,9 @@
 #!/bin/sh
 # MAG dev plugin setup
-# Usage: ./setup.sh [--clone] [--force]
+# Usage: ./setup.sh [--clone] [--build] [--force]
 #   --clone  Copy production ~/.mag/memory.db to ~/.dev-mag/ for testing with real data
-#   --force  Overwrite .mcp.json even if it already exists
+#   --build  Compile mag from source and install to ~/.dev-mag/bin/mag
+#   --force  Overwrite .mcp.json even if it already exists; also overwrite dev DB on --clone
 #
 # NOTE: mcp.json is a TEMPLATE — do NOT edit .mcp.json directly.
 # setup.sh processes mcp.json into .mcp.json by expanding $HOME.
@@ -10,10 +11,12 @@
 set -eu
 
 CLONE=0
+BUILD=0
 FORCE=0
 for arg in "$@"; do
   case "$arg" in
     --clone) CLONE=1 ;;
+    --build) BUILD=1 ;;
     --force) FORCE=1 ;;
     *) echo "Unknown argument: $arg" >&2; exit 1 ;;
   esac
@@ -33,9 +36,22 @@ mkdir -p "$DEV_ROOT"
 mkdir -p "$DEV_ROOT/state"
 echo "    OK"
 
-# 2. Optionally clone production DB
+# 2. Optionally build dev binary from source
+if [ "$BUILD" -eq 1 ]; then
+  echo "--> Building dev binary (this may take 60+ seconds)..."
+  REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+  (cd "$REPO_ROOT" && cargo build --release)
+  mkdir -p "$DEV_ROOT/bin"
+  cp "$REPO_ROOT/target/release/mag" "$DEV_ROOT/bin/mag"
+  echo "    OK ($("$DEV_ROOT/bin/mag" --version))"
+fi
+
+# 3. Optionally clone production DB
 if [ "$CLONE" -eq 1 ]; then
-  if [ -f "$PROD_ROOT/memory.db" ]; then
+  # Clone guard: warn and skip if dev DB already exists and --force not set
+  if [ -f "$DEV_ROOT/memory.db" ] && [ "$FORCE" -eq 0 ]; then
+    echo "    WARNING: $DEV_ROOT/memory.db already exists. Use --force to overwrite."
+  elif [ -f "$PROD_ROOT/memory.db" ]; then
     echo "--> Cloning $PROD_ROOT/memory.db to $DEV_ROOT/memory.db ..."
     # SQLite uses WAL mode — use sqlite3 backup API for consistency, fall back to
     # copying the DB + WAL + SHM sidecars together if sqlite3 is not available.
@@ -53,17 +69,23 @@ if [ "$CLONE" -eq 1 ]; then
   fi
 fi
 
-# 3. Verify mag CLI is available
+# 4. Verify mag CLI is available
 echo "--> Checking mag CLI ..."
-if ! command -v mag >/dev/null 2>&1; then
-  echo "    ERROR: 'mag' not found in PATH. Install it first:"
-  echo "           cargo install --git https://github.com/George-RD/mag"
+if [ -x "$DEV_ROOT/bin/mag" ]; then
+  MAG_VERSION=$("$DEV_ROOT/bin/mag" --version 2>/dev/null | head -1 || echo "unknown")
+  echo "    Found (dev binary): $MAG_VERSION"
+elif command -v mag >/dev/null 2>&1; then
+  MAG_VERSION=$(mag --version 2>/dev/null | head -1 || echo "unknown")
+  echo "    Found (PATH): $MAG_VERSION"
+  echo "    NOTE: dev binary not built — hook scripts will fail. Run setup.sh --build."
+else
+  echo "    ERROR: 'mag' not found in PATH and dev binary not built."
+  echo "           Run: ./setup.sh --build"
+  echo "           Or:  cargo install --git https://github.com/George-RD/mag"
   exit 1
 fi
-MAG_VERSION=$(mag --version 2>/dev/null | head -1 || echo "unknown")
-echo "    Found: $MAG_VERSION"
 
-# 4. Verify jq is available (needed for JSONL output)
+# 5. Verify jq is available (needed for JSONL output)
 echo "--> Checking jq (required for full telemetry) ..."
 if command -v jq >/dev/null 2>&1; then
   echo "    Found: $(jq --version)"
@@ -73,12 +95,12 @@ else
   echo "             Install jq for full telemetry: https://jqlang.github.io/jq/download/"
 fi
 
-# 5. Make all hook scripts executable
+# 7. Make all hook scripts executable
 echo "--> Setting script permissions ..."
 chmod +x "$SCRIPT_DIR/scripts/"*.sh
 echo "    OK"
 
-# 6. Install the .mcp.json with $HOME expanded
+# 8. Install the .mcp.json with $HOME expanded
 # Note: .mcp.json shipped as mcp.json because dotfiles can't be committed in some envs.
 # setup.sh installs it to the correct location, always regenerating to pick up any changes.
 MCP_SRC="$SCRIPT_DIR/mcp.json"
@@ -100,7 +122,7 @@ else
   echo "    WARNING: mcp.json source not found — skipping .mcp.json install"
 fi
 
-# 7. Print installation instructions
+# 9. Print installation instructions
 cat << EOF
 
 ==> Installation complete!

--- a/plugin/dev/test-env.sh
+++ b/plugin/dev/test-env.sh
@@ -3,10 +3,12 @@
 # Creates an isolated MAG dev plugin test environment.
 #
 # Usage:
-#   ./test-env.sh [--clone] [--no-session] [--teardown]
+#   ./test-env.sh [--clone] [--build] [--no-build] [--no-session] [--teardown]
 #
 # Flags:
 #   --clone       Sync production ~/.mag/memory.db to ~/.dev-mag/ before setup
+#   --build       Compile MAG from source and install to ~/.dev-mag/bin/mag (default: on)
+#   --no-build    Skip compilation (use when you only want to test hooks, not rebuild)
 #   --no-session  Skip launching the terminal session (just set up the repo)
 #   --teardown    Destroy the test repo and ~/.dev-mag, kill the session
 
@@ -18,12 +20,17 @@ DEV_ROOT="$HOME/.dev-mag"
 SESSION_NAME="mag-test"
 
 CLONE=0
+BUILD=1
+FORCE=0
 NO_SESSION=0
 TEARDOWN=0
 
 for _arg in "$@"; do
   case "$_arg" in
     --clone)      CLONE=1 ;;
+    --build)      BUILD=1 ;;
+    --no-build)   BUILD=0 ;;
+    --force)      FORCE=1 ;;
     --no-session) NO_SESSION=1 ;;
     --teardown)   TEARDOWN=1 ;;
     *) printf 'test-env.sh: unknown argument: %s\n' "$_arg" >&2; exit 1 ;;
@@ -92,11 +99,12 @@ fi
 
 # 2. Run setup.sh (creates ~/.dev-mag, verifies deps, renders .mcp.json)
 printf -- '--> Running setup.sh ...\n'
-if [ "$CLONE" -eq 1 ]; then
-  sh "$SCRIPT_DIR/setup.sh" --clone
-else
-  sh "$SCRIPT_DIR/setup.sh"
-fi
+SETUP_ARGS=""
+[ "$CLONE" -eq 1 ] && SETUP_ARGS="$SETUP_ARGS --clone"
+[ "$BUILD" -eq 1 ] && SETUP_ARGS="$SETUP_ARGS --build"
+[ "$FORCE" -eq 1 ] && SETUP_ARGS="$SETUP_ARGS --force"
+# shellcheck disable=SC2086
+sh "$SCRIPT_DIR/setup.sh" $SETUP_ARGS
 
 # 3. Write per-repo settings.local.json scoping dev plugin to this test repo only
 printf -- '--> Writing %s/.claude/settings.local.json ...\n' "$TEST_REPO"


### PR DESCRIPTION
## Summary
- `setup.sh --build`: compiles MAG from source, installs to `~/.dev-mag/bin/mag`
- Dev hook scripts fail hard if dev binary missing (no silent PATH fallback)
- `mcp.json` uses dev binary path instead of PATH `mag`
- Clone guard: `--clone` warns if dev DB exists, requires `--force` to overwrite
- `test-env.sh` defaults to `--build` for full stack isolation

From Palantir debate — addresses all Critical and Important findings.

## Test plan
- [ ] `setup.sh --build` compiles and installs dev binary
- [ ] `setup.sh --clone` warns on existing dev DB
- [ ] `setup.sh --clone --force` overwrites dev DB
- [ ] Dev hook scripts fail with clear error if binary missing
- [ ] MCP server uses dev binary (check rendered .mcp.json)
- [ ] `test-env.sh --no-build` skips compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)