### PR TITLE
fix: add sandbox compatibility for Claude Code (#274)

### DIFF
--- a/plugin/dev/scripts/session-start.sh
+++ b/plugin/dev/scripts/session-start.sh
@@ -34,7 +34,11 @@ SESSION_ID="${SESSION_ID:-}"
 CWD="${CWD:-$PWD}"
 PROJECT="$(basename "$CWD")"
 
-mkdir -p "$MAG_DATA_ROOT"
+# Sandbox compatibility check
+if ! mkdir -p "$MAG_DATA_ROOT" 2>/dev/null; then
+  printf '{"additionalContext":"⚠ MAG: Cannot write to %s (sandbox restriction). Add %s to sandbox.filesystem.allowWrite in ~/.claude/settings.json or run: mag setup --fix-sandbox"}\n' "$MAG_DATA_ROOT" "$MAG_DATA_ROOT"
+  exit 0
+fi
 
 # Reap stale pre-compact snapshots (moved here from pre-compact.sh where timing is critical)
 STATE_DIR="$MAG_DATA_ROOT/state"

--- a/plugin/scripts/session-start.sh
+++ b/plugin/scripts/session-start.sh
@@ -28,7 +28,11 @@ SESSION_ID="${SESSION_ID:-}"
 CWD="${CWD:-$PWD}"
 PROJECT="$(basename "$CWD")"
 
-mkdir -p "$MAG_DATA_ROOT"
+# Sandbox compatibility check
+if ! mkdir -p "$MAG_DATA_ROOT" 2>/dev/null; then
+  printf '{"additionalContext":"⚠ MAG: Cannot write to %s (sandbox restriction). Add %s to sandbox.filesystem.allowWrite in ~/.claude/settings.json or run: mag setup --fix-sandbox"}\n' "$MAG_DATA_ROOT" "$MAG_DATA_ROOT"
+  exit 0
+fi
 
 # Reap stale pre-compact snapshots (moved here from pre-compact.sh where timing is critical)
 STATE_DIR="$MAG_DATA_ROOT/state"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -395,6 +395,10 @@ pub enum Commands {
         /// Force reconfiguration even if already configured.
         #[arg(long)]
         force: bool,
+        /// Only patch ~/.claude/settings.json to add ~/.mag to the sandbox
+        /// filesystem allowlist. Skips all other setup steps.
+        #[arg(long)]
+        fix_sandbox: bool,
     },
 }
 

--- a/src/config_writer.rs
+++ b/src/config_writer.rs
@@ -814,6 +814,108 @@ fn remove_toml_config(tool: &DetectedTool) -> Result<RemoveResult> {
 }
 
 // ---------------------------------------------------------------------------
+// Sandbox allowlist patcher
+// ---------------------------------------------------------------------------
+
+/// Outcome of a sandbox patch operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SandboxPatchResult {
+    /// `~/.mag` was added to `sandbox.filesystem.allowWrite`.
+    Patched,
+    /// `~/.mag` was already present; no change needed.
+    AlreadyPresent,
+    /// `~/.claude/settings.json` does not exist yet; created it with the entry.
+    Created,
+}
+
+/// Patches `~/.claude/settings.json` to add `~/.mag` (or the current
+/// `MAG_DATA_ROOT`) to `sandbox.filesystem.allowWrite`.
+///
+/// - Reads the file if it exists, or starts from `{}`.
+/// - Navigates / creates the path `sandbox` → `filesystem` → `allowWrite` (array).
+/// - Appends `~/.mag` only if it is not already present.
+/// - Writes back with 2-space indent via [`atomic_write`].
+pub fn patch_sandbox_allowlist() -> Result<SandboxPatchResult> {
+    let home = crate::app_paths::home_dir()?;
+    let settings_path = home.join(".claude/settings.json");
+
+    // Resolve the entry to add: use MAG_DATA_ROOT env var if set, otherwise ~/.mag
+    let entry_to_add = if let Ok(data_root) = std::env::var("MAG_DATA_ROOT") {
+        data_root
+    } else {
+        home.join(".mag").to_string_lossy().into_owned()
+    };
+
+    let file_existed = settings_path.exists();
+
+    // Read existing settings or start from empty object
+    let mut root: serde_json::Value = if file_existed {
+        let content = std::fs::read_to_string(&settings_path)
+            .with_context(|| format!("reading {}", settings_path.display()))?;
+        let content = content.strip_prefix('\u{FEFF}').unwrap_or(&content);
+        if content.trim().is_empty() {
+            serde_json::Value::Object(serde_json::Map::new())
+        } else {
+            serde_json::from_str(content)
+                .with_context(|| format!("parsing {}", settings_path.display()))?
+        }
+    } else {
+        serde_json::Value::Object(serde_json::Map::new())
+    };
+
+    // Navigate / create: root → sandbox → filesystem → allowWrite (array)
+    let root_obj = root
+        .as_object_mut()
+        .context("settings.json root is not an object")?;
+
+    root_obj
+        .entry("sandbox")
+        .or_insert_with(|| serde_json::json!({}));
+
+    let sandbox_obj = root_obj["sandbox"]
+        .as_object_mut()
+        .context("sandbox key is not an object")?;
+
+    sandbox_obj
+        .entry("filesystem")
+        .or_insert_with(|| serde_json::json!({}));
+
+    let fs_obj = sandbox_obj["filesystem"]
+        .as_object_mut()
+        .context("sandbox.filesystem is not an object")?;
+
+    fs_obj
+        .entry("allowWrite")
+        .or_insert_with(|| serde_json::Value::Array(vec![]));
+
+    let allow_write = fs_obj["allowWrite"]
+        .as_array_mut()
+        .context("sandbox.filesystem.allowWrite is not an array")?;
+
+    // Check if already present
+    let already_present = allow_write
+        .iter()
+        .any(|v| v.as_str() == Some(&entry_to_add));
+
+    if already_present {
+        return Ok(SandboxPatchResult::AlreadyPresent);
+    }
+
+    // Append the entry
+    allow_write.push(serde_json::Value::String(entry_to_add));
+
+    // Serialize and write back
+    let serialized = serialize_json(&root)?;
+    atomic_write(&settings_path, serialized.as_bytes())?;
+
+    if file_existed {
+        Ok(SandboxPatchResult::Patched)
+    } else {
+        Ok(SandboxPatchResult::Created)
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,6 +105,7 @@ async fn main() -> anyhow::Result<()> {
         no_start,
         uninstall,
         force,
+        fix_sandbox,
     } = cli.command
     {
         let transport_mode = mag::setup::parse_transport(&transport, port)?;
@@ -116,6 +117,7 @@ async fn main() -> anyhow::Result<()> {
             no_start,
             uninstall,
             force,
+            fix_sandbox,
         })
         .await;
     }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -25,6 +25,8 @@ pub struct SetupArgs {
     pub no_start: bool,
     pub uninstall: bool,
     pub force: bool,
+    /// Only patch `~/.claude/settings.json` sandbox allowlist; skip full setup.
+    pub fix_sandbox: bool,
 }
 
 /// Summary of a configuration run.
@@ -45,6 +47,11 @@ struct ConfigureSummary {
 pub async fn run_setup(args: SetupArgs) -> Result<()> {
     if args.uninstall {
         return crate::uninstall::run_uninstall(false, true).await;
+    }
+
+    // --fix-sandbox: only patch the sandbox allowlist, then exit.
+    if args.fix_sandbox {
+        return run_fix_sandbox();
     }
 
     // Detect phase
@@ -77,6 +84,10 @@ pub async fn run_setup(args: SetupArgs) -> Result<()> {
         present_summary(&summary);
     }
 
+    // Sandbox allowlist patch — always runs on normal setup so that ~/.mag is
+    // writable even when Claude Code's sandbox is active.
+    patch_sandbox_allowlist_with_feedback();
+
     // Model download phase — always runs; daemon must start after models are ready.
     #[cfg(feature = "real-embeddings")]
     {
@@ -102,6 +113,61 @@ pub async fn run_setup(args: SetupArgs) -> Result<()> {
     #[cfg(feature = "daemon-http")]
     maybe_start_daemon(args.port, args.no_start)?;
 
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Sandbox allowlist helpers
+// ---------------------------------------------------------------------------
+
+/// Patches `~/.claude/settings.json` sandbox allowlist and prints feedback.
+fn patch_sandbox_allowlist_with_feedback() {
+    match config_writer::patch_sandbox_allowlist() {
+        Ok(config_writer::SandboxPatchResult::Patched) => {
+            println!("    \u{2713} sandbox — added ~/.mag to sandbox.filesystem.allowWrite");
+        }
+        Ok(config_writer::SandboxPatchResult::Created) => {
+            println!(
+                "    \u{2713} sandbox — created ~/.claude/settings.json with ~/.mag in sandbox.filesystem.allowWrite"
+            );
+        }
+        Ok(config_writer::SandboxPatchResult::AlreadyPresent) => {
+            tracing::debug!("sandbox allowlist already contains ~/.mag — skipping");
+        }
+        Err(e) => {
+            eprintln!(
+                "    \u{26a0} sandbox — could not patch sandbox allowlist: {e}\n      \
+                 You can fix this manually: add ~/.mag to sandbox.filesystem.allowWrite in ~/.claude/settings.json"
+            );
+        }
+    }
+}
+
+/// Entry point for `mag setup --fix-sandbox`.
+fn run_fix_sandbox() -> Result<()> {
+    println!("\n  Patching Claude Code sandbox allowlist...\n");
+    match config_writer::patch_sandbox_allowlist() {
+        Ok(config_writer::SandboxPatchResult::Patched) => {
+            println!(
+                "    \u{2713} Added ~/.mag to sandbox.filesystem.allowWrite in ~/.claude/settings.json"
+            );
+        }
+        Ok(config_writer::SandboxPatchResult::Created) => {
+            println!(
+                "    \u{2713} Created ~/.claude/settings.json with ~/.mag in sandbox.filesystem.allowWrite"
+            );
+        }
+        Ok(config_writer::SandboxPatchResult::AlreadyPresent) => {
+            println!(
+                "    \u{2713} ~/.mag is already in sandbox.filesystem.allowWrite — nothing to do"
+            );
+        }
+        Err(e) => {
+            eprintln!("    \u{2717} Failed to patch sandbox allowlist: {e}");
+            return Err(e);
+        }
+    }
+    println!("\n  Restart Claude Code for the sandbox change to take effect.\n");
     Ok(())
 }
 
@@ -890,6 +956,7 @@ mod tests {
             no_start: false,
             uninstall: false,
             force: false,
+            fix_sandbox: false,
         };
         assert!(!args.non_interactive);
         assert!(args.tools.is_none());
@@ -927,6 +994,7 @@ mod tests {
             no_start: true,
             uninstall: false,
             force: false,
+            fix_sandbox: false,
         };
 
         let selected = select_tools(&result, &args).unwrap();
@@ -953,6 +1021,7 @@ mod tests {
             no_start: true,
             uninstall: false,
             force: false,
+            fix_sandbox: false,
         };
 
         let selected = select_tools(&result, &args).unwrap();
@@ -977,6 +1046,7 @@ mod tests {
             no_start: true,
             uninstall: false,
             force: true,
+            fix_sandbox: false,
         };
 
         let selected = select_tools(&result, &args).unwrap();
@@ -1000,6 +1070,7 @@ mod tests {
             no_start: true,
             uninstall: false,
             force: false,
+            fix_sandbox: false,
         };
 
         let selected = select_tools(&result, &args).unwrap();
@@ -1197,6 +1268,7 @@ mod tests {
                 no_start: true,
                 uninstall: false,
                 force: false,
+                fix_sandbox: false,
             };
 
             let selected = select_tools(&result, &args).unwrap();
@@ -1271,6 +1343,7 @@ mod tests {
             no_start: true,
             uninstall: false,
             force: false,
+            fix_sandbox: false,
         };
 
         let selected = select_tools(&result, &args).unwrap();
@@ -1296,6 +1369,7 @@ mod tests {
             no_start: true,
             uninstall: false,
             force: false,
+            fix_sandbox: false,
         };
 
         let selected = select_tools(&result, &args).unwrap();
@@ -1326,6 +1400,7 @@ mod tests {
             no_start: true,
             uninstall: false,
             force: false,
+            fix_sandbox: false,
         };
 
         let selected = select_tools(&result, &args).unwrap();
@@ -1350,6 +1425,7 @@ mod tests {
             no_start: true,
             uninstall: false,
             force: true,
+            fix_sandbox: false,
         };
 
         let selected = select_tools(&result, &args).unwrap();


### PR DESCRIPTION
## Summary
- `session-start.sh` emits visible `additionalContext` warning when `~/.mag/` write fails in sandbox
- `mag setup` patches `~/.claude/settings.json` to add `~/.mag` to `sandbox.filesystem.allowWrite`
- `mag setup --fix-sandbox` flag for targeted sandbox fix (referenced in warning message)
- Both production and dev scripts updated

Fixes #274

## Test plan
- [ ] In sandbox mode without `~/.mag` in allowlist: session-start shows warning
- [ ] `mag setup` adds `~/.mag` to sandbox allowlist
- [ ] `mag setup --fix-sandbox` only patches sandbox (doesn't redo full setup)
- [ ] Existing sandbox settings preserved (no overwrites)
- [ ] `cargo test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--fix-sandbox` command option to automatically configure Claude Code sandbox write permissions
  * Setup process now automatically patches sandbox allowlist to enable proper data directory access
  * Enhanced error messages and guidance when sandbox write permissions are unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->