### PR TITLE
fix: normalize test vector + lower Linux GLIBC floor to 2.35

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,9 +103,9 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-22.04           # GLIBC 2.35 — matches ORT prebuilt floor
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-24.04-arm
+            os: ubuntu-22.04-arm       # GLIBC 2.35 — matches ORT prebuilt floor
           # x86_64-apple-darwin removed: ort (ONNX Runtime) has no prebuilt
           # binaries for Intel Mac, and Apple has discontinued Intel Macs.
           # Users on Intel Mac can build from source or use Rosetta.

--- a/src/memory_core/storage/sqlite/tests.rs
+++ b/src/memory_core/storage/sqlite/tests.rs
@@ -19,7 +19,7 @@ impl Embedder for KeywordEmbedder {
         if text.contains("alpha") {
             Ok(vec![1.0, 0.0, 0.0, 0.0])
         } else if text.contains("beta") {
-            Ok(vec![0.9, 0.1, 0.0, 0.0])
+            Ok(vec![0.993_883_7, 0.110_431_53, 0.0, 0.0]) // L2-normalized [0.9, 0.1, 0, 0]
         } else {
             Ok(vec![0.0, 0.0, 1.0, 0.0])
         }


### PR DESCRIPTION
## Summary
- Fix `KeywordEmbedder` beta vector to be L2-normalized (`[0.993, 0.110, 0, 0]`), preventing `debug_assert` panic in `dot_product()` and mutex poisoning cascade that caused 2 flaky test failures
- Change Linux CI runners from `ubuntu-24.04` → `ubuntu-22.04`, lowering GLIBC requirement from 2.39 → 2.35

## GLIBC coverage gained

| Distro | GLIBC | Before | After |
|---|---|---|---|
| Ubuntu 24.04 | 2.39 | Yes | Yes |
| Ubuntu 22.04 | 2.35 | No | **Yes** |
| Debian 12 | 2.36 | No | **Yes** |

Floor is set by ORT prebuilt `.so` (pyke.io builds against GLIBC 2.35). Going lower requires building ORT from source.

## Test plan
- [x] `cargo test` — 565/565 pass (0 failures)
- [x] All integration test suites pass
- [ ] CI release build succeeds on ubuntu-22.04

🤖 Generated with [Claude Code](https://claude.com/claude-code)