### PR TITLE
fix(ci): revert Linux runners to ubuntu-24.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,9 +103,9 @@ jobs:
       matrix:
         include:
           - target: x86_64-unknown-linux-gnu
-            os: ubuntu-22.04           # GLIBC 2.35 — matches ORT prebuilt floor
+            os: ubuntu-24.04           # ORT 1.23.2 prebuilts need glibc >= 2.38
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-22.04-arm       # GLIBC 2.35 — matches ORT prebuilt floor
+            os: ubuntu-24.04-arm       # ORT 1.23.2 prebuilts need glibc >= 2.38
           # x86_64-apple-darwin removed: ort (ONNX Runtime) has no prebuilt
           # binaries for Intel Mac, and Apple has discontinued Intel Macs.
           # Users on Intel Mac can build from source or use Rosetta.


### PR DESCRIPTION
## Summary
Reverts Linux CI runners from ubuntu-22.04 back to ubuntu-24.04.

ORT 1.23.2 prebuilts use `__isoc23_*` symbols which require glibc >= 2.38. ubuntu-22.04 only has glibc 2.35, causing linker failures on both x86_64 and aarch64 Linux builds.

The GLIBC floor is set by ORT's prebuilt `.so`, not our Rust code. Lowering it requires building ORT from source — a separate effort.

This blocked the v0.1.8 release (run 24236105196).

## Test plan
- [ ] Release CI builds Linux targets successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Linux build environment to Ubuntu 24.04 for x86_64 and ARM64 targets, replacing Ubuntu 22.04 versions for improved infrastructure compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->