### PR TITLE
docs: add substrate campaign specs, strongholds, and Palantir debates

### DIFF
--- a/docs/specs/benchmark-harness.md
+++ b/docs/specs/benchmark-harness.md
@@ -1,0 +1,568 @@
+# Benchmark Harness Extension Spec
+<!-- Status: DRAFT | Valid for: v0.1.9+ -->
+
+This spec defines the multi-strategy comparison layer for the LoCoMo benchmark harness.
+It extends the existing infrastructure without breaking any current workflows.
+
+---
+
+## 1. Strategy Registry (`benches/locomo/strategies.rs`)
+
+### Purpose
+
+Centralise all retrieval-strategy configurations so that `main.rs`, `bench.sh`, and the
+Python comparison script share a single source of truth. Strategy selection happens at
+**runtime via `--strategy <name>`**, mirroring the existing embedder-selection pattern
+(the long if-else chain in `main.rs` lines 281-506).
+
+### File layout
+
+```
+benches/locomo/strategies.rs   ← new file, mod declared in main.rs
+```
+
+### Public API
+
+```rust
+/// Stable identifier used on the CLI and in CSV/JSON outputs.
+/// kebab-case, e.g. "sqlite-v1", "sqlite-v1-no-graph".
+pub type StrategyId = &'static str;
+
+#[derive(Debug, Clone)]
+pub struct StrategyConfig {
+    pub id: StrategyId,
+    /// One-line human description printed in --list-strategies output.
+    pub description: &'static str,
+    /// Override graph_neighbor_factor. None = use storage default.
+    pub graph_neighbor_factor: Option<f64>,
+    /// Disable graph traversal entirely when true.
+    pub no_graph: bool,
+    /// Disable cross-encoder reranking even when the binary supports it.
+    pub no_rerank: bool,
+    /// Disable entity-tag extraction during seeding.
+    pub no_entity_tags: bool,
+    /// Override RRF k constant. None = use storage default.
+    pub rrf_k: Option<f64>,
+}
+
+/// Ordered registry of all known strategies.
+pub const STRATEGIES: &[StrategyConfig] = &[
+    StrategyConfig {
+        id: "sqlite-v1",
+        description: "Reference strategy — production defaults (graph + entity tags, no reranking)",
+        graph_neighbor_factor: None,
+        no_graph: false,
+        no_rerank: false,
+        no_entity_tags: false,
+        rrf_k: None,
+    },
+    StrategyConfig {
+        id: "sqlite-v1-no-graph",
+        description: "Ablation: disables graph traversal to measure its contribution",
+        graph_neighbor_factor: Some(0.0),
+        no_graph: true,
+        no_rerank: false,
+        no_entity_tags: false,
+        rrf_k: None,
+    },
+    StrategyConfig {
+        id: "sqlite-v1-no-rerank",
+        description: "Ablation: disables cross-encoder reranking (for when --cross-encoder is on)",
+        graph_neighbor_factor: None,
+        no_graph: false,
+        no_rerank: true,
+        no_entity_tags: false,
+        rrf_k: None,
+    },
+    StrategyConfig {
+        id: "sqlite-v1-rrf-tuned",
+        description: "Experimental: RRF k=30 (lower k up-weights top results)",
+        graph_neighbor_factor: None,
+        no_graph: false,
+        no_rerank: false,
+        no_entity_tags: false,
+        rrf_k: Some(30.0),
+    },
+];
+
+/// Look up a strategy by id. Returns None for unknown names.
+pub fn find_strategy(id: &str) -> Option<&'static StrategyConfig> { ... }
+
+/// Print all strategies to stdout in human-readable form.
+pub fn list_strategies() { ... }
+
+/// Construct and configure a SqliteStorage instance from a StrategyConfig.
+/// Mirrors the per-sample storage setup in main.rs (lines 560-573).
+pub fn build_storage(
+    cfg: &StrategyConfig,
+    embedder: Arc<dyn Embedder>,
+    graph_factor_override: Option<f64>, // from --graph-factor CLI flag; wins over cfg
+) -> Result<SqliteStorage> { ... }
+```
+
+### Integration with `main.rs`
+
+Add to `Args`:
+
+```rust
+/// Retrieval strategy to use. Defaults to "sqlite-v1".
+/// Use --list-strategies to see all available options.
+#[arg(long, default_value = "sqlite-v1")]
+strategy: String,
+
+/// List all available strategies and exit.
+#[arg(long)]
+list_strategies: bool,
+```
+
+In `main()`, before the sample loop:
+1. If `args.list_strategies`, call `strategies::list_strategies()` and exit 0.
+2. Call `strategies::find_strategy(&args.strategy)` — bail with a clear error if unknown.
+3. In the per-sample storage setup block, replace the inline `graph_factor` override with
+   `strategies::build_storage(cfg, embedder.clone(), args.graph_factor)`.
+
+The `strategy` field must be included in `LoCoMoSummary` (see Section 3).
+
+---
+
+## 2. P95 Latency Tracking (`benches/bench_utils/stats.rs`)
+
+### Purpose
+
+Surface tail-latency behaviour so strategy comparisons can catch regressions that are
+invisible in mean query time (e.g. graph traversal spiking on large conversations).
+
+### New file
+
+```
+benches/bench_utils/stats.rs
+```
+
+Add `pub mod stats;` to `benches/bench_utils/mod.rs`.
+
+### API
+
+```rust
+/// Compute the p-th percentile of a slice of millisecond measurements.
+/// `percentile` must be in [0.0, 100.0]. Returns 0.0 for empty slices.
+///
+/// Uses the nearest-rank method (sorted, index = ceil(p/100 * n) - 1).
+pub fn percentile_ms(samples: &[u128], percentile: f64) -> f64 { ... }
+```
+
+### Integration with `main.rs`
+
+- Accumulate per-question query durations in `Vec<u128>` alongside the existing
+  `total_query_ms` accumulator.
+- After the sample loop, call `percentile_ms(&query_durations, 95.0)`.
+- Store the result in `LoCoMoSummary::p95_query_ms` (see Section 3).
+
+---
+
+## 3. `LoCoMoSummary` Changes (`benches/locomo/types.rs`)
+
+Add two fields to the existing `LoCoMoSummary` struct:
+
+```rust
+/// Strategy identifier used for this run (e.g. "sqlite-v1").
+pub strategy: String,
+
+/// 95th-percentile per-question query latency in milliseconds.
+pub p95_query_ms: f64,
+```
+
+`strategy` defaults to `"sqlite-v1"` when the field is populated from the existing
+`--strategy` default. Both fields are `#[serde(default)]` so that old JSON outputs
+(from CI artifacts) remain deserializable.
+
+No other existing fields change. Serialization order: insert `strategy` after
+`scoring_mode`, insert `p95_query_ms` after `avg_query_ms`.
+
+---
+
+## 4. Baseline File (`docs/benchmarks/baselines.json`)
+
+### Purpose
+
+Replace the implicit CSV grep in `bench.sh` (lines 218-219) with an explicit, version-
+controlled source of truth. The gate logic becomes deterministic regardless of CSV
+history.
+
+### Schema
+
+```jsonc
+{
+  "schema_version": 1,
+  // Top-level keys are strategy IDs. Each strategy holds per-scoring-mode baselines.
+  "sqlite-v1": {
+    "word-overlap": {
+      "samples": 10,
+      "overall": 90.1,
+      "single_hop": 86.9,
+      "temporal": 85.0,
+      "multi_hop": 56.2,
+      "open_domain": 95.7,
+      "adversarial": 92.6,
+      "evidence_recall": 92.0,
+      "avg_query_ms": 7.0,
+      "p95_query_ms": null,       // null until first --update-baseline run
+      "embedder": "bge-small-en-v1.5 (onnx, 384-dim)",
+      "commit": "83abccf",
+      "date": "2026-03-28",
+      "notes": "validated 10-sample; source: methodology.md"
+    },
+    "e2e-word-overlap": {
+      "samples": 2,
+      "overall": 91.2,
+      // ... category fields ...
+      "embedder": "bge-small-en-v1.5 (onnx, 384-dim)",
+      "commit": "83abccf",
+      "date": "2026-03-28",
+      "notes": "gpt-5.4, 2-sample; source: methodology.md"
+    }
+  }
+  // Additional strategies added as they are validated.
+}
+```
+
+### Append-only contract
+
+- Entries are **never deleted or overwritten** by tooling.
+- `--update-baseline` in `bench.sh` and `compare_strategies.py` appends a new key
+  (e.g. `"sqlite-v1-no-graph"`) or replaces a scoring-mode sub-object for an existing
+  strategy. A new timestamp + commit are written; the old entry is left commented out
+  via a `"_superseded_YYYY-MM-DD"` sibling key pattern (JSON does not support
+  comments, so the prior value is preserved under a prefixed key).
+- CI never writes to `baselines.json`; only humans and explicit `--update-baseline`
+  invocations do.
+
+### Gate logic replacement in `bench.sh`
+
+Replace the current grep-based baseline lookup:
+
+```bash
+# OLD (fragile — depends on CSV row ordering):
+BASELINE=$(grep ",10," "${RESULTS_CSV}" | grep "bge-small" | tail -1 | cut -d',' -f8)
+
+# NEW:
+BASELINE=$(python3 -c "
+import json, sys
+with open('${REPO_DIR}/docs/benchmarks/baselines.json') as f:
+    db = json.load(f)
+strategy = '${STRATEGY:-sqlite-v1}'
+mode = '${SCORING_MODE}'
+try:
+    print(db[strategy][mode]['overall'])
+except KeyError:
+    print('')
+")
+```
+
+---
+
+## 5. Comparison Mode (`bench.sh --compare A B` and `scripts/compare_strategies.py`)
+
+### `bench.sh` interface extension
+
+```bash
+# New flag parsed before the model/samples block:
+--compare    STRATEGY_A STRATEGY_B   # run both, produce ComparisonReport
+--update-baseline                    # after a run, write result to baselines.json
+```
+
+Example invocations:
+
+```bash
+./scripts/bench.sh --compare sqlite-v1 sqlite-v1-no-graph --samples 10
+./scripts/bench.sh --compare sqlite-v1 sqlite-v1-rrf-tuned --scoring-mode word-overlap
+```
+
+When `--compare` is active, `bench.sh`:
+1. Runs `locomo_bench --strategy A --json` and captures JSON output.
+2. Runs `locomo_bench --strategy B --json` and captures JSON output.
+3. Calls `scripts/compare_strategies.py --a-json <path> --b-json <path>
+   --baselines docs/benchmarks/baselines.json --output-dir docs/benchmarks/comparisons/`
+4. Appends **two** CSV rows to `benchmark_log.csv` — one per strategy — with
+   `strategy=<id>` included in the `notes` field (space-separated key=value tokens).
+5. Prints the Markdown comparison report to stdout.
+
+### `scripts/compare_strategies.py`
+
+**Python 3 stdlib only — zero pip dependencies.**
+
+```
+python3 scripts/compare_strategies.py \
+    --a-json /tmp/result_a.json \
+    --b-json /tmp/result_b.json \
+    --baselines docs/benchmarks/baselines.json \
+    --output-dir docs/benchmarks/comparisons/ \
+    [--update-baseline]
+```
+
+#### Output artefacts
+
+`docs/benchmarks/comparisons/YYYY-MM-DD_<A>_vs_<B>/`
+
+```
+comparison_report.md    # Human-readable table
+comparison_report.json  # Machine-readable ComparisonReport
+```
+
+#### `ComparisonReport` JSON schema
+
+```jsonc
+{
+  "generated_at": "2026-04-14T12:00:00Z",
+  "strategy_a": "sqlite-v1",
+  "strategy_b": "sqlite-v1-no-graph",
+  "scoring_mode": "word-overlap",
+  "samples": 10,
+  "embedder": "bge-small-en-v1.5 (onnx, 384-dim)",
+  "verdict": "BETTER",        // BETTER | EQUIVALENT | REGRESSION | INCONCLUSIVE
+  "verdict_reason": "...",
+  "baseline_used": {          // null if no baseline for strategy_a
+    "overall": 90.1,
+    "samples": 10
+  },
+  "results": {
+    "strategy_a": {
+      "overall": 90.1,
+      "single_hop": 86.9,
+      "temporal": 85.0,
+      "multi_hop": 56.2,
+      "open_domain": 95.7,
+      "adversarial": 92.6,
+      "evidence_recall": 92.0,
+      "avg_query_ms": 7.0,
+      "p95_query_ms": 18.5
+    },
+    "strategy_b": { ... }
+  },
+  "deltas": {                 // strategy_b minus strategy_a (positive = B wins)
+    "overall": -3.2,
+    "single_hop": -1.1,
+    // ...
+    "avg_query_ms": -0.5,
+    "p95_query_ms": -2.1
+  }
+}
+```
+
+#### Verdict logic
+
+| Condition | Verdict |
+|-----------|---------|
+| B overall delta >= +0.5pp and no category regresses > 2pp | `BETTER` |
+| Abs(B delta) < 0.5pp across all categories | `EQUIVALENT` |
+| B overall delta <= -2pp (hard threshold) | `REGRESSION` |
+| Mixed category results; overall delta -2pp to +0.5pp | `INCONCLUSIVE` |
+
+The thresholds are constants at the top of the script so they can be tuned without
+touching the algorithm.
+
+#### Markdown report format
+
+```markdown
+# Strategy Comparison: sqlite-v1 vs sqlite-v1-no-graph
+
+- Date: 2026-04-14
+- Scoring mode: word-overlap
+- Samples: 10
+- Embedder: bge-small-en-v1.5 (onnx, 384-dim)
+- Verdict: **INCONCLUSIVE** — mixed category results; overall delta within noise floor
+
+## Score Comparison
+
+| Category      | sqlite-v1 | sqlite-v1-no-graph | Delta |
+|---------------|----------:|-------------------:|------:|
+| Single-Hop QA |     86.9% |              85.8% |  -1.1 |
+| Temporal      |     85.0% |              83.4% |  -1.6 |
+| Multi-Hop QA  |     56.2% |              52.1% |  -4.1 |
+| Open-Domain   |     95.7% |              95.9% |  +0.2 |
+| Adversarial   |     92.6% |              92.4% |  -0.2 |
+| **Overall**   | **90.1%** |          **87.9%** | **-2.2** |
+| Evidence Rec  |     92.0% |              91.5% |  -0.5 |
+
+## Latency
+
+| Metric        | sqlite-v1 | sqlite-v1-no-graph | Delta |
+|---------------|----------:|-------------------:|------:|
+| Avg query ms  |       7.0 |                6.5 |  -0.5 |
+| P95 query ms  |      18.5 |               16.4 |  -2.1 |
+
+## Baseline comparison (sqlite-v1 reference)
+
+Baseline: 90.1% (10-sample, 2026-03-28, commit 83abccf)
+Current A: 90.1% — within 0.0pp of baseline. Gate: PASS
+```
+
+---
+
+## 6. CI Integration (`.github/workflows/ci.yml`)
+
+### New job: `benchmark-compare`
+
+Add after the existing `benchmark` job:
+
+```yaml
+benchmark-compare:
+  name: Strategy Comparison
+  runs-on: ubuntu-latest
+  if: github.event_name == 'pull_request'
+  steps:
+    - uses: actions/checkout@v6
+
+    - name: Detect strategy/baseline changes
+      id: filter
+      uses: dorny/paths-filter@v3
+      with:
+        filters: |
+          strategies:
+            - 'benches/locomo/strategies.rs'
+            - 'docs/benchmarks/baselines.json'
+
+    - name: Install Rust
+      if: steps.filter.outputs.strategies == 'true'
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Cache Rust build artifacts
+      if: steps.filter.outputs.strategies == 'true'
+      uses: Swatinem/rust-cache@v2
+
+    - name: Run strategy comparison
+      if: steps.filter.outputs.strategies == 'true'
+      run: |
+        ./scripts/bench.sh --compare sqlite-v1 sqlite-v1-no-graph \
+          --samples 2 --scoring-mode word-overlap
+
+    - name: Upload comparison report
+      if: steps.filter.outputs.strategies == 'true'
+      uses: actions/upload-artifact@v4
+      with:
+        name: strategy-comparison-${{ github.sha }}
+        path: docs/benchmarks/comparisons/
+        retention-days: 30
+```
+
+### Notes
+
+- `--samples 2` keeps the CI run under 5 minutes on a cold Rust cache.
+- The job is **additive** — it does not replace the existing `benchmark` job. Both run
+  independently on PRs.
+- The `dorny/paths-filter` version matches what the existing `benchmark` job already
+  uses (`@v3`), avoiding a second copy of the action.
+- No secrets are required; the comparison uses the local ONNX embedder.
+
+---
+
+## 7. Notes Field Extension for `benchmark_log.csv`
+
+No schema change is required. The existing `notes` (column 16) is free text. The
+convention is to embed space-separated `key=value` tokens for machine parseability:
+
+```
+strategy=sqlite-v1 compare_with=sqlite-v1-no-graph
+```
+
+`bench.sh` in `--compare` mode appends this automatically. Manual runs can add it
+via `--notes`.
+
+The `print_table()` function in `bench.sh` does not need to change; the notes column
+is already present in the CSV and displayed in the table when non-empty. Future tooling
+can filter on `strategy=` tokens using awk.
+
+---
+
+## 8. Implementation Sequence
+
+Implement in this order to keep the repo in a working state at each step:
+
+### Step 1 — `stats.rs` (isolated, zero-risk)
+
+Create `benches/bench_utils/stats.rs` with `percentile_ms()`. Add `pub mod stats;` to
+`benches/bench_utils/mod.rs`. Add unit tests (empty slice, single element, known
+distribution). No changes to any existing code yet.
+
+### Step 2 — `LoCoMoSummary` additions
+
+Add `strategy: String` and `p95_query_ms: f64` to `LoCoMoSummary` with
+`#[serde(default)]`. Update `main.rs` to populate both fields (accumulate
+`query_durations: Vec<u128>`, call `percentile_ms`, pass `"sqlite-v1"` as the hardcoded
+strategy string for now). Run `cargo test` and a `--json` bench invocation to verify
+JSON output.
+
+### Step 3 — `strategies.rs`
+
+Create `benches/locomo/strategies.rs` with `STRATEGIES`, `find_strategy()`,
+`list_strategies()`, and `build_storage()`. Declare `mod strategies;` in `main.rs`.
+Add `--strategy` and `--list-strategies` flags to `Args`. Wire `build_storage()` into
+the per-sample loop, replacing the inline `graph_factor` override block. The
+`"sqlite-v1"` default must produce identical output to the pre-patch behaviour — verify
+by running a 2-sample word-overlap bench and comparing scores.
+
+### Step 4 — `baselines.json`
+
+Create `docs/benchmarks/baselines.json` with the `sqlite-v1` `word-overlap` and
+`e2e-word-overlap` entries populated from `methodology.md` values. Update `bench.sh`
+gate logic to read from the JSON file instead of CSV grep. Run `./scripts/bench.sh
+--gate` locally to confirm the gate still passes.
+
+### Step 5 — `compare_strategies.py`
+
+Write `scripts/compare_strategies.py`. Test locally:
+
+```bash
+cargo run --release --bin locomo_bench -- --strategy sqlite-v1 --samples 2 \
+    --scoring-mode word-overlap --json > /tmp/a.json
+cargo run --release --bin locomo_bench -- --strategy sqlite-v1-no-graph --samples 2 \
+    --scoring-mode word-overlap --json > /tmp/b.json
+python3 scripts/compare_strategies.py \
+    --a-json /tmp/a.json --b-json /tmp/b.json \
+    --baselines docs/benchmarks/baselines.json \
+    --output-dir /tmp/comparison-test/
+```
+
+Verify JSON and Markdown outputs are well-formed.
+
+### Step 6 — `bench.sh --compare`
+
+Extend `bench.sh` to parse `--compare A B` and `--update-baseline`. Wire the two
+`locomo_bench` invocations and the Python script call. Test the full pipeline locally.
+
+### Step 7 — CI job
+
+Add the `benchmark-compare` job to `.github/workflows/ci.yml`. Open a draft PR that
+touches `benches/locomo/strategies.rs` to confirm the path filter triggers correctly
+and the artifact upload works.
+
+---
+
+## Appendix A: File Inventory
+
+| Path | Status | Description |
+|------|--------|-------------|
+| `benches/locomo/strategies.rs` | new | Strategy registry |
+| `benches/bench_utils/stats.rs` | new | Percentile helper |
+| `benches/bench_utils/mod.rs` | modify | Add `pub mod stats;` |
+| `benches/locomo/main.rs` | modify | `--strategy`, `--list-strategies`, p95 accumulation |
+| `benches/locomo/types.rs` | modify | `strategy` + `p95_query_ms` fields |
+| `scripts/bench.sh` | modify | `--compare`, `--update-baseline`, JSON gate |
+| `scripts/compare_strategies.py` | new | Comparison + report generator |
+| `docs/benchmarks/baselines.json` | new | Per-strategy per-mode baselines |
+| `docs/benchmarks/comparisons/` | new dir | Comparison report artefacts (gitignored or tracked) |
+| `.github/workflows/ci.yml` | modify | `benchmark-compare` job |
+
+## Appendix B: Key Invariants
+
+1. **No Cargo features added.** All strategy selection is runtime CLI flags. The build
+   matrix stays identical to today.
+2. **sqlite-v1 parity.** Running with `--strategy sqlite-v1` (the default) must produce
+   scores within floating-point rounding of the current unpatched binary. This is the
+   correctness gate for Step 3.
+3. **bench.sh remains standalone.** The Python script is invoked as a subprocess; it is
+   never imported. `bench.sh` continues to work without `--compare` exactly as it does
+   today.
+4. **baselines.json is append-only by convention.** CI reads it but never writes it.
+   Only `--update-baseline` writes it, and only a human merges that change.
+5. **CSV format unchanged.** No new columns are added; the `notes` field carries the
+   `strategy=` token as free text. Existing tooling that reads the CSV is unaffected.

--- a/docs/specs/execution-roadmap.md
+++ b/docs/specs/execution-roadmap.md
@@ -1,0 +1,587 @@
+# Execution Roadmap
+<!-- Generated: 2026-04-14 | Baseline: v0.1.9-dev | Horizon: v0.2.2 -->
+
+This document is the single source of truth for planned structural improvements to MAG. It covers four phases spanning v0.1.9 through v0.2.2, 15 pull requests, their dependencies, quality gates, risk mitigations, and parked items.
+
+---
+
+## Guiding Principles
+
+- **Trait-first design** — add new traits and impls; never break existing signatures.
+- **Benchmark-gated merges** — any PR touching scoring, search, or storage passes `./scripts/bench.sh --gate` before merge; a >5 pp regression blocks the PR.
+- **One group at a time** — structural moves happen in atomic, test-passing steps, not big-bang rewrites.
+- **Additive PRs only** — no removal of existing public APIs until a successor has been proven stable for one release.
+- **Quality gates every PR** — `prek run` (fmt + clippy + tests) passes before push.
+
+---
+
+## Relationship to trait-surface.md
+
+This roadmap (Phases 1-4) delivers **2 of the 7 substrate traits** defined in `trait-surface.md` — `ScoringStrategy` (PR-2a/2d) and `Reranker` (PR-2b) — plus structural decomposition of the four largest files and one reference backend (`MemoryStorage`). PR-4a-i adds a third trait (`RetrievalStrategy`), aligned with `trait-surface.md` §3.2's signature.
+
+The full `substrate/` module — the remaining 5 traits (`FusionStrategy`, `Scorer`, `LifecyclePolicy`, `ConsolidationStrategy`, `IngestionPipeline`), the `SearchPipeline` and `WritePipeline` orchestrators, `MemoryStore` supertrait, blanket impls for backward compatibility, and the 5-phase deprecation path (Define, Implement, Wire, Deprecate, Remove) — is the **v0.3.x campaign**. `trait-surface.md` is the design reference for that campaign. It is not superseded by this roadmap.
+
+Implementation agents working on v0.2.x should treat this roadmap as authoritative. When this roadmap and `trait-surface.md` conflict on trait signatures or module layout, this roadmap governs for Phases 1-4. For work beyond v0.2.2, `trait-surface.md` governs.
+
+---
+
+## Phase 1 — Clean House (target: v0.1.9)
+
+Four independent PRs that can be opened and merged in parallel. No benchmark risk on 1a/1b/1d; 1c is benchmark-gated.
+
+### PR-1a: Wire McpToolMode::Minimal list_tools filter
+
+**Complexity**: S | **Risk**: Low | **Benchmark gate**: No
+
+**Problem** (`src/mcp_server.rs`, lines 54–56): `McpToolMode::Minimal` is declared and stored but the rmcp proc-macro-generated router has no `list_tools` override, so the flag is a no-op at runtime. Clients that pass `--mcp-tools=minimal` see all 19 tools regardless.
+
+**Scope**:
+- Implement a `list_tools` override on the MCP handler struct that filters `TOOL_REGISTRY` to the 4 unified facades (`memory`, `memory_manage`, `memory_session`, `memory_admin`) when `mode == McpToolMode::Minimal`.
+- Remove the "NOTE: Minimal mode filtering is not yet wired" comment from the `McpToolMode` doc block.
+- Add a unit test asserting the filtered set contains exactly the 4 facade names.
+
+**Acceptance**: `prek run` passes; `cargo test --all-features` includes the new test; comment is gone. Unit test asserting `McpToolMode::Full` (or default) returns all 19 registered tools from `TOOL_REGISTRY`.
+
+---
+
+### PR-1b: Fix AGENTS.md tool count
+
+**Complexity**: S | **Risk**: None | **Benchmark gate**: No
+
+**Problem** (`AGENTS.md`, Architecture section): The line `src/mcp_server.rs — MCP stdio server (16 tools)` is stale. `TOOL_REGISTRY` now has 19 entries (15 legacy + 4 unified facades).
+
+**Scope**:
+- Update the AGENTS.md reference from "16 tools" to "19 tools".
+- Optionally clarify that `--mcp-tools=minimal` narrows the advertised set to 4.
+
+**Acceptance**: AGENTS.md reflects the current registry count.
+
+---
+
+### PR-1c: Parallelize sub-queries in advanced_search (Issue #121)
+
+**Complexity**: M | **Risk**: Medium | **Benchmark gate**: Yes
+
+**Problem** (`src/memory_core/storage/sqlite/advanced.rs`, lines 1541–1559): The query-decomposition loop runs sub-queries sequentially with a `TODO(#121)` comment. The comment identifies two blockers: uncertain concurrent-reader support in the pool, and serial `seen_ids` accumulation across iterations.
+
+**Scope**:
+- Verify `ConnPool` supports concurrent reader connections (inspect `conn_pool.rs`). If not, add a reader-pool expansion path first.
+- Replace the sequential `for sub_query` loop with `futures::future::join_all` (or `tokio::task::JoinSet`) issuing sub-queries concurrently.
+- Merge results after join: collect all sub-results, then apply the `seen_ids` dedup and score-max logic in a single pass.
+- Remove the `// TODO(#121)` comment.
+
+**Risk mitigations**:
+- Run the parallel path only for Conceptual/General intents (already the path that reaches decomposition).
+- Confirm with `cargo test --all-features` that no test uses a single-connection in-memory pool where concurrent access would deadlock.
+
+**Acceptance**: `prek run` passes; `./scripts/bench.sh --gate` shows no regression; `TODO(#121)` comment removed. Unit test verifying that when two parallel sub-queries return the same `memory_id` with different scores, the result contains exactly one entry with `score = max(scores)`.
+
+---
+
+### PR-1d: Split admin.rs into admin/ subdirectory
+
+**Complexity**: M | **Risk**: Low | **Benchmark gate**: No
+
+**Problem**: `src/memory_core/storage/sqlite/admin.rs` (1,619 lines) contains four independent trait impl groups (`BackupManager`, `MaintenanceManager`, `WelcomeProvider`, `StatsProvider`) with no cross-group coupling. The module-decomposition spec (Section 2d, Section 3d) identifies this as the easiest structural split in the codebase.
+
+**Scope — target layout** (per `module-decomposition.md` §2d):
+
+| File | Content |
+|---|---|
+| `sqlite/admin/mod.rs` | Re-exports, constants (`MAX_BACKUPS`, `BACKUP_INTERVAL_SECS`, `BACKUP_PREFIX`, `BACKUP_SUFFIX`) |
+| `sqlite/admin/backup.rs` | `backups_dir()`, `collect_backup_entries()`, `create_backup_sync()`, `rotate_backups_sync()`, `list_backups_sync()`, `restore_backup_sync()`, `needs_backup()`, `impl BackupManager for SqliteStorage` |
+| `sqlite/admin/maintenance.rs` | `impl MaintenanceManager for SqliteStorage`: `check_health()`, `consolidate()`, `compact()`, `auto_compact()`, `clear_session()`, `estimate_tokens()` |
+| `sqlite/admin/welcome.rs` | `impl WelcomeProvider for SqliteStorage`: `welcome()`, `welcome_scoped()` |
+| `sqlite/admin/stats.rs` | `impl StatsProvider for SqliteStorage`: `type_stats()`, `session_stats()`, `weekly_digest()`, `access_rate_stats()` |
+
+**Execution order** (move one group at a time, verify `prek run` between each):
+1. Create `admin/` directory and `admin/mod.rs` with re-exports
+2. Move `impl BackupManager` block → `admin/backup.rs`
+3. Move `impl MaintenanceManager` block → `admin/maintenance.rs`
+4. Move `impl WelcomeProvider` block → `admin/welcome.rs`
+5. Move `impl StatsProvider` block → `admin/stats.rs`
+6. Replace `admin.rs` with `admin/mod.rs`; update parent `mod.rs` declaration
+
+**File size exceptions**: `admin/maintenance.rs` (~580 lines) and `admin/welcome.rs` (~490 lines) exceed the 500-line target. Both exceptions are justified in `module-decomposition.md` §4: `MaintenanceManager` methods share `estimate_tokens()` helper with strong semantic cohesion; `welcome()` and `welcome_scoped()` are tightly coupled with shared JSON output shape.
+
+**Risk mitigations**:
+- Each step is a pure move — no logic changes. The four trait impl groups are completely independent.
+- `prek run` after each step catches compilation issues immediately.
+- Admin logic is not on the search path; no benchmark gate needed.
+
+**Acceptance**: `prek run` passes; `admin.rs` replaced by `admin/` directory with 5 files; no public API surface changes.
+
+---
+
+## Phase 2 — Scoring Decoupling + Structural Cleanup (target: v0.2.0)
+
+Four PRs with a serial dependency chain. PR-2a and PR-2b can be opened in parallel; PR-2c starts only after both land; PR-2d starts after PR-2c.
+
+```
+PR-2a ──┐
+        ├──> PR-2c ──> PR-2d
+PR-2b ──┘
+```
+
+### PR-2a: Extract ScoringStrategy trait
+
+**Complexity**: M | **Risk**: Low | **Benchmark gate**: No (additive)
+
+**Problem**: Scoring logic is embedded in `SqliteStorage` and tied to the concrete `ScoringParams` struct. Phase 3 and Phase 4 need a scoring abstraction that can be swapped without rebuilding storage.
+
+**Scope**:
+- Define a `ScoringStrategy` trait in `src/memory_core/scoring.rs` (or a new `scoring_strategy.rs`).
+- Trait surface (initial): `fn score(&self, candidate: &RankedSemanticCandidate, query: &str, params: &ScoringParams) -> f64`.
+- Implement `DefaultScoringStrategy` that wraps the existing score-refinement logic from `advanced.rs` Phase 4 (`fuse_refine_and_output`).
+- No behavioral changes; the existing path delegates to `DefaultScoringStrategy`.
+- Design for extensibility: the trait should accept a context bag (query, options, scoring params) so Phase 4's `KeywordOnlyStrategy` can ignore unused fields without a breaking signature change.
+
+**Acceptance**: `prek run` passes; no existing test changes behavior; trait is documented with a doc comment explaining the extension point.
+
+---
+
+### PR-2b: Extract Reranker trait boundary (Issue #119)
+
+**Complexity**: M | **Risk**: Medium | **Benchmark gate**: Yes
+
+**Problem**: `CrossEncoderReranker` (`src/memory_core/reranker.rs`) is a concrete struct referenced directly in `SqliteStorage` via `#[cfg(feature = "real-embeddings")]`. There is no trait boundary, making alternative reranker implementations (e.g., a no-op pass-through for testing, or a future LLM-based reranker) impossible without modifying `SqliteStorage`.
+
+**Scope**:
+- Define a `Reranker` trait in `src/memory_core/reranker.rs`:
+  - `async fn rerank(&self, query: &str, candidates: &[RankedSemanticCandidate]) -> Result<HashMap<String, f32>>`.
+- Implement `Reranker` for `CrossEncoderReranker` (feature-gated as today).
+- Add a `NoOpReranker` that returns an empty scores map (used in tests and non-`real-embeddings` builds).
+- Change `SqliteStorage::reranker` field from `Option<Arc<CrossEncoderReranker>>` to `Option<Arc<dyn Reranker + Send + Sync>>`.
+
+**Risk mitigations**:
+- The cross-encoder path is feature-gated; the trait change is contained to a `cfg` block.
+- Run full benchmark suite after landing to verify the reranker-enabled path scores identically.
+
+**Acceptance**: `prek run` passes; `./scripts/bench.sh --gate` shows no regression; `CrossEncoderReranker` is not directly referenced in `mcp_server.rs` or `SqliteStorage` field types.
+
+---
+
+### PR-2c: sqlite/mod.rs structural extraction
+
+**Complexity**: L | **Risk**: Medium | **Benchmark gate**: Yes (structural sanity check)
+
+**Problem**: `src/memory_core/storage/sqlite/mod.rs` (1,281 lines) holds the `SqliteStorage` struct definition, all constructor/builder methods, cache management logic (`CachedQuery`, `QueryCache`, `invalidate_cache_selective`, `invalidate_query_cache`), hot-cache lifecycle methods (`refresh_hot_cache`, `start_hot_cache_refresh_task`, `ensure_hot_cache_ready`), the `add_relationship` method, and the `stats`/`optimize` utility methods. These concerns are distinct and the file is long enough to impede navigation.
+
+The trait implementations themselves are already distributed across submodules (`crud.rs`, `search.rs`, `advanced.rs`, `graph.rs`, `lifecycle.rs`, `session.rs`, `admin.rs`, etc.) — no trait redistribution is needed.
+
+**Target file layout after this PR**:
+
+| New file | Content |
+|---|---|
+| `storage.rs` | `SqliteStorage` struct definition, `InitMode`, `ConnPool` wiring, all constructor/builder methods (`new`, `new_default`, `new_with_path`, `with_reranker`, `with_scoring_params`, `set_scoring_params`, `scoring_params`, `optimize`) |
+| `cache.rs` | `CachedQuery`, `QueryCache`, `new_query_cache`, `invalidate_query_cache`, `invalidate_cache_selective`, `cache_entry_could_be_affected` |
+| `hot_cache_mgmt.rs` | `refresh_hot_cache`, `refresh_hot_cache_best_effort`, `ensure_hot_cache_ready`, `start_hot_cache_refresh_task` (orchestration logic; `HotTierCache` struct stays in `hot_cache.rs`) |
+| `relationships.rs` | `add_relationship`, `graph_edge_stats` |
+| `io.rs` | `stats`, any remaining bulk-read helpers currently in `mod.rs` |
+
+`mod.rs` becomes a thin re-export facade after extraction.
+
+**Execution order** (move one group at a time, verify `prek run` between each):
+1. Extract cache types/functions → `cache.rs`
+2. Extract hot-cache management → `hot_cache_mgmt.rs`
+3. Extract relationship methods → `relationships.rs`
+4. Extract I/O helpers → `io.rs`
+5. Extract struct + constructors → `storage.rs`
+6. Reduce `mod.rs` to re-exports
+
+**Risk mitigations**:
+- Each step is a pure move — no logic changes. Compile after every step.
+- Use `pub(super)` visibility where submodules already rely on it; adjust visibility declarations to match the new module boundary.
+- The existing 500+ tests in `tests.rs` cover this surface; no test changes expected.
+
+**Acceptance**: `prek run` passes; `./scripts/bench.sh --gate` shows no regression (per `module-decomposition.md` §6 test gates — even for structural moves, the gate catches subtle visibility/import errors that could alter behavior); `mod.rs` is under 100 lines of re-exports; no public API surface changes.
+
+---
+
+### PR-2d: Inject ScoringStrategy into SqliteStorage
+
+**Complexity**: M | **Risk**: Medium | **Benchmark gate**: Yes (10-sample gate required — manual; CI runs 2-sample fast mode)
+
+**Depends on**: PR-2a (trait definition) and PR-2c (storage struct extracted, easier to modify)
+
+**Problem**: After PR-2a defines the `ScoringStrategy` trait, `SqliteStorage` should hold a `Box<dyn ScoringStrategy>` (or `Arc`) field and delegate Phase 4 scoring to it. This severs the hard coupling between the storage struct and the scoring implementation, enabling Phase 3's `MemoryStorage` to use a different strategy without duplicating code.
+
+**Scope**:
+- Add `scoring_strategy: Arc<dyn ScoringStrategy + Send + Sync>` field to `SqliteStorage`.
+- Default-initialize to `Arc::new(DefaultScoringStrategy::new())`.
+- Add `with_scoring_strategy` builder method.
+- Thread the strategy into `fuse_refine_and_output` (currently in `advanced.rs`) by passing it through the call chain or storing it in `SqliteStorage` for sub-function access.
+- Update grid-search and benchmark harnesses that call `set_scoring_params` to still work (they configure the `ScoringParams` struct, which `DefaultScoringStrategy` reads — no change needed there).
+
+**Risk mitigations**:
+- Keep `ScoringParams` as a plain data struct (not part of the trait) so grid-search continues to work unmodified.
+- Benchmark gates catch any scoring drift from the delegation layer.
+
+**Acceptance**: `prek run` passes; `./scripts/bench.sh --samples 10 --notes "PR-2d pre-merge"` shows no regression (10-sample gate required — PR-2d threads scoring delegation through the hot path, which is an algorithmic-path change, not a code move; 2-sample noise floor is insufficient to detect subtle parameter-passing bugs); `ScoringStrategy` is injected and documented.
+
+---
+
+## Phase 3 — Prove the Substrate (target: v0.2.1)
+
+Three PRs with internal dependencies. PR-3a is independent. PR-3b depends on PR-2d (needs `ScoringStrategy` injection to wire `DefaultScoringStrategy`). PR-3c depends on PR-3b (conformance suite requires `MemoryStorage` to exist). PR-3a can run in parallel with PR-3b; PR-3c is serial after PR-3b.
+
+```
+PR-3a (independent, parallel with PR-3b)
+PR-3b (depends on PR-2d) ──> PR-3c
+```
+
+### PR-3a: Strategy comparison benchmark harness
+
+**Complexity**: M | **Risk**: Low | **Benchmark gate**: No (adds harness, no behavior change)
+
+**Problem**: There is currently no tooling to compare scoring strategies head-to-head against the LoCoMo benchmark. Adding strategies without comparative tooling means regressions can only be caught after the fact.
+
+**Governing spec**: `benchmark-harness.md` defines the detailed design for the strategy comparison feature. PR-3a implements that spec. Where this section summarizes, the benchmark-harness spec is authoritative.
+
+**Scope** (per `benchmark-harness.md` §1-§5):
+- Add `--strategy <name>` and `--list-strategies` flags to the existing `locomo_bench` binary (not a standalone binary).
+- Create `benches/locomo/strategies.rs` with the `STRATEGIES` registry, `find_strategy()`, `list_strategies()`, and `build_storage()` functions.
+- Create `benches/bench_utils/stats.rs` with `percentile_ms()` P95 latency helper.
+- Add `strategy: String` and `p95_query_ms: f64` fields to `LoCoMoSummary` in `benches/locomo/types.rs` (both `#[serde(default)]`).
+- Create `docs/benchmarks/baselines.json` bootstrapped from `methodology.md` values (schema per `benchmark-harness.md` §4).
+- Update `bench.sh --gate` to read the baseline from `baselines.json` instead of CSV grep (per `benchmark-harness.md` §4).
+- Create `scripts/compare_strategies.py` (Python 3 stdlib only) for strategy comparison reports.
+- Extend `bench.sh` with `--compare A B` mode that runs two strategy invocations and calls `compare_strategies.py`.
+
+**Acceptance**: `cargo run --release --bin locomo_bench -- --strategy sqlite-v1 --list-strategies` works; `--strategy sqlite-v1` (default) produces scores identical to the unpatched binary; `baselines.json` exists and `bench.sh --gate` reads from it; `compare_strategies.py` produces well-formed JSON and Markdown reports; CSV rows are appended with `strategy=<id>` in the notes field.
+
+---
+
+### PR-3b: In-memory HashMap backend (MemoryStorage)
+
+**Complexity**: M | **Risk**: Low | **Benchmark gate**: No
+
+**Problem**: All tests run against SQLite (`:memory:`). An in-memory `HashMap`-backed storage backend would enable faster unit tests for pure logic, make conformance testing explicit, and serve as a reference implementation of the storage traits.
+
+**Scope**:
+- Add `src/memory_core/storage/memory/mod.rs` implementing `MemoryStorage`.
+- Implement the core trait set: `Storage`, `Retriever`, `Searcher` (text-match only, no FTS5/vector), `Deleter`, `Updater`, `Lister`, `Tagger`, `StatsProvider`.
+- Traits that are SQLite-specific (`AdvancedSearcher`, `PhraseSearcher`) can be stubbed with `unimplemented!()` for now.
+- Use `Arc<RwLock<HashMap<String, StoredMemory>>>` internally.
+- Inject `DefaultScoringStrategy` (from PR-2a/2d) for any scoring that happens at retrieval time.
+
+**Acceptance**: `prek run` passes; at least 10 unit tests cover `MemoryStorage` CRUD paths.
+
+---
+
+### PR-3c: Shared backend conformance suite
+
+**Complexity**: M | **Risk**: Low | **Benchmark gate**: No
+
+**Depends on**: PR-3b (`MemoryStorage` must exist to instantiate the suite against it)
+
+**Problem**: Without a shared test suite, the `MemoryStorage` and `SqliteStorage` backends can diverge silently. A conformance suite ensures both backends exhibit identical behavior for the traits they share.
+
+**Scope**:
+- Add `tests/storage_conformance.rs`.
+- Define a macro or generic function `run_conformance_suite<S: Storage + Retriever + ...>(storage: S)` that runs a standard set of assertions: store/retrieve round-trip, update, delete, tag search, list ordering, stats counts.
+- Instantiate it for both `SqliteStorage::new_with_path(":memory:")` and `MemoryStorage::new()`.
+- Failures in conformance tests are treated as blocking bugs, not warnings.
+
+**Trait scope note**: The conformance suite tests the trait subset that `MemoryStorage` implements: `Storage`, `Retriever`, `Deleter`, `Updater`, `Lister`, `Searcher`, `Tagger`, `StatsProvider`. It does NOT include `AdvancedSearcher` or `PhraseSearcher` in the generic bound — `MemoryStorage` stubs these with `unimplemented!()` (per PR-3b), so including them would panic at test time. The suite covers the common-subset contract; SQLite-specific traits are tested by the existing `tests.rs` suite.
+
+**Acceptance**: `cargo test --all-features` runs the conformance suite against both backends; all tests pass.
+
+---
+
+## Phase 4 — Exercise & Decompose (target: v0.2.2)
+
+Four PRs. PR-4a-i depends on PR-2a/PR-2d and can be opened after Phase 2 merges. PR-4b can be opened any time after Phase 1 — it has no dependency on Phases 2 or 3. PR-4a-ii depends on PR-4a-i. PR-4c depends on PR-4b.
+
+```
+PR-4a-i ──> PR-4a-ii
+PR-4b   ──> PR-4c
+```
+
+### PR-4a-i: Define RetrievalStrategy trait + FullPipelineStrategy reference impl
+
+**Complexity**: M | **Risk**: Low | **Benchmark gate**: No (additive — no behavior change)
+
+**Depends on**: PR-2a, PR-2d (ScoringStrategy injection in place)
+
+**Problem**: The current pipeline always runs the full 6-phase RRF pipeline (vector + FTS5 + rerank + refinement + graph + abstention). Before alternative retrieval paths can be added (PR-4a-ii), the retrieval abstraction must be defined.
+
+**Scope**:
+- Define a `RetrievalStrategy` trait aligned with `trait-surface.md` §3.2 (returns raw `CandidateSet`, not fully-scored `Vec<SemanticResult>`):
+  - `fn name(&self) -> &str`
+  - `async fn collect(&self, ctx: &QueryContext) -> Result<CandidateSet>`
+- **Design alignment note**: PR-4a-i's trait design MUST match `trait-surface.md` §3.2. The trait returns unscored `CandidateSet` to preserve the fusion step. Strategies produce raw candidates; fusion, scoring, and abstention happen downstream in the pipeline composition model. This ensures `RetrievalStrategy` is composable with multi-strategy pipelines in the v0.3.x substrate campaign.
+- Implement `FullPipelineStrategy` as a reference impl that wraps the existing 6-phase path, collecting candidates into a `CandidateSet`.
+- No behavioral changes — the existing path delegates to `FullPipelineStrategy` and the downstream fusion/scoring/abstention steps remain unchanged.
+
+**Acceptance**: `prek run` passes; no existing test changes behavior; `RetrievalStrategy` trait and `FullPipelineStrategy` impl are documented with doc comments.
+
+---
+
+### PR-4a-ii: Implement KeywordOnlyStrategy + wire dispatch
+
+**Complexity**: M | **Risk**: High | **Benchmark gate**: Yes (10-sample gate required — manual; CI runs 2-sample fast mode)
+
+**Depends on**: PR-4a-i (trait definition)
+
+**Problem**: For Keyword-intent queries, the vector and rerank phases add latency with marginal quality benefit. A `KeywordOnlyStrategy` allows the query classifier to select a simpler, faster path.
+
+**Scope**:
+- Implement `KeywordOnlyStrategy`: FTS5 BM25 only, no embedding, no reranker. Returns raw FTS candidates as a `CandidateSet` (per the trait contract). Scoring via `DefaultScoringStrategy` happens downstream in the pipeline, not inside the strategy.
+- Register both strategies in `SqliteStorage`; dispatch to `KeywordOnlyStrategy` when `intent.primary == QueryIntent::Keyword`.
+- The 10-sample benchmark gate guards against latency/quality tradeoffs that hurt overall LoCoMo score.
+
+**Risk mitigations**:
+- The `name()`-based dispatch means the full pipeline is preserved for all other intents.
+- Run `./scripts/bench.sh --samples 10 --notes "PR-4a-ii pre-merge"` to establish a baseline; gate at >5 pp regression.
+- If keyword queries show a quality drop, tune `KeywordOnlyStrategy` scoring weights before merging.
+
+**Acceptance**: `prek run` passes; `./scripts/bench.sh --samples 10` passes with no >5pp regression; keyword-intent queries use `KeywordOnlyStrategy` (verifiable via tracing log).
+
+---
+
+### PR-4b: Split mcp_server.rs into mcp/ module
+
+**Complexity**: L | **Risk**: Medium | **Benchmark gate**: No
+
+**Problem**: `src/mcp_server.rs` (2,709 lines) contains the tool registry, MCP instructions, validation helpers, `McpToolMode`, and every tool handler. It is the largest single file in the codebase.
+
+**Scope — target module layout**:
+
+| File | Content |
+|---|---|
+| `src/mcp/mod.rs` | Re-exports, `McpToolMode`, `MCP_INSTRUCTIONS`, `ToolMeta`, `TOOL_REGISTRY` |
+| `src/mcp/validation.rs` | `require_finite`, `MAX_RESULT_LIMIT`, `MAX_BATCH_SIZE` |
+| `src/mcp/tools/storage.rs` | `memory_store`, `memory_store_batch`, `memory_retrieve`, `memory_delete`, `memory_update`, `memory` facade |
+| `src/mcp/tools/search.rs` | `memory_search`, `memory_list` |
+| `src/mcp/tools/relations.rs` | `memory_relations` |
+| `src/mcp/tools/lifecycle.rs` | `memory_feedback`, `memory_lifecycle` |
+| `src/mcp/tools/session.rs` | `memory_checkpoint`, `memory_remind`, `memory_lessons`, `memory_profile`, `memory_session_info`, `memory_session` facade |
+| `src/mcp/tools/admin.rs` | `memory_admin` facade |
+| `src/mcp/tools/manage.rs` | `memory_manage` facade |
+
+**Risk mitigations**:
+- The thin-wrapper pattern is documented in `module-decomposition.md` §2a with a working code example. The `#[tool_router] impl McpMemoryServer` block stays in `mcp/mod.rs` with 1-3 line wrapper methods that delegate to free functions in `tools/*.rs`. Verify the rmcp 0.16 `#[tool_router]` proc-macro accepts cross-module handler delegation in the first commit before proceeding with the full extraction.
+- If the proc macros require co-location with the impl block, consolidate tool method bodies into submodules called from a single `impl MagServer` in `mcp/mod.rs`.
+- Run `cargo test --all-features` including MCP smoke tests (`tests/mcp_smoke.rs`) after each file split.
+
+**Acceptance**: `prek run` passes; `src/mcp_server.rs` is either removed or reduced to a thin re-export shim; MCP smoke tests pass. Update AGENTS.md Architecture section to reflect `src/mcp/` module structure (replacing `src/mcp_server.rs` references).
+
+---
+
+### PR-4c: Split advanced.rs into pipeline/ subdirectory
+
+**Complexity**: M | **Risk**: Medium | **Benchmark gate**: Yes (structural sanity check)
+
+**Depends on**: PR-4b (establishes the module-split pattern; lessons applied here)
+
+**Problem**: `advanced.rs` (1,739 lines, 6-phase pipeline + decomposition) is the last major god file after PR-1d (which already split `admin.rs` in Phase 1). The target layout follows `module-decomposition.md` §2c and §3c, which provide line-by-line function assignments to the `pipeline/` subdirectory.
+
+**Pre-split requirement**: Audit shared helper types across `advanced.rs` and the target `pipeline/` files before splitting. If types like `RankedSemanticCandidate` or utility functions are shared across multiple target files, extract them to `mod.rs` re-exports or a `types.rs` first. This avoids circular imports during the split.
+
+**Scope — advanced.rs → pipeline/** (per `module-decomposition.md` §2c):
+
+| File | Content |
+|---|---|
+| `sqlite/pipeline/mod.rs` | Module re-exports, `ADVANCED_FTS_CANDIDATE_*` constants, `advanced_fts_candidate_limit()` |
+| `sqlite/pipeline/retrieval.rs` | `collect_vector_candidates()` (Phase 1), `collect_fts_candidates()` (Phase 2) |
+| `sqlite/pipeline/rerank.rs` | `compute_cross_encoder_scores()` [cfg(real-embeddings)] |
+| `sqlite/pipeline/fusion.rs` | `fuse_refine_and_output()` Phase 3 RRF block: RRF scoring, dual-match boost, cross-encoder blend |
+| `sqlite/pipeline/scoring.rs` | `refine_scores()` (Phase 4) |
+| `sqlite/pipeline/enrichment.rs` | `enrich_graph_neighbors()` (Phase 5), `expand_entity_tags()` (Phase 5b) |
+| `sqlite/pipeline/abstention.rs` | Abstention + dedup block (Phase 6), `merge_hot_cache_results()`, `merge_semantic_result()`, `merge_semantic_metadata()` |
+| `sqlite/pipeline/decomp.rs` | `run_single_query_pipeline()`, query decomposition orchestration |
+
+`advanced.rs` residual (~350 lines): `impl AdvancedSearcher for SqliteStorage` (the `advanced_search` body, cache read/write) + tests module. The residual calls into `pipeline/` functions.
+
+**Risk mitigations**:
+- This touches the search scoring path. Run `./scripts/bench.sh --gate` after the split to catch any subtle visibility/import errors.
+- Each step is a pure move — no logic changes. Compile after every step.
+- The module-decomposition spec (§3c) provides exact line-number assignments for every function.
+
+**Acceptance**: `prek run` passes; `./scripts/bench.sh --gate` shows no regression; file sizes are all under 500 lines (with `admin/maintenance.rs` ~580 and `admin/welcome.rs` ~490 exceptions per `module-decomposition.md` §4); no behavioral changes. Update AGENTS.md Architecture section to reflect `sqlite/pipeline/` and `sqlite/admin/` module structures.
+
+---
+
+## Dependency Graph
+
+```
+Phase 1 (parallel)
+├── PR-1a  Wire McpToolMode::Minimal
+├── PR-1b  Fix AGENTS.md tool count
+├── PR-1c  Parallelize sub-queries [bench gate]
+└── PR-1d  Split admin.rs → admin/
+
+Phase 2 (serial chain)
+├── PR-2a  ScoringStrategy trait ──┐
+├── PR-2b  Reranker trait [bench]  ├──> PR-2c  sqlite/mod.rs extraction [bench] ──> PR-2d  Inject strategy [10-sample bench]
+└─────────────────────────────────┘
+
+Phase 3 (after Phase 2 completes)
+├── PR-3a  Strategy comparison harness (independent, parallel with PR-3b)
+├── PR-3b  MemoryStorage backend (depends on PR-2d) ──> PR-3c  Conformance suite
+└──────────────────────────────────────────────────────────────────────────────
+
+Phase 4
+├── PR-4a-i   Define RetrievalStrategy trait + FullPipelineStrategy (after Phase 2)
+├── PR-4a-ii  KeywordOnlyStrategy + dispatch [10-sample bench] (depends on PR-4a-i)
+├── PR-4b     Split mcp_server.rs (no dependency — can start after Phase 1) ──> PR-4c  Split advanced.rs → pipeline/ [bench gate]
+└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+```
+
+---
+
+## Risk Registry
+
+| # | Risk | Probability | Impact | Mitigation |
+|---|---|---|---|---|
+| 1 | PR-2c breaks the test suite during file moves | Medium | High | Move one group at a time; run `prek run` after each step; no logic changes, only moves |
+| 2 | PR-4a-ii causes LoCoMo regression on keyword or adversarial categories | Medium | High | 10-sample gate required; tune `KeywordOnlyStrategy` weights before merge; rollback path is removing the dispatch |
+| 3 | rmcp proc-macro incompatibility blocks PR-4b module split | Medium | Medium | Thin-wrapper pattern documented in `module-decomposition.md` §2a with code example; verify `#[tool_router]` accepts cross-module delegation in first commit; fallback is consolidating method bodies in submodules called from a single `impl` block |
+| 4 | `ScoringStrategy` trait surface too narrow for Phase 4's `KeywordOnlyStrategy` | Medium | Medium | Design trait with a context bag parameter from the start (PR-2a); extend rather than break if needed |
+| 5 | `MemoryStorage` conformance suite reveals hidden invariants in SQLite backend | Low | Low (positive) | Treat as a feature: invariants should be documented and enforced; conformance failures are bugs to fix, not tests to skip |
+| 6 | Visibility cascade when moving `SqliteStorage` to `storage.rs` (PR-2c) — every `super::SqliteStorage` reference in sibling submodules (`advanced.rs`, `crud.rs`, `search.rs`, `graph.rs`, `session.rs`, `lifecycle.rs`) breaks | High | Medium | Re-export `SqliteStorage` from `mod.rs` (`pub use storage::SqliteStorage;`) so existing `super::SqliteStorage` paths resolve. Apply this re-export as the first step of PR-2c, before moving any methods. |
+| 7 | PR-2b benchmark warning blocks entire PR-2c/PR-2d chain — a >2pp delta triggers a mandatory 10-sample run, stalling the serial chain | Medium | High | If PR-2b warns, investigate the delta before proceeding. A reranker-path regression is a real signal, not noise. Do not block the chain on noise — but do not ignore a genuine regression. If the 10-sample run confirms no regression, proceed; if it confirms regression, fix PR-2b before continuing. |
+| 8 | PR-1c scope expansion if `ConnPool` lacks concurrent reader support — the "if not, add a reader-pool expansion path first" clause is unscoped work hiding inside a Phase 1 quick-win | Medium | Medium | Spike `ConnPool` reader availability (`conn_pool.rs` inspection) before committing to PR-1c scope. If concurrent readers are not supported, either expand PR-1c to L-complexity with pool changes, or defer PR-1c to Phase 2 and replace it with a smaller Phase 1 win. |
+
+---
+
+## Milestone Checkpoints
+
+### v0.1.9 checkpoint
+- [ ] PR-1a merged: `--mcp-tools=minimal` filters the tool list at runtime
+- [ ] PR-1b merged: AGENTS.md tool count is accurate
+- [ ] PR-1c merged: sub-query parallelism active; `TODO(#121)` gone; no benchmark regression
+- [ ] PR-1d merged: `admin.rs` split into `admin/` subdirectory (4 files + mod.rs)
+
+### v0.2.0 checkpoint
+- [ ] PR-2a merged: `ScoringStrategy` trait and `DefaultScoringStrategy` in place
+- [ ] PR-2b merged: `Reranker` trait in place; `CrossEncoderReranker` implements it; no benchmark regression
+- [ ] PR-2c merged: `sqlite/mod.rs` reduced to re-export facade; `storage.rs`, `cache.rs`, `hot_cache_mgmt.rs`, `relationships.rs`, `io.rs` all exist and pass tests; benchmark gate passes
+- [ ] PR-2d merged: `ScoringStrategy` injected into `SqliteStorage`; 10-sample benchmark gate passes
+
+### v0.2.1 checkpoint
+
+Prerequisite: v0.2.0 checkpoint must be fully complete (all Phase 2 PRs merged) before PR-3b implementation begins. PR-3b depends on PR-2d's `ScoringStrategy` injection.
+
+- [ ] PR-3a merged: strategy comparison harness with `--strategy` flag on `locomo_bench`
+- [ ] PR-3b merged: `MemoryStorage` backend with 10+ unit tests
+- [ ] PR-3c merged: conformance suite passes for both backends
+
+### v0.2.2 checkpoint
+- [ ] PR-4a-i merged: `RetrievalStrategy` trait defined (aligned with `trait-surface.md` §3.2); `FullPipelineStrategy` reference impl in place
+- [ ] PR-4a-ii merged: `KeywordOnlyStrategy` dispatched for keyword intent; 10-sample gate passed
+- [ ] PR-4b merged: `mcp_server.rs` split into `mcp/` module; MCP smoke tests pass
+- [ ] PR-4c merged: `advanced.rs` split into `pipeline/` subdirectory; benchmark gate passes
+
+---
+
+## Quality Gate Summary
+
+| Gate | When | Command |
+|---|---|---|
+| Format | Every PR | `cargo fmt --all -- --check` |
+| Lint | Every PR | `cargo clippy --all-targets --all-features -- -D warnings` |
+| Tests | Every PR | `cargo test --all-features` |
+| Combined | Every PR | `prek run` (runs all three above) |
+| Benchmark 2-sample | PRs touching scoring/search/storage | `./scripts/bench.sh --gate` (warns >2 pp, fails >5 pp) |
+| Benchmark 10-sample | If 2-sample gate warned; required for PR-2d, PR-4a-ii | `./scripts/bench.sh --samples 10 --notes "pre-merge <pr>"` |
+
+10-sample gates are manual pre-merge checks. CI enforces 2-sample fast gates automatically. The 10-sample requirement for PR-2d and PR-4a-ii must be verified by the developer before merge and logged to the benchmark CSV.
+
+Results must be appended to `docs/benchmarks/benchmark_log.csv` using `bench.sh` (not raw `cargo run`).
+
+The benchmark gate compares against `docs/benchmarks/baselines.json` (see `benchmark-harness.md` §4). Before PR-3a lands, the gate uses the existing CSV-grep baseline.
+
+---
+
+## Branch Naming and Rebase Protocol
+
+This repo is jj-colocated. Use jj bookmarks for all PR branches. For the serial dependency chains (PR-2a through PR-2d, PR-4a-i through PR-4a-ii), the following protocol applies:
+
+### Bookmark names
+
+| PR | Bookmark |
+|---|---|
+| PR-1a | `fix/mcp-minimal-filter` |
+| PR-1b | `fix/agents-tool-count` |
+| PR-1c | `feat/parallel-subqueries` |
+| PR-1d | `refactor/admin-split` |
+| PR-2a | `refactor/scoring-strategy` |
+| PR-2b | `refactor/reranker-trait` |
+| PR-2c | `refactor/sqlite-extraction` |
+| PR-2d | `refactor/scoring-injection` |
+| PR-3a | `refactor/strategy-harness` |
+| PR-3b | `refactor/memory-storage` |
+| PR-3c | `refactor/conformance-suite` |
+| PR-4a-i | `refactor/retrieval-strategy` |
+| PR-4a-ii | `refactor/keyword-strategy` |
+| PR-4b | `refactor/mcp-split` |
+| PR-4c | `refactor/pipeline-split` |
+
+### Rebase protocol for serial chains
+
+When an earlier PR in a dependency chain merges to main:
+
+```bash
+# After PR-2a merges:
+jj rebase -b refactor/sqlite-extraction -d main
+
+# After PR-2c merges:
+jj rebase -b refactor/scoring-injection -d main
+
+# After PR-4a-i merges:
+jj rebase -b refactor/keyword-strategy -d main
+```
+
+For parallel PRs (Phase 1, PR-3a/3b), no rebase coordination is needed — each is branched from main independently.
+
+When subagents are dispatched to implement PRs in parallel on overlapping files, use `isolation: "worktree"` to prevent conflicting edits. The serial chain PRs (2a/2b → 2c → 2d) must NOT be implemented concurrently on the same worktree.
+
+---
+
+## Parked Items
+
+These are noted but explicitly out of scope for this roadmap. File GitHub issues for each if they need tracking.
+
+| Item | Reason parked |
+|---|---|
+| Voyage-4-nano ONNX as default embedder | Requires embedding dimension migration; separate campaign |
+| Knowledge graph as primary retrieval path | Phase 5 graph enrichment at 0.1 factor is deliberately conservative; promote only after benchmarked improvement |
+| LLM-based reranker | Requires `Reranker` trait (PR-2b) first; adds external dependency; cost model unclear |
+| Admin HTTP API / daemon-mode REST expansion | Separate feature campaign; not a structural refactor |
+| `conductor/` Gemini CLI cleanup | Legacy artifact; not actively maintained; low priority |
+| Multi-file import streaming | Useful but orthogonal; file separately |
+
+---
+
+## Version Targets Summary
+
+| Phase | Version | PRs | Focus |
+|---|---|---|---|
+| 1 | v0.1.9 | 1a, 1b, 1c, 1d | Quick wins: unblock Minimal mode, correct docs, parallelize sub-queries, split admin.rs |
+| 2 | v0.2.0 | 2a, 2b, 2c, 2d | Scoring decoupling + `sqlite/mod.rs` structural cleanup |
+| 3 | v0.2.1 | 3a, 3b, 3c | Prove the abstraction substrate: harness, in-memory backend, conformance |
+| 4 | v0.2.2 | 4a-i, 4a-ii, 4b, 4c | Exercise strategies, decompose mcp_server.rs and advanced.rs |
+
+---
+
+## PR Summary Table
+
+| PR | Phase | Complexity | Risk | Benchmark Gate | Depends On |
+|---|---|---|---|---|---|
+| PR-1a | 1 | S | Low | No | — |
+| PR-1b | 1 | S | None | No | — |
+| PR-1c | 1 | M | Medium | Yes (2-sample) | — |
+| PR-1d | 1 | M | Low | No | — |
+| PR-2a | 2 | M | Low | No (additive) | — |
+| PR-2b | 2 | M | Medium | Yes (2-sample) | — |
+| PR-2c | 2 | L | Medium | Yes (structural) | PR-2a, PR-2b |
+| PR-2d | 2 | M | Medium | Yes (10-sample, manual) | PR-2a, PR-2c |
+| PR-3a | 3 | M | Low | No (adds harness) | — |
+| PR-3b | 3 | M | Low | No | PR-2d |
+| PR-3c | 3 | M | Low | No | PR-3b |
+| PR-4a-i | 4 | M | Low | No (additive) | PR-2a, PR-2d |
+| PR-4a-ii | 4 | M | High | Yes (10-sample, manual) | PR-4a-i |
+| PR-4b | 4 | L | Medium | No | — |
+| PR-4c | 4 | M | Medium | Yes (structural) | PR-4b |

--- a/docs/specs/module-decomposition.md
+++ b/docs/specs/module-decomposition.md
@@ -1,0 +1,551 @@
+# Module Decomposition Spec
+<!-- Status: DRAFT | Verified against source: 2026-04-14 | Target: v0.2.x -->
+
+## 0. Recon Corrections
+
+The initial recon contained one critical error that affects the decomposition plan:
+
+**WRONG:** `sqlite/mod.rs` holds 19 inline trait impls.
+**CORRECT:** All trait impls are already distributed across submodules (`crud.rs`, `search.rs`,
+`graph.rs`, `session.rs`, `lifecycle.rs`, `advanced.rs`, `admin.rs`). The `mod.rs` file's 1,281
+lines consist of: `SqliteStorage` struct definition and constructors, cache management structs
+and methods, hot-cache background task, relationship operations (`add_relationship`,
+`try_auto_relate`, `try_create_temporal_edges`, `try_create_entity_edges`), bulk I/O methods
+(`stats`, `export_all`, `import_all`), the `RankedSemanticCandidate` struct, and submodule
+declarations + re-exports. There are no inline trait impls to extract — only concerns to separate.
+
+---
+
+## 1. Current State Inventory
+
+| File | Lines | Problem |
+|------|-------|---------|
+| `src/mcp_server.rs` | 2,709 | Mixed: protocol, request types, validation, 19 tool bodies, server infra |
+| `src/memory_core/storage/sqlite/advanced.rs` | 1,739 | Mixed: 7 pipeline phase functions, hot-cache helpers, query decomp orchestration, `impl AdvancedSearcher` |
+| `src/memory_core/storage/sqlite/admin.rs` | 1,619 | Mixed: 4 independent trait impl groups (backup, maintenance, welcome/stats, stats sub-methods) |
+| `src/memory_core/storage/sqlite/mod.rs` | 1,281 | Mixed: struct+constructors, cache management, hot-cache task, relationships, bulk I/O, shared types |
+
+---
+
+## 2. Target Module Tree
+
+### 2a. MCP Server: `src/mcp/`
+
+```
+src/mcp/
+├── mod.rs              ~400 lines   McpMemoryServer struct, #[tool_router] with 1-3 line wrappers,
+│                                    McpToolMode enum, serve_stdio(), ServerHandler impl
+├── protocol.rs         ~200 lines   MCP_INSTRUCTIONS const, TOOL_REGISTRY, CATEGORY_ORDER,
+│                                    generate_protocol_markdown(), tool_registry_json(), ToolMeta struct
+├── request_types.rs    ~350 lines   All *Request structs (StoreRequest, SearchRequest, ListRequest,
+│                                    DeleteRequest, UpdateRequest, RelationsRequest, FeedbackRequest,
+│                                    LifecycleRequest, CheckpointRequest, RemindRequest, LessonsRequest,
+│                                    SessionInfoRequest, ProfileRequest, MemoryRequest,
+│                                    MemoryManageRequest, MemorySessionRequest, MemoryAdminFacadeRequest)
+├── validation.rs        ~80 lines   MAX_RESULT_LIMIT, MAX_BATCH_SIZE, require_finite(),
+│                                    serialize_results(), build_memory_input()
+└── tools/
+    ├── storage.rs      ~180 lines   memory_store, memory_store_batch, memory_retrieve,
+    │                                memory_delete, memory_update bodies
+    ├── search.rs       ~200 lines   memory_search, memory_list bodies
+    ├── relations.rs    ~120 lines   memory_relations body
+    ├── lifecycle.rs    ~160 lines   memory_feedback, memory_lifecycle bodies
+    ├── session.rs      ~180 lines   memory_checkpoint, memory_remind, memory_lessons,
+    │                                memory_profile, memory_session_info bodies
+    └── facades.rs      ~300 lines   memory (unified), memory_manage, memory_session,
+                                     memory_admin bodies
+```
+
+### 2b. SQLite `mod.rs`: `src/memory_core/storage/sqlite/`
+
+New files extracted from mod.rs; existing submodule files untouched:
+
+```
+src/memory_core/storage/sqlite/
+├── mod.rs              ~120 lines   Constants (QUERY_CACHE_TTL_SECS, QUERY_CACHE_CAPACITY,
+│                                    SUPERSESSION_*), enums (StoreOutcome, InitMode),
+│                                    type aliases (QueryCache), submodule declarations,
+│                                    pub re-exports
+├── storage.rs          ~200 lines   SqliteStorage struct definition, new(), new_default(),
+│                                    new_with_path(), with_reranker(), reranker(),
+│                                    optimize(), scoring_params(), with_scoring_params(),
+│                                    set_scoring_params(), new_query_cache(),
+│                                    ensure_vec_extension_registered() [cfg(sqlite-vec)],
+│                                    new_in_memory() [cfg(test)], new_in_memory_with_embedder() [cfg(test)],
+│                                    test_conn() [cfg(test)], debug_* helpers [cfg(test)]
+├── cache.rs            ~180 lines   CachedQuery struct, invalidate_query_cache(),
+│                                    invalidate_cache_selective(), cache_entry_could_be_affected(),
+│                                    build_stats_paths_json()
+├── hot_cache_mgmt.rs   ~120 lines   refresh_hot_cache(), refresh_hot_cache_best_effort(),
+│                                    ensure_hot_cache_ready(), start_hot_cache_refresh_task()
+├── relationships.rs    ~180 lines   add_relationship(), try_auto_relate(),
+│                                    try_create_temporal_edges(), try_create_entity_edges(),
+│                                    relationship_exists(), graph_edge_stats()
+└── io.rs               ~380 lines   stats(), export_all(), import_all()
+                                     (plus RankedSemanticCandidate struct, shared between
+                                     mod.rs and advanced.rs — moves here or to a types.rs)
+```
+
+> Note: `RankedSemanticCandidate` is defined in `mod.rs` (lines 1225–1243) and used heavily in
+> `advanced.rs`. It should move to `storage.rs` or a new `types.rs` so `advanced.rs` can import it.
+
+### 2c. SQLite `advanced.rs`: `src/memory_core/storage/sqlite/pipeline/`
+
+```
+src/memory_core/storage/sqlite/pipeline/
+├── mod.rs              ~100 lines   Module re-exports, ADVANCED_FTS_CANDIDATE_* constants,
+│                                    advanced_fts_candidate_limit()
+├── retrieval.rs        ~250 lines   collect_vector_candidates() (Phase 1),
+│                                    collect_fts_candidates() (Phase 2)
+├── rerank.rs           ~80 lines    compute_cross_encoder_scores() [cfg(real-embeddings)]
+├── fusion.rs           ~200 lines   fuse_refine_and_output() Phase 3 (RRF fusion block only):
+│                                    RRF scoring, dual-match boost, cross-encoder blend
+├── scoring.rs          ~100 lines   refine_scores() (Phase 4)
+├── enrichment.rs       ~250 lines   enrich_graph_neighbors() (Phase 5),
+│                                    expand_entity_tags() (Phase 5b)
+├── abstention.rs       ~130 lines   Abstention + dedup block extracted from fuse_refine_and_output()
+│                                    (Phase 6), merge_hot_cache_results(), merge_semantic_result(),
+│                                    merge_semantic_metadata()
+└── decomp.rs           ~250 lines   run_single_query_pipeline(), query decomposition orchestration
+                                     within impl AdvancedSearcher::advanced_search
+```
+
+`advanced.rs` residual (renamed to the impl home):
+
+```
+src/memory_core/storage/sqlite/advanced.rs  ~350 lines
+    impl AdvancedSearcher for SqliteStorage (advanced_search body, cache read/write),
+    tests module
+```
+
+### 2d. SQLite `admin.rs`: `src/memory_core/storage/sqlite/admin/`
+
+```
+src/memory_core/storage/sqlite/admin/
+├── mod.rs              ~30 lines    pub use re-exports, constants (MAX_BACKUPS,
+│                                    BACKUP_INTERVAL_SECS, BACKUP_PREFIX, BACKUP_SUFFIX)
+├── backup.rs           ~310 lines   backups_dir(), collect_backup_entries(),
+│                                    create_backup_sync(), rotate_backups_sync(),
+│                                    list_backups_sync(), restore_backup_sync(),
+│                                    needs_backup(), impl BackupManager for SqliteStorage
+├── maintenance.rs      ~580 lines   impl MaintenanceManager for SqliteStorage:
+│                                    check_health(), consolidate(), compact(), auto_compact(),
+│                                    clear_session(), estimate_tokens()
+├── welcome.rs          ~490 lines   impl WelcomeProvider for SqliteStorage:
+│                                    welcome(), welcome_scoped()
+└── stats.rs            ~220 lines   impl StatsProvider for SqliteStorage:
+│                                    type_stats(), session_stats(), weekly_digest(),
+│                                    access_rate_stats()
+```
+
+---
+
+## 3. Function-to-File Assignments with Line Numbers
+
+### 3a. `src/mcp_server.rs` (2,709 lines)
+
+| Lines | Symbol | Destination |
+|-------|--------|-------------|
+| 1–25 | imports | `mcp/mod.rs` |
+| 27–43 | `MAX_RESULT_LIMIT`, `MAX_BATCH_SIZE`, `require_finite()` | `mcp/validation.rs` |
+| 48–117 | `McpToolMode`, `MCP_INSTRUCTIONS` const | `mcp/mod.rs` |
+| 119–233 | `ToolMeta`, `TOOL_REGISTRY`, `CATEGORY_ORDER` | `mcp/protocol.rs` |
+| 246–266 | `generate_protocol_markdown()` | `mcp/protocol.rs` |
+| 270–277 | `tool_registry_json()` | `mcp/protocol.rs` |
+| 279–292 | `serialize_results()` | `mcp/validation.rs` |
+| 294–329 | `build_memory_input()` | `mcp/validation.rs` |
+| 331–357 | `McpMemoryServer` struct, `new()`, `with_tool_mode()`, `serve_stdio()` | `mcp/mod.rs` |
+| 361–699 | All `*Request` structs (15 named + 4 unified = 19 total) | `mcp/request_types.rs` |
+| 702–755 | `memory_store`, `memory_store_batch` tool bodies | `mcp/tools/storage.rs` |
+| 757–971 | `memory_retrieve`, `memory_search` tool bodies | `mcp/tools/search.rs` (search); `mcp/tools/storage.rs` (retrieve) |
+| 973–1030 | `memory_list` tool body | `mcp/tools/search.rs` |
+| 1032–1087 | `memory_delete`, `memory_update` tool bodies | `mcp/tools/storage.rs` |
+| 1089–1233 | `memory_relations` tool body | `mcp/tools/relations.rs` |
+| 1236–1261 | `memory_feedback` tool body | `mcp/tools/lifecycle.rs` |
+| 1263–1423 | `memory_lifecycle` tool body | `mcp/tools/lifecycle.rs` |
+| 1425–1523 | `memory_checkpoint` tool body | `mcp/tools/session.rs` |
+| 1525–1617 | `memory_remind`, `memory_lessons` tool bodies | `mcp/tools/session.rs` |
+| 1619–1688 | `memory_profile`, `memory_session_info` tool bodies | `mcp/tools/session.rs` |
+| 1690–1780 | `memory` unified facade body | `mcp/tools/facades.rs` |
+| 1782–2201 | `memory_manage` unified facade body | `mcp/tools/facades.rs` |
+| 2203–2627 | `memory_session`, `memory_admin` unified facade bodies | `mcp/tools/facades.rs` |
+| 2630–2638 | `ServerHandler` impl (`get_info`) | `mcp/mod.rs` |
+| 2641–2709 | tests | `mcp/mod.rs` (tests submodule) |
+
+**`#[tool_router]` constraint:** The `#[tool_router]` proc-macro requires all `#[tool(...)]`
+methods to be in a single `impl McpMemoryServer` block. The solution is a **thin-wrapper
+pattern**: `mcp/mod.rs` keeps the `#[tool_router] impl McpMemoryServer` block with 1-3 line
+wrapper methods that delegate to functions in `tools/*.rs`. The tool function bodies live in the
+`tools/` files as free functions or methods on a helper struct, and are called via `use
+crate::mcp::tools::storage::memory_store_impl` etc. Each wrapper is:
+
+```rust
+async fn memory_store(&self, params: Parameters<StoreRequest>) -> Result<CallToolResult, McpError> {
+    tools::storage::memory_store_impl(&self.storage, params).await
+}
+```
+
+### 3b. `src/memory_core/storage/sqlite/mod.rs` (1,281 lines)
+
+| Lines | Symbol | Destination |
+|-------|--------|-------------|
+| 1–28 | imports | `mod.rs` (residual) |
+| 29–51 | `QUERY_CACHE_TTL_SECS`, `QUERY_CACHE_CAPACITY`, `CachedQuery`, `QueryCache` | `cache.rs` |
+| 53–62 | `SUPERSESSION_COSINE_THRESHOLD`, `SUPERSESSION_JACCARD_THRESHOLD` | `mod.rs` or `storage.rs` |
+| 63–73 | `StoreOutcome`, `InitMode` enums | `mod.rs` (shared types) |
+| 81–95 | `SqliteStorage` struct | `storage.rs` |
+| 97–119 | `ensure_vec_extension_registered()`, `new_query_cache()` | `storage.rs` |
+| 121–222 | `impl SqliteStorage { new(), new_default(), new_with_path(), with_reranker(), reranker(), optimize(), scoring_params(), with_scoring_params(), set_scoring_params() }` | `storage.rs` |
+| 224–306 | `invalidate_query_cache()`, `invalidate_cache_selective()`, `cache_entry_could_be_affected()` | `cache.rs` |
+| 308–411 | `refresh_hot_cache()`, `refresh_hot_cache_best_effort()`, `ensure_hot_cache_ready()`, `start_hot_cache_refresh_task()` | `hot_cache_mgmt.rs` |
+| 413–451 | `add_relationship()` | `relationships.rs` |
+| 453–461 | `store()` and `update()` forwarding methods | `storage.rs` |
+| 463–535 | `graph_edge_stats()`, `stats()` | `relationships.rs` (`graph_edge_stats`); `io.rs` (`stats`) |
+| 537–660 | `export_all()` | `io.rs` |
+| 662–824 | `import_all()` | `io.rs` |
+| 826–902 | `new_in_memory()`, `new_in_memory_with_embedder()`, `test_conn()`, `debug_*` helpers [cfg(test)] | `storage.rs` |
+| 954–1059 | `try_auto_relate()` | `relationships.rs` |
+| 1061–1097 | `try_create_temporal_edges()` | `relationships.rs` |
+| 1099–1177 | `try_create_entity_edges()` | `relationships.rs` |
+| 1179–1206 | `relationship_exists()` | `relationships.rs` |
+| 1209–1223 | `build_stats_paths_json()` | `cache.rs` or `io.rs` |
+| 1225–1243 | `RankedSemanticCandidate` struct | `storage.rs` (or new `types.rs`) |
+| 1245–1281 | `mod` declarations, `use` re-exports | `mod.rs` (residual) |
+
+### 3c. `src/memory_core/storage/sqlite/advanced.rs` (1,739 lines)
+
+| Lines | Symbol | Destination |
+|-------|--------|-------------|
+| 1–23 | imports, `ADVANCED_FTS_*` constants, `advanced_fts_candidate_limit()` | `pipeline/mod.rs` |
+| 25–190 | `collect_vector_candidates()` (Phase 1) | `pipeline/retrieval.rs` |
+| 192–313 | `collect_fts_candidates()` (Phase 2) | `pipeline/retrieval.rs` |
+| 315–366 | `compute_cross_encoder_scores()` [cfg(real-embeddings)] | `pipeline/rerank.rs` |
+| 368–448 | `refine_scores()` (Phase 4) | `pipeline/scoring.rs` |
+| 450–672 | `enrich_graph_neighbors()` (Phase 5) | `pipeline/enrichment.rs` |
+| 674–866 | `expand_entity_tags()` (Phase 5b) | `pipeline/enrichment.rs` |
+| 868–1093 | `fuse_refine_and_output()` — Phase 3 RRF block (868–999) + abstention/dedup (1035–1093) | `pipeline/fusion.rs` (RRF), `pipeline/abstention.rs` (dedup+gate) |
+| 1095–1170 | `merge_hot_cache_results()`, `merge_semantic_result()`, `merge_semantic_metadata()` | `pipeline/abstention.rs` |
+| 1172–1293 | `run_single_query_pipeline()` | `pipeline/decomp.rs` |
+| 1295–1613 | `impl AdvancedSearcher for SqliteStorage { advanced_search() }` | `advanced.rs` (residual, calls pipeline functions) |
+| 1615–1739 | tests | `advanced.rs` (residual, tests submodule) |
+
+### 3d. `src/memory_core/storage/sqlite/admin.rs` (1,619 lines)
+
+| Lines | Symbol | Destination |
+|-------|--------|-------------|
+| 1–12 | imports, `MAX_BACKUPS`, `BACKUP_INTERVAL_SECS`, `BACKUP_PREFIX`, `BACKUP_SUFFIX` | `admin/mod.rs` |
+| 14–40 | `backups_dir()`, `collect_backup_entries()` | `admin/backup.rs` |
+| 42–157 | `create_backup_sync()`, `rotate_backups_sync()`, `list_backups_sync()`, `restore_backup_sync()` | `admin/backup.rs` |
+| 220–311 | `needs_backup()`, `impl BackupManager for SqliteStorage` | `admin/backup.rs` |
+| 313–886 | `impl MaintenanceManager for SqliteStorage` (check_health, consolidate, compact, auto_compact, clear_session, estimate_tokens) | `admin/maintenance.rs` |
+| 887–1379 | `impl WelcomeProvider for SqliteStorage` (welcome, welcome_scoped) | `admin/welcome.rs` |
+| 1381–1619 | `impl StatsProvider for SqliteStorage` (type_stats, session_stats, weekly_digest, access_rate_stats) | `admin/stats.rs` |
+
+---
+
+## 4. File Size Targets
+
+| Target File | Estimated Lines | Status |
+|-------------|----------------|--------|
+| `mcp/mod.rs` | ~400 | Within limit |
+| `mcp/protocol.rs` | ~200 | Within limit |
+| `mcp/request_types.rs` | ~350 | Within limit |
+| `mcp/validation.rs` | ~80 | Within limit |
+| `mcp/tools/storage.rs` | ~180 | Within limit |
+| `mcp/tools/search.rs` | ~200 | Within limit |
+| `mcp/tools/relations.rs` | ~120 | Within limit |
+| `mcp/tools/lifecycle.rs` | ~160 | Within limit |
+| `mcp/tools/session.rs` | ~180 | Within limit |
+| `mcp/tools/facades.rs` | ~300 | Within limit |
+| `sqlite/mod.rs` (residual) | ~120 | Within limit |
+| `sqlite/storage.rs` | ~200 | Within limit |
+| `sqlite/cache.rs` | ~180 | Within limit |
+| `sqlite/hot_cache_mgmt.rs` | ~120 | Within limit |
+| `sqlite/relationships.rs` | ~180 | Within limit |
+| `sqlite/io.rs` | ~380 | Within limit |
+| `pipeline/mod.rs` | ~100 | Within limit |
+| `pipeline/retrieval.rs` | ~250 | Within limit |
+| `pipeline/rerank.rs` | ~80 | Within limit |
+| `pipeline/fusion.rs` | ~200 | Within limit |
+| `pipeline/scoring.rs` | ~100 | Within limit |
+| `pipeline/enrichment.rs` | ~250 | Within limit |
+| `pipeline/abstention.rs` | ~130 | Within limit |
+| `pipeline/decomp.rs` | ~250 | Within limit |
+| `advanced.rs` (residual) | ~350 | Within limit |
+| `admin/mod.rs` | ~30 | Within limit |
+| `admin/backup.rs` | ~310 | Within limit |
+| `admin/maintenance.rs` | ~580 | Exception justified |
+| `admin/welcome.rs` | ~490 | Exception justified |
+| `admin/stats.rs` | ~220 | Within limit |
+
+**Exception justifications:**
+
+- `admin/maintenance.rs` (~580 lines): `MaintenanceManager` has 5 methods (`check_health`,
+  `consolidate`, `compact`, `auto_compact`, `clear_session`) that share the `estimate_tokens()`
+  helper and have strong semantic cohesion as a single trait impl. Splitting individual methods
+  into sub-files would create excessive file-per-method granularity with no navigability benefit.
+
+- `admin/welcome.rs` (~490 lines): `welcome()` and `welcome_scoped()` are tightly coupled — they
+  share identical JSON output shape and `welcome_scoped()` delegates to `welcome()` for the
+  simple case. Separation would require either duplication or continued cross-file calling.
+
+---
+
+## 5. Module Dependency Graph
+
+```
+src/main.rs
+  └── mcp/mod.rs
+        ├── mcp/protocol.rs           (no deps on other mcp/ files)
+        ├── mcp/request_types.rs      (no deps on other mcp/ files)
+        ├── mcp/validation.rs         ← mcp/request_types.rs
+        └── mcp/tools/
+              ├── storage.rs          ← mcp/request_types.rs, mcp/validation.rs
+              ├── search.rs           ← mcp/request_types.rs, mcp/validation.rs
+              ├── relations.rs        ← mcp/request_types.rs, mcp/validation.rs
+              ├── lifecycle.rs        ← mcp/request_types.rs, mcp/validation.rs
+              ├── session.rs          ← mcp/request_types.rs, mcp/validation.rs
+              └── facades.rs          ← mcp/request_types.rs, mcp/validation.rs,
+                                         + all other tools/* (delegates into them)
+        All tools/* → memory_core::storage::SqliteStorage (via trait dispatch)
+
+src/memory_core/storage/sqlite/
+  mod.rs
+    ├── storage.rs         (SqliteStorage + constructors)
+    ├── cache.rs           ← storage.rs (CachedQuery lives here, SqliteStorage methods)
+    ├── hot_cache_mgmt.rs  ← storage.rs, hot_cache.rs (existing)
+    ├── relationships.rs   ← storage.rs, conn_pool.rs
+    ├── io.rs              ← storage.rs, conn_pool.rs, helpers.rs
+    ├── advanced.rs        ← pipeline/ (calls all pipeline phase functions)
+    │     └── pipeline/
+    │           ├── retrieval.rs   ← helpers.rs, embedding_codec.rs
+    │           ├── rerank.rs      ← reranker (real-embeddings feature)
+    │           ├── fusion.rs      ← retrieval.rs (types), scoring.rs
+    │           ├── scoring.rs     ← memory_core::scoring
+    │           ├── enrichment.rs  ← helpers.rs, memory_core::domain
+    │           ├── abstention.rs  ← helpers.rs
+    │           └── decomp.rs      ← retrieval.rs, fusion.rs, abstention.rs
+    └── admin/
+          ├── backup.rs      ← conn_pool.rs
+          ├── maintenance.rs ← conn_pool.rs, helpers.rs, embedding_codec.rs
+          ├── welcome.rs     ← advanced.rs (calls AdvancedSearcher), session.rs (ProfileManager, ReminderManager)
+          └── stats.rs       ← conn_pool.rs
+```
+
+### Circular Dependency Analysis
+
+**No circular dependencies exist or will be introduced**, with one caveat to watch:
+
+- `admin/welcome.rs` calls `<SqliteStorage as AdvancedSearcher>::advanced_search()`, which is
+  implemented in `advanced.rs`. Both are submodules of the same `sqlite/` crate, so this is a
+  sibling-module call, not a circular import. The call goes through the trait object, not a direct
+  module path. This pattern is already present today and is safe.
+
+- `mcp/tools/facades.rs` delegates to the other `tools/*.rs` files. This is a fan-out pattern,
+  not a cycle. `facades.rs` imports from sibling `tools/` modules; none of those siblings import
+  from `facades.rs`.
+
+- `pipeline/decomp.rs` calls `run_single_query_pipeline()` which calls `collect_vector_candidates`,
+  `collect_fts_candidates`, and `fuse_refine_and_output()` — all within `pipeline/`. No cycle.
+
+---
+
+## 6. Migration Strategy
+
+### Phase Sequence
+
+```
+Phase 1: admin.rs → admin/          (independent, easiest, 4 clean groups)
+Phase 2: mod.rs → 5 new files       (touches more code but no trait logic changes)
+Phase 3: advanced.rs → pipeline/    (requires benchmark gate — search quality sensitive)
+Phase 4: mcp_server.rs → mcp/       (independent of phases 1-3, can run in parallel)
+```
+
+### PR Boundaries
+
+Each PR must be a pure refactor: zero behavioral changes, zero test additions or removals.
+All PRs must pass `prek run` and, for phases 2-3, `./scripts/bench.sh --gate`.
+
+**PR 1: `refactor(sqlite): split admin.rs into admin/ subdir`**
+- Create `src/memory_core/storage/sqlite/admin/` directory
+- Move `impl BackupManager` → `admin/backup.rs`
+- Move `impl MaintenanceManager` → `admin/maintenance.rs`
+- Move `impl WelcomeProvider` → `admin/welcome.rs`
+- Move `impl StatsProvider` → `admin/stats.rs`
+- Replace `admin.rs` with `admin/mod.rs` re-exporting `use super::*` (so `mod.rs` declarations are unchanged)
+- Test gate: `prek run` only (admin logic is not on the search path)
+
+**PR 2: `refactor(sqlite): decompose mod.rs into storage/cache/relationships/io`**
+- Create `storage.rs` (struct + constructors + test helpers)
+- Create `cache.rs` (CachedQuery + invalidation methods + `build_stats_paths_json`)
+- Create `hot_cache_mgmt.rs` (background task methods)
+- Create `relationships.rs` (add_relationship + auto-relate methods)
+- Create `io.rs` (stats + export_all + import_all)
+- Move `RankedSemanticCandidate` to `storage.rs` (or `types.rs` if cleaner)
+- `mod.rs` becomes ~120 lines of constants, type aliases, submodule declarations, re-exports
+- Test gate: `prek run` + `./scripts/bench.sh --gate`
+
+**PR 3: `refactor(sqlite): extract search pipeline into pipeline/ subdir`**
+- Create `src/memory_core/storage/sqlite/pipeline/`
+- Move phase functions per section 3c
+- `advanced.rs` residual keeps `impl AdvancedSearcher` + tests
+- This is the highest-risk PR: touches the search scoring path directly
+- Test gate: `prek run` + `./scripts/bench.sh --gate`; if gate warns, run `--samples 10` validation
+
+**PR 4: `refactor(mcp): split mcp_server.rs into mcp/ module`**
+- Create `src/mcp/` directory
+- Apply thin-wrapper pattern for `#[tool_router]` constraint
+- Move request types, validation, protocol, tool bodies
+- Update `src/main.rs` import path from `mcp_server` to `mcp`
+- Test gate: `prek run` (MCP tools are integration-tested via `tests/mcp_smoke.rs`)
+
+PRs 1 and 4 are **fully independent** and can be done in parallel. PRs 2 and 3 depend on
+each other only in that PR 3 will be easier after PR 2 (no conflicts on `mod.rs`).
+
+### Test Gates by Phase
+
+| Phase | Gate |
+|-------|------|
+| PR 1 (admin) | `prek run` |
+| PR 2 (mod.rs) | `prek run` + `./scripts/bench.sh --gate` |
+| PR 3 (pipeline) | `prek run` + `./scripts/bench.sh --gate` + full `--samples 10` if gate warns |
+| PR 4 (mcp) | `prek run` |
+
+---
+
+## 7. What Moves vs. What Stays
+
+### What Moves (extracted from god modules)
+
+- **From `mcp_server.rs`**: All `*Request` structs, all tool function bodies, `TOOL_REGISTRY`,
+  `MCP_INSTRUCTIONS`, `generate_protocol_markdown()`, `tool_registry_json()`, `ToolMeta`,
+  `serialize_results()`, `build_memory_input()`, `require_finite()`
+- **From `sqlite/mod.rs`**: `SqliteStorage` struct, all constructors and scoring methods,
+  cache management methods, hot-cache background task, relationship operations, bulk I/O methods,
+  `RankedSemanticCandidate` struct, `build_stats_paths_json()`
+- **From `sqlite/advanced.rs`**: All 7 phase functions (Phase 1 through Phase 6),
+  `merge_hot_cache_results()`, `merge_semantic_result()`, `merge_semantic_metadata()`,
+  `run_single_query_pipeline()`
+- **From `sqlite/admin.rs`**: All four `impl` blocks (BackupManager, MaintenanceManager,
+  WelcomeProvider, StatsProvider) plus all sync helper functions
+
+### What Stays In Place (unchanged)
+
+- All existing `sqlite/` submodules: `crud.rs`, `search.rs`, `graph.rs`, `session.rs`,
+  `lifecycle.rs`, `helpers.rs`, `nlp.rs`, `query_classifier.rs`, `temporal.rs`,
+  `conn_pool.rs`, `embedding_codec.rs`, `hot_cache.rs`, `entities.rs`, `schema.rs`
+- All `memory_core/` trait definitions (`traits.rs`, `domain.rs`, `scoring.rs`)
+- `src/main.rs` (only the import path for mcp_server changes)
+- Test files in `src/memory_core/storage/sqlite/tests/` (unchanged)
+- `tests/mcp_smoke.rs` (unchanged)
+- All benchmark code under `benches/`
+
+### Visibility Changes Required
+
+Functions currently private to `sqlite/mod.rs` that are called by submodules will need
+`pub(super)` or `pub(crate)` visibility when moved:
+
+- `invalidate_query_cache()` and `invalidate_cache_selective()` — already `pub(super)`;
+  move to `cache.rs`, visibility unchanged
+- `refresh_hot_cache()`, `refresh_hot_cache_best_effort()`, `ensure_hot_cache_ready()` —
+  already `pub(super)`; move to `hot_cache_mgmt.rs`, re-export via `mod.rs`
+- `try_auto_relate()`, `try_create_temporal_edges()`, `try_create_entity_edges()` — private;
+  called only from `crud.rs` (via `impl Storage`); need `pub(super)` in `relationships.rs`
+
+---
+
+## 8. Build Sequence Checklist
+
+Use this checklist for each PR. Run items in order; stop and fix before proceeding.
+
+### Pre-work (all phases)
+- [ ] Confirm working on a fresh branch from current `main`
+- [ ] Run `prek run` baseline — must pass clean before any changes
+
+### Phase 1 — admin/
+- [ ] Create `src/memory_core/storage/sqlite/admin/` directory
+- [ ] Create `admin/backup.rs` — copy BackupManager impl + sync helpers
+- [ ] Create `admin/maintenance.rs` — copy MaintenanceManager impl + `estimate_tokens`
+- [ ] Create `admin/welcome.rs` — copy WelcomeProvider impl
+- [ ] Create `admin/stats.rs` — copy StatsProvider impl
+- [ ] Create `admin/mod.rs` — constants + `mod backup; mod maintenance; mod welcome; mod stats;` + re-exports
+- [ ] Replace `admin.rs` with `admin/mod.rs` (jj tracks this as a delete + creates)
+- [ ] Update `sqlite/mod.rs` `mod admin;` declaration (unchanged if `mod.rs` approach used)
+- [ ] `cargo build --all-features` — must compile
+- [ ] `prek run` — must pass
+- [ ] Submit PR
+
+### Phase 2 — mod.rs decomposition
+- [ ] Create `sqlite/storage.rs` — SqliteStorage struct + all constructors + test helpers
+- [ ] Create `sqlite/cache.rs` — CachedQuery, QueryCache, cache methods, build_stats_paths_json
+- [ ] Create `sqlite/hot_cache_mgmt.rs` — four hot-cache methods
+- [ ] Create `sqlite/relationships.rs` — relationship methods
+- [ ] Create `sqlite/io.rs` — stats, export_all, import_all
+- [ ] Move `RankedSemanticCandidate` to `storage.rs` — update import in `advanced.rs`
+- [ ] Rewrite `sqlite/mod.rs` as ~120 line shell with submodule decls + re-exports
+- [ ] Verify all `pub(super)` visibility is correct for cross-submodule calls
+- [ ] `cargo build --all-features` — must compile
+- [ ] `prek run` — must pass
+- [ ] `./scripts/bench.sh --gate` — must pass (warn < 2pp, fail < 5pp delta)
+- [ ] Submit PR
+
+### Phase 3 — pipeline/ extraction (benchmark-gated)
+- [ ] Create `src/memory_core/storage/sqlite/pipeline/` directory
+- [ ] Create `pipeline/retrieval.rs` — Phase 1 + Phase 2 functions
+- [ ] Create `pipeline/rerank.rs` — cross-encoder function
+- [ ] Create `pipeline/fusion.rs` — RRF block from fuse_refine_and_output
+- [ ] Create `pipeline/scoring.rs` — refine_scores
+- [ ] Create `pipeline/enrichment.rs` — enrich_graph_neighbors + expand_entity_tags
+- [ ] Create `pipeline/abstention.rs` — abstention/dedup block + merge helpers
+- [ ] Create `pipeline/decomp.rs` — run_single_query_pipeline + query decomp logic
+- [ ] Create `pipeline/mod.rs` — constants + re-exports
+- [ ] Rewrite `advanced.rs` as residual — `impl AdvancedSearcher` calling pipeline functions
+- [ ] Add `mod pipeline;` to `sqlite/mod.rs`
+- [ ] `cargo build --all-features` — must compile
+- [ ] `cargo build --no-default-features` — verify no missing cfg gates
+- [ ] `prek run` — must pass
+- [ ] `./scripts/bench.sh --gate` — must pass
+- [ ] If bench gate warns: `./scripts/bench.sh --samples 10 --notes "pre-merge pipeline refactor"` — must pass
+- [ ] Submit PR
+
+### Phase 4 — mcp/ extraction (independent)
+- [ ] Create `src/mcp/` directory and `src/mcp/tools/` directory
+- [ ] Create `mcp/request_types.rs` — all Request structs
+- [ ] Create `mcp/validation.rs` — constants + validation functions
+- [ ] Create `mcp/protocol.rs` — TOOL_REGISTRY + protocol functions
+- [ ] Create `mcp/tools/storage.rs` — storage tool impl functions
+- [ ] Create `mcp/tools/search.rs` — search/list tool impl functions
+- [ ] Create `mcp/tools/relations.rs` — relations tool impl function
+- [ ] Create `mcp/tools/lifecycle.rs` — feedback/lifecycle tool impl functions
+- [ ] Create `mcp/tools/session.rs` — checkpoint/remind/lessons/profile/session_info impl functions
+- [ ] Create `mcp/tools/facades.rs` — unified facade impl functions
+- [ ] Rewrite `mcp/mod.rs` — McpMemoryServer, thin `#[tool_router]` wrappers, ServerHandler impl
+- [ ] Update `src/lib.rs` or `src/main.rs` — change `mod mcp_server;` to `mod mcp;`
+- [ ] `cargo build --all-features` — must compile
+- [ ] `prek run` — must pass
+- [ ] Run `tests/mcp_smoke.rs` explicitly: `cargo test --all-features mcp_smoke`
+- [ ] Submit PR
+
+---
+
+## 9. Key Invariants to Preserve
+
+1. **`#[tool_router]` constraint**: The proc-macro requires a single `impl McpMemoryServer` block
+   containing all `#[tool(...)]` methods. Thin wrappers of 1-3 lines satisfy this while keeping
+   actual logic in `tools/*.rs`.
+
+2. **Benchmark regression gate**: Any change to `advanced.rs` or its pipeline dependencies must
+   pass `./scripts/bench.sh --gate`. The LoCoMo-10 baseline is 90.1% (word-overlap scoring).
+   A >5pp drop fails the gate; 2-5pp triggers a full 10-sample validation run.
+
+3. **No behavioral changes**: Each PR must be a pure mechanical refactor. No logic changes,
+   parameter renames, or algorithm tweaks. Verify with `git diff` showing only file movements.
+
+4. **`spawn_blocking` pattern**: All SQLite I/O must remain wrapped in `tokio::task::spawn_blocking`.
+   Moving functions between files does not change this requirement.
+
+5. **`pub(super)` visibility**: Functions crossing the new module boundaries need explicit
+   `pub(super)` or `pub(crate)`. Audit each moved function for callers in sibling modules.
+
+6. **Feature flag guards**: `#[cfg(feature = "real-embeddings")]` and `#[cfg(feature = "sqlite-vec")]`
+   gates must be preserved exactly as-is on moved code. Test with `--no-default-features`.

--- a/docs/specs/testing-skill.md
+++ b/docs/specs/testing-skill.md
@@ -1,0 +1,643 @@
+# MAG Dev Plugin Testing Skill — Specification
+
+**File:** `docs/specs/testing-skill.md`
+**Status:** Draft v1.0 — 2026-04-14
+**Scope:** `plugin/dev/skills/mag-test.md` and all supporting files under `plugin/dev/`
+
+---
+
+## 1. Overview
+
+### What
+
+A Claude Code skill (`plugin/dev/skills/mag-test.md`) that orchestrates five test modes against the MAG dev plugin: quick smoke checks, the full TAP hook suite, scenario-based recall quality tests, a longitudinal regression suite, and an interactive tmux environment for exploratory testing.
+
+### Why
+
+The TAP suite (`tests/hooks/`) validates hook wiring — that events fire and JSONL fields are correct. It cannot validate recall quality: whether MAG surfaces the right memories in the right context. Only real Claude Code sessions with controlled memory databases can answer that. The testing skill closes this gap by running actual `claude` processes against known DB states and asserting on what Claude says back.
+
+The secondary benefit is accumulation. Each scenario run adds a timestamped data point. Over weeks of development this becomes a real-world regression suite that no synthetic dataset can replicate. Continuous scoring metrics (true benchmark mode with quantitative recall/precision tracking) are planned for v2.
+
+### Scope boundary
+
+This skill does not replace the TAP suite. It augments it. The TAP suite remains the authoritative gate for hook correctness. The testing skill is for recall quality, regression detection, and interactive exploration.
+
+---
+
+## 2. Architecture
+
+### Components
+
+```
+plugin/dev/
+  skills/
+    mag-test.md               <- the skill (this spec)
+    mag-dev-status.md         <- existing status skill (unchanged)
+  fixtures/
+    README.md                 <- fixture inventory and privacy policy
+    seeded/
+      basic-recall.json       <- 5 generic memories, tests baseline recall
+      project-context.json    <- project-specific memories, tests project isolation
+      multi-session.json      <- memories from 3 synthetic sessions
+  scenarios/
+    s01-basic-recall.yaml
+    s02-project-isolation.yaml
+    s03-error-pattern.yaml
+    s04-commit-context.yaml
+  logs/
+    test-runs.jsonl           <- one line per run: timestamp, mode, pass/fail, scores
+    discoveries.md            <- human-written learning log
+    decisions.md              <- decisions made based on test outcomes
+  run-scenario.sh             <- executes one scenario, writes result line
+  run-benchmark.sh            <- executes all scenarios, aggregates scores
+tests/hooks/
+  helpers/common.sh           <- existing (unchanged)
+  helpers/plugin-install.sh   <- existing (unchanged)
+  t01-t06.sh                  <- existing (unchanged)
+```
+
+### Data flow for scenario mode
+
+```
+Scenario YAML
+  -> run-scenario.sh reads prompt, fixture_name, assertions
+  -> loads fixture into ~/.dev-mag/memory.db via mag import
+  -> invokes claude -p <prompt> --model <model>
+  -> captures stdout (Claude's response) + new JSONL lines
+  -> evaluates assertions (substring / JSONL field / memory count)
+  -> appends one result line to plugin/dev/logs/test-runs.jsonl
+  -> prints PASS/FAIL with details
+```
+
+### Live plugin isolation
+
+**Decision:** Use `CLAUDE_CODE_HOME` env var for full isolation. `disabledPlugins` is NOT a real Claude Code setting. Instead, `CLAUDE_CODE_HOME` points Claude Code at a completely separate environment with no plugins loaded except what is explicitly configured there.
+
+The test-env.sh invocation becomes:
+
+```sh
+CLAUDE_CODE_HOME=/tmp/mag-test-claude claude -p "..." --model haiku
+```
+
+`test-env.sh` creates `/tmp/mag-test-claude/settings.json` with only the dev plugin path:
+
+```json
+{
+  "plugins": [{"path": "<plugin/dev absolute path>"}]
+}
+```
+
+This guarantees the live (marketplace-installed) MAG plugin does not fire — the isolated `CLAUDE_CODE_HOME` has no knowledge of it.
+
+**Alternative approach:** `claude plugin disable mag --scope project` in the test repo. This modifies the project-level settings to disable the production plugin. Less clean than `CLAUDE_CODE_HOME` because it mutates the test repo's settings and does not isolate other user-level configuration.
+
+The TAP suite uses `plugin-install.sh` which writes raw hook paths into `settings.json` and never activates the named plugin at all, so the TAP suite is already isolated by construction.
+
+---
+
+## 3. Test Modes
+
+### 3.1 smoke
+
+**Purpose:** Confirm the dev plugin is wired up and session-start fires. Takes ~5 seconds. Zero configuration required.
+
+**What it does:**
+1. Pre-flight: verifies `/tmp/mag-test-repo` exists with `settings.local.json` (exits with instructions to run `test-env.sh` if missing).
+2. Verifies `~/.dev-mag/bin/mag` exists.
+3. Runs `CLAUDE_CODE_HOME=/tmp/mag-test-claude claude -p "Echo HELLO" --model haiku --max-turns 1 --dangerously-skip-permissions` from the test repo directory.
+4. Checks `~/.dev-mag/auto-capture.jsonl` for a `hook.session_start` event in the last 20 lines. The `tail -20` approach is intentionally loose for smoke mode -- it confirms hook wiring, not event attribution.
+5. Prints PASS with event timestamp, or FAIL with the last 5 JSONL lines.
+
+**Model:** Haiku (cheapest; hook validation only).
+
+**Does not require:** tmux, fixtures, scenarios.
+
+### 3.2 hooks
+
+**Purpose:** Run the full TAP suite against the dev plugin. This is a wrapper around the existing `plugin/dev/run-tests.sh`.
+
+**What it does:**
+1. Calls `plugin/dev/run-tests.sh` with `--model haiku`.
+2. Captures the TAP output and exit code.
+3. Reports pass/fail counts to the user.
+
+**Model:** Haiku.
+
+**Accepts optional flags:**
+- `--filter <glob>` — passed through to `run-tests.sh`.
+- `--model <name>` — overrides Haiku for specific tests.
+
+### 3.3 scenario
+
+**Purpose:** Run a specific prompt against a controlled DB, assert recall quality.
+
+**Arguments:** `--scenario <name>` (e.g. `s01-basic-recall`). Required.
+
+**What it does:**
+1. Reads `plugin/dev/scenarios/<name>.yaml`.
+2. Loads the named fixture into `~/.dev-mag/memory.db` (via `run-scenario.sh`).
+3. Runs `claude -p <prompt>` from the test repo.
+4. Evaluates assertions.
+5. Writes one line to `plugin/dev/logs/test-runs.jsonl`.
+6. Prints PASS/FAIL.
+
+**Model:** Configurable per scenario (default: Haiku). Use Sonnet only when the scenario explicitly requires semantic nuance (see Section 7).
+
+### 3.4 benchmark (regression suite)
+
+**Purpose:** Run all scenarios, score each, produce a summary table, track regressions over time. In v1 this is a pass/fail regression suite, not a continuous scoring benchmark. Quantitative recall/precision metrics are planned for v2.
+
+**What it does:**
+1. Iterates over all `plugin/dev/scenarios/*.yaml` in filename order.
+2. Runs each via `run-scenario.sh`.
+3. Aggregates pass/fail and per-scenario scores (binary 0.0/1.0 in v1).
+4. Prints a summary table.
+5. Appends a single summary line (with `"line_type": "benchmark_summary"`) to `plugin/dev/logs/test-runs.jsonl`.
+
+**Model:** Per-scenario from YAML; defaults to Haiku.
+
+**Run cadence:** Manual. Run before and after significant algorithm changes. Do not run in CI (cost, latency).
+
+### 3.5 interactive
+
+**Purpose:** Set up a tmux environment for manual exploratory testing. Leaves the user in a live Claude session with dev plugin active and telemetry visible in a split pane.
+
+**What it does:**
+1. Runs `plugin/dev/test-env.sh --no-build` to ensure the test repo exists.
+2. Creates (or re-uses) the `mag-test` tmux session with the two-pane layout.
+3. Prints the attach command.
+
+**Does not start Claude automatically** — the user attaches and types `claude` themselves. This avoids the tool controlling an interactive session.
+
+---
+
+## 4. DB Fixture System
+
+### Storage location
+
+**Decision: in-repo at `plugin/dev/fixtures/seeded/`.**
+
+Rationale: Version-controlled fixtures enable reproducible scenario runs across machines and contributors. The fixtures are synthetic (not cloned from a real user's DB), so there is no privacy concern. The `plugin/dev/fixtures/README.md` enforces this: it explicitly states that fixtures must not contain real user data.
+
+The `--clone` workflow (copying `~/.mag/memory.db` to `~/.dev-mag/memory.db`) remains available for personal regression testing but produces no committed artifacts.
+
+### Fixture format
+
+Fixtures are JSON files produced by `mag export` and consumed by `mag import`. The schema is whatever `export_all()` emits from `src/memory_core/storage/sqlite/mod.rs`. No wrapper format is added.
+
+### Fixture creation workflow
+
+```sh
+# Seed memories manually
+# IMPORTANT: --project must match basename of the test repo CWD (/tmp/mag-test-repo).
+# MAG uses exact-match project filtering (WHERE project = ?), not fuzzy/boost.
+# Memories stored with --project test will NOT surface when querying with --project mag-test-repo.
+MAG_DATA_ROOT=~/.dev-mag mag process "George prefers concise answers" \
+  --event-type preference --project mag-test-repo --importance 0.8
+
+# Export to a named fixture
+MAG_DATA_ROOT=~/.dev-mag mag export > plugin/dev/fixtures/seeded/basic-recall.json
+```
+
+### Fixture loading in run-scenario.sh
+
+```sh
+# Reset dev DB to a known state
+rm -f ~/.dev-mag/memory.db
+MAG_DATA_ROOT=~/.dev-mag mag import plugin/dev/fixtures/seeded/<fixture>.json
+```
+
+The DB is wiped before import to guarantee deterministic state. The `~/.dev-mag/auto-capture.jsonl` is NOT wiped between scenario runs — the JSONL mark pattern from `common.sh` (snapshot line count before, tail from mark after) handles isolation.
+
+### Fixture inventory
+
+| File | Contents | Used by |
+|---|---|---|
+| `basic-recall.json` | 5 generic preference/fact memories | s01 |
+| `project-context.json` | 8 memories tagged to project "alpha" | s02 |
+| `multi-session.json` | 15 memories across 3 session-ids | s03, s04 |
+
+---
+
+## 5. tmux Automation
+
+### Session layout
+
+```
+Session: mag-test
+Window 0: mag-test
+  Pane 0 (left, 75%):  cd /tmp/mag-test-repo && $SHELL
+  Pane 1 (right, 25%): tail -f ~/.dev-mag/auto-capture.jsonl | jq -r '[.ts,.event,.hook.status] | @tsv'
+```
+
+### Creation command (illustrative -- implementation calls `test-env.sh`)
+
+```sh
+tmux new-session -d -s mag-test -x 220 -y 50 \; \
+  send-keys "cd /tmp/mag-test-repo" Enter \; \
+  split-window -h -p 25 \; \
+  send-keys "tail -f $HOME/.dev-mag/auto-capture.jsonl | jq -r '[.ts,.event,.hook.status] | @tsv'" Enter \; \
+  select-pane -t 0
+```
+
+This is illustrative only. The skill invokes `test-env.sh --no-build` which handles session creation internally.
+
+### Sandbox note
+
+tmux commands require access to the Unix socket at `/private/tmp/tmux-$(id -u)/default`. Claude Code's sandbox blocks this by default. `run-scenario.sh` and `test-env.sh` must either:
+- Run outside the Claude Code sandbox (with `dangerouslyDisableSandbox: true`), or
+- The user must add the tmux socket path (`/private/tmp/tmux-*/`) to the sandbox filesystem allowlist.
+
+### Automated session control (scenario/benchmark modes)
+
+Scenario and benchmark modes do NOT use tmux for the `claude -p` invocations. They run `claude -p` as a subprocess directly (same as the TAP suite). tmux is only for `interactive` mode.
+
+For future multi-turn testing (compaction, session continuity), the pattern is:
+
+```sh
+# Send a prompt to the Claude session running in pane 0
+tmux send-keys -t mag-test:0.0 "your prompt here" Enter
+
+# Wait for prompt to return (naive: sleep; robust: poll for the shell prompt)
+sleep 5
+
+# Capture pane output
+tmux capture-pane -t mag-test:0.0 -p -S -50
+```
+
+This is documented in KNOWN_GAPS.md territory and is not implemented in the initial skill. The `interactive` mode leaves it to the user. A `multi-turn` scenario type is reserved for a future iteration.
+
+### cmux note
+
+`cmux send`/`read-screen` does not work cross-workspace. The skill uses raw `tmux` commands throughout, even when `cmux` is available on PATH. `test-env.sh` already handles the cmux/tmux fallback for session creation — the skill re-uses that script rather than duplicating the logic.
+
+---
+
+## 6. Scenario Format
+
+Scenarios are YAML files. YAML was chosen over TOML for readability (multi-line strings are natural) and over shell scripts for parseability (no eval surface).
+
+### Schema
+
+```yaml
+# plugin/dev/scenarios/s01-basic-recall.yaml
+id: s01-basic-recall
+description: "Verify that a simple preference memory surfaces in a recall query"
+fixture: basic-recall          # filename without extension under fixtures/seeded/
+model: haiku                   # haiku | sonnet | opus (default: haiku)
+prompt: |
+  What do you know about my preferences?
+  List any facts or preferences you have stored about me.
+assertions:
+  - type: response_contains
+    value: "concise"           # Claude's response must contain this substring
+  - type: event_fired
+    event: hook.session_start  # JSONL event must appear since test start
+  # memory_recalled is not yet supported — see Section 7 and Q7.
+  # The JSONL `memory` field is always null in the current session-start.sh.
+  # This assertion type will be added when session-start.sh is patched to
+  # capture `mag welcome` output into the JSONL memory field.
+timeout_seconds: 30
+notes: "Baseline recall test. If this fails, recall pipeline is broken."
+```
+
+### Assertion types
+
+| Type | Parameters | Evaluation method |
+|---|---|---|
+| `response_contains` | `value: string` | Case-insensitive substring match in `claude -p` stdout |
+| `response_not_contains` | `value: string` | Inverse substring match |
+| `event_fired` | `event: string` | JSONL new lines contain at least one object with `.event == value` |
+| `jsonl_field` | `event`, `path`, `expected` | `get_event \| jq -r path == expected` |
+| `memory_stored` | `min_count: int` | Memory count delta >= min_count (uses the same pattern as `assert_memory_stored` in common.sh) |
+
+**Note:** `memory_recalled` is **not available in v1**. The `memory` field in the `hook.session_start` JSONL event is hardcoded to `null` in `session-start.sh`. The `mag welcome` output goes to stdout as `additionalContext` for Claude but is never captured in JSONL. This assertion type will be added after `session-start.sh` is patched to capture `mag welcome` output into the JSONL `memory` field (see Phase 0 in Section 10 and Q7).
+
+### Parsing
+
+`run-scenario.sh` parses YAML with shell tools. The schema is intentionally flat to keep parsing tractable without a real YAML library.
+
+**Approach — shell-native (no external dependency):**
+- Simple key-value fields: `grep '^key:' file | sed 's/^key: *//'`
+- Multi-line `prompt: |` block scalar: `awk` to read from `^prompt: \|` until the next non-indented key
+- Assertion blocks: iterate by scanning for `- type:` delimiters, extracting subsequent indented key-value pairs
+
+**Alternative — python3 (simpler, recommended if complexity grows):**
+```sh
+eval "$(python3 -c "
+import yaml, json, sys
+d = yaml.safe_load(open(sys.argv[1]))
+print(f'SCENARIO_ID={d[\"id\"]}')
+print(f'FIXTURE={d[\"fixture\"]}')
+print(f'MODEL={d.get(\"model\",\"haiku\")}')
+print(f'PROMPT={json.dumps(d[\"prompt\"])}')
+print(f'ASSERTIONS={json.dumps(d[\"assertions\"])}')
+" "$scenario_file")"
+```
+Python 3 with PyYAML is available on macOS and Linux. This avoids the awk complexity for multi-line block scalars entirely. The tradeoff is a runtime dependency on `python3` and `PyYAML` (present in most environments but not guaranteed).
+
+---
+
+## 7. Assertion System
+
+### response_contains (and response_not_contains)
+
+`claude -p` stdout is captured to a temp file. The assertion does a case-insensitive grep. This is intentionally loose — the goal is "did the memory surface in Claude's answer" not "did Claude say the exact string." If a scenario requires strict matching, use `response_contains` with a distinctive phrase that only appears in the seeded memory.
+
+### event_fired
+
+Uses the JSONL mark pattern from `common.sh`: snapshot `wc -l $JSONL_LOG` before running `claude -p`, then `tail -n +$(mark+1)` after. Filter with `jq 'select(.event == "...")'`. This is identical to `assert_event_fired` in the TAP suite.
+
+### memory_recalled (NOT AVAILABLE IN v1)
+
+The `memory` field in the `hook.session_start` JSONL event is **always `null`** — it is hardcoded in `session-start.sh`. The `mag welcome` output goes to stdout (as `additionalContext` for Claude) but is never captured in JSONL. Therefore `memory_recalled` assertions cannot be evaluated against the JSONL log.
+
+**Fix path:** Patch `session-start.sh` to capture `mag welcome` stdout into a variable and write it into the JSONL `memory` field. This is tracked as a Phase 0 prerequisite in Section 10. Once patched, `memory_recalled` becomes: `jq '.memory != null'` on the session-start event, with `min_count` evaluated against a `memory.count` or array length field.
+
+### Model selection per test mode
+
+| Mode | Default model | Override |
+|---|---|---|
+| smoke | haiku | none |
+| hooks | haiku | `--model` flag |
+| scenario | per-scenario YAML field | `--model` flag overrides YAML |
+| benchmark | per-scenario YAML field | `--model` flag overrides all scenarios |
+| interactive | user chooses | n/a |
+
+Use Sonnet only when a scenario's `description` indicates semantic nuance is required (e.g., paraphrase matching, multi-hop reasoning). The default of Haiku for all hook-wiring assertions is non-negotiable — Haiku costs ~20x less and hook correctness does not require intelligence.
+
+---
+
+## 8. Logging
+
+All logs are in-repo under `plugin/dev/logs/`. This directory is committed but JSONL contents are gitignored via `plugin/dev/logs/.gitignore` containing `*.jsonl`. The markdown logs (`discoveries.md`, `decisions.md`) are committed.
+
+### test-runs.jsonl
+
+One JSONL line per scenario execution (and one summary line per benchmark run). Appended, never overwritten.
+
+```json
+{"ts":"2026-04-14T10:00:00Z","line_type":"scenario","run_id":"r1","mode":"scenario","scenario":"s01-basic-recall","fixture":"basic-recall","model":"haiku","result":"pass","score":1.0,"assertions":[{"type":"response_contains","value":"concise","result":"pass"}],"duration_ms":4200,"mag_version":"0.1.9-dev"}
+```
+
+For a regression suite run, an additional summary line:
+
+```json
+{"ts":"2026-04-14T10:01:00Z","line_type":"benchmark_summary","run_id":"r1","mode":"benchmark","scenarios_run":4,"passed":3,"failed":1,"score":0.75,"duration_ms":18000,"mag_version":"0.1.9-dev"}
+```
+
+The `line_type` field discriminates between per-scenario results and aggregate summaries. The `score` field is 0.0-1.0; in v1 it is binary (1.0 = all assertions pass, 0.0 = any failure). Continuous scoring (partial credit, recall precision metrics) is planned for v2.
+
+`mag_version` is captured from `~/.dev-mag/bin/mag --version` at the start of each run.
+
+### discoveries.md
+
+Human-written. Format: dated entries, free prose. Example:
+
+```
+## 2026-04-14
+Ran s02 for the first time. The project-context fixture revealed that recall
+correctly scopes to the active project but leaks one memory tagged "global".
+Filed as a candidate for investigation.
+```
+
+### decisions.md
+
+Human-written. Format: dated decision records. Example:
+
+```
+## 2026-04-14 — Use Haiku for all hook assertions
+Cost: ~$0.002 per TAP run. Sonnet would be ~$0.04.
+Hook correctness is binary and does not require model intelligence.
+Decision: Haiku for hooks, Sonnet optional per-scenario for recall quality.
+```
+
+### TAP logs (existing)
+
+`run-tests.sh` already writes TAP logs to `~/.dev-mag/test-results-<timestamp>.tap`. These remain outside the repo (ephemeral). The skill does not change this.
+
+---
+
+## 9. Skill Interface
+
+The skill lives at `/Users/george/repos/mag/plugin/dev/skills/mag-test.md`.
+
+### Trigger phrases
+
+- "run mag tests"
+- "run smoke test"
+- "test the dev plugin"
+- "run scenario <name>"
+- "run benchmark"
+- "set up interactive testing"
+- "show test results"
+
+### Invocation patterns
+
+The skill is a Claude Code skill — it provides instructions that guide the assistant to run specific shell commands. It does not execute autonomously; it tells Claude Code what to run and what to check.
+
+### Argument parsing by Claude Code
+
+The user's natural language maps to a mode. Claude Code parses intent:
+
+| User says | Mode | Key parameters |
+|---|---|---|
+| "run smoke test" | smoke | none |
+| "run hook tests" or "run tap suite" | hooks | optional `--filter`, `--model` |
+| "run scenario s01" | scenario | `--scenario s01-basic-recall` |
+| "run all scenarios" or "run benchmark" | benchmark | optional `--model` |
+| "set up interactive" or "open test env" | interactive | none |
+| "show test results" or "what did the last run show" | results | reads `logs/test-runs.jsonl` |
+
+### Step-by-step instructions per mode (what the skill tells Claude Code to do)
+
+**smoke:**
+```sh
+# 0. Pre-flight: ensure test environment exists
+[ -d /tmp/mag-test-repo ] && [ -f /tmp/mag-test-repo/.claude/settings.local.json ] || {
+  echo "MISSING: run plugin/dev/test-env.sh first"; exit 1
+}
+
+# 1. Pre-flight: ensure dev mag binary exists
+ls ~/.dev-mag/bin/mag || echo "MISSING: run setup.sh --build"
+
+# 2. Run claude from test repo (isolated via CLAUDE_CODE_HOME)
+cd /tmp/mag-test-repo && \
+  CLAUDE_CODE_HOME=/tmp/mag-test-claude \
+  claude -p "Echo HELLO" \
+    --model haiku \
+    --max-turns 1 \
+    --dangerously-skip-permissions \
+    2>/dev/null
+
+# 3. Check JSONL
+# NOTE: The tail -20 approach is intentionally loose for smoke mode —
+# it confirms hook wiring, not event attribution. A session-start event
+# anywhere in the last 20 lines is sufficient to prove the dev plugin fired.
+tail -20 ~/.dev-mag/auto-capture.jsonl | \
+  jq -c 'select(.event == "hook.session_start")' | tail -1
+```
+Report: event present = PASS, absent = FAIL with last 5 raw lines.
+
+**hooks:**
+```sh
+cd /path/to/repo && \
+  sh plugin/dev/run-tests.sh [--filter <f>] [--model <m>]
+```
+Report: TAP summary line.
+
+**scenario:**
+```sh
+sh plugin/dev/run-scenario.sh --scenario <name> [--model <m>]
+```
+Report: PASS/FAIL per assertion, duration, result line written to logs.
+
+**benchmark:**
+```sh
+sh plugin/dev/run-benchmark.sh [--model <m>]
+```
+Report: summary table of all scenarios with scores.
+
+**interactive:**
+```sh
+sh plugin/dev/test-env.sh --no-build
+tmux attach -t mag-test
+```
+
+**results:**
+```sh
+tail -20 plugin/dev/logs/test-runs.jsonl | \
+  jq -r '[.ts, .mode, .scenario // "all", .result // "\(.passed)/\(.scenarios_run)"] | @tsv'
+```
+
+---
+
+## 10. Implementation Plan
+
+### Phase 0 — Hook schema prerequisite
+
+- [ ] Patch `plugin/dev/hooks/session-start.sh` to capture `mag welcome` stdout into a variable and write it into the JSONL `memory` field (currently hardcoded to `null`). This is a prerequisite for `memory_recalled` assertions. Without this patch, recall quality can only be asserted via `response_contains` (checking Claude's output for recalled content).
+
+### Phase 1 — Foundation (prerequisite for all other phases)
+
+- [ ] Create `plugin/dev/logs/` directory with `plugin/dev/logs/.gitignore` containing `*.jsonl`.
+- [ ] Create `plugin/dev/logs/discoveries.md` and `plugin/dev/logs/decisions.md` (empty dated stubs).
+- [ ] Create `plugin/dev/fixtures/seeded/` directory and `plugin/dev/fixtures/README.md`.
+- [ ] Patch `plugin/dev/test-env.sh`: use `CLAUDE_CODE_HOME=/tmp/mag-test-claude` for plugin isolation. Create `/tmp/mag-test-claude/settings.json` with only the dev plugin path. Remove any `disabledPlugins` references (not a real Claude Code setting).
+- [ ] Seed and export the three initial fixtures (`basic-recall.json`, `project-context.json`, `multi-session.json`) using the dev plugin manually, then commit. Use `--project mag-test-repo` (matching `basename` of `/tmp/mag-test-repo`) for all fixture memories.
+
+### Phase 2 — run-scenario.sh
+
+- [ ] Write `plugin/dev/run-scenario.sh`. Responsibilities:
+  - Parse a scenario YAML file (grep/sed/awk for simple fields, awk for multi-line block scalars; or python3+PyYAML if available — see Section 6).
+  - Accept `--scenario <name>` and optional `--model <name>`.
+  - Reset `~/.dev-mag/memory.db` and load the named fixture via `mag import`.
+  - Snapshot JSONL line count (JSONL mark pattern).
+  - Run `claude -p <prompt>` from `/tmp/mag-test-repo`, capture stdout to tempfile.
+  - Evaluate each assertion.
+  - Append one result line to `plugin/dev/logs/test-runs.jsonl`.
+  - Exit 0 on all-pass, exit 1 on any failure.
+- [ ] Write the four initial scenario YAML files (`s01` through `s04`).
+- [ ] Smoke-test `run-scenario.sh` against `s01-basic-recall` manually.
+
+### Phase 3 — run-benchmark.sh
+
+- [ ] Write `plugin/dev/run-benchmark.sh`. Responsibilities:
+  - Iterate all `plugin/dev/scenarios/*.yaml`.
+  - Call `run-scenario.sh` for each.
+  - Aggregate pass/fail counts and per-scenario durations.
+  - Print a summary table.
+  - Append one benchmark-run summary line to `test-runs.jsonl`.
+- [ ] Run the benchmark once to establish a baseline result line in the log.
+
+### Phase 4 — Skill file
+
+- [ ] Write `plugin/dev/skills/mag-test.md` with all five modes, step-by-step instructions, and the invocation table from Section 9.
+
+### Phase 5 — Validation
+
+- [ ] Run smoke mode: confirm PASS.
+- [ ] Run hooks mode: confirm all 6 TAP tests pass (or skip with known reason).
+- [ ] Run benchmark mode: confirm all 4 scenarios produce result lines in `test-runs.jsonl`.
+- [ ] Run interactive mode: confirm tmux session created, telemetry tail visible.
+- [ ] Verify `plugin/dev/logs/.gitignore` contains `*.jsonl` (created in Phase 1).
+
+---
+
+## 11. Open Questions
+
+### Q1 — live plugin isolation (RESOLVED -- VERIFIED)
+
+**Resolution:** `disabledPlugins` is NOT a real Claude Code setting. Verified approach: use `CLAUDE_CODE_HOME=/tmp/mag-test-claude` to create a fully isolated Claude Code environment. This env has its own `settings.json` with only the dev plugin path configured. The live (marketplace-installed) MAG plugin is invisible to the isolated environment.
+
+Alternative verified approach: `claude plugin disable mag --scope project` in the test repo. Less clean because it mutates the test repo's settings.
+
+The TAP suite is already isolated via `plugin-install.sh` and does not need this change.
+
+### Q2 — Fixture privacy (RESOLVED)
+
+**Resolution:** Only synthetic fixtures live in-repo. The `--clone` workflow produces no committed artifacts. `plugin/dev/fixtures/README.md` states this explicitly. A `.gitignore` entry in `plugin/dev/fixtures/` ignores `*.db` to prevent accidental DB commits.
+
+### Q3 — Scenario format (RESOLVED)
+
+**Resolution:** YAML with grep/awk parsing. No external dependency. Schema is intentionally flat. See Section 6.
+
+### Q4 — Skill orchestration model (RESOLVED)
+
+**Resolution:** Semi-automated. The skill provides step-by-step shell commands for Claude Code to execute. It does not drive tmux for `scenario`/`benchmark` modes — those run `claude -p` as a direct subprocess. tmux is only for `interactive` mode setup. This avoids cross-workspace cmux issues entirely.
+
+### Q5 — Multi-turn testing (DEFERRED)
+
+**Status:** Documented in KNOWN_GAPS.md territory. Not in scope for initial implementation. The `interactive` mode leaves multi-turn testing to the user. A `multi-turn` scenario type that uses `tmux send-keys` + `tmux capture-pane` is reserved for a future iteration after the basic scenario/benchmark infrastructure is validated.
+
+**Trigger for deferral:** PreCompact/PostCompact hooks require a context-filling conversation. This is only testable interactively or with a very long synthetic prompt. Neither approach is clean enough to automate in the first iteration.
+
+### Q6 — Cost control (RESOLVED)
+
+**Resolution:** Haiku for all hook/wiring assertions (smoke, hooks, any scenario not explicitly requiring Sonnet). Sonnet is opt-in per-scenario via the `model:` YAML field. The `--model` CLI flag overrides everything. The skill notes in its documentation that benchmark runs with all-Sonnet cost approximately $0.05-0.10 per full run (4 scenarios x ~5 turns each).
+
+### Q7 — Recall assertion for memory_recalled (VERIFIED BROKEN -- FIX PLANNED)
+
+**Verified finding:** The `memory` field in `hook.session_start` JSONL events is **always `null`** — it is hardcoded in `session-start.sh`. The `mag welcome` output goes to stdout (as `additionalContext` for Claude) but is never captured in the JSONL event.
+
+**Fix path:** Phase 0 in Section 10 adds a prerequisite: patch `session-start.sh` to capture `mag welcome` stdout into a variable and write it into the JSONL `memory` field. Once patched, the `memory_recalled` assertion type can be re-added to the assertion types table (Section 6) with evaluation via `jq '.memory != null'` and optional `min_count` against an array length or count field.
+
+**Current workaround:** Use `response_contains` assertions to verify recall quality indirectly — if Claude's response includes content from the seeded memories, recall is working. This is less precise but sufficient for v1.
+
+---
+
+## Appendix A — File Paths Reference
+
+| Path | Description |
+|---|---|
+| `plugin/dev/skills/mag-test.md` | The skill file (new) |
+| `plugin/dev/run-scenario.sh` | Scenario executor (new) |
+| `plugin/dev/run-benchmark.sh` | Benchmark runner (new) |
+| `plugin/dev/fixtures/seeded/basic-recall.json` | Fixture (new) |
+| `plugin/dev/fixtures/seeded/project-context.json` | Fixture (new) |
+| `plugin/dev/fixtures/seeded/multi-session.json` | Fixture (new) |
+| `plugin/dev/fixtures/README.md` | Fixture policy (new) |
+| `plugin/dev/scenarios/s01-basic-recall.yaml` | Scenario (new) |
+| `plugin/dev/scenarios/s02-project-isolation.yaml` | Scenario (new) |
+| `plugin/dev/scenarios/s03-error-pattern.yaml` | Scenario (new) |
+| `plugin/dev/scenarios/s04-commit-context.yaml` | Scenario (new) |
+| `plugin/dev/logs/test-runs.jsonl` | Run log (new, gitignored) |
+| `plugin/dev/logs/discoveries.md` | Learning log (new, committed) |
+| `plugin/dev/logs/decisions.md` | Decision log (new, committed) |
+| `plugin/dev/test-env.sh` | Patch: use `CLAUDE_CODE_HOME` isolation |
+| `tests/hooks/KNOWN_GAPS.md` | Reference: known limitations |
+| `tests/hooks/helpers/common.sh` | Reference: assertion helpers |
+
+## Appendix B — Key Design Decisions Summary
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Fixture storage | In-repo `plugin/dev/fixtures/seeded/` (synthetic only) | Version-controlled, portable, no privacy risk |
+| Scenario format | YAML, grep/sed/awk parsed (python3+PyYAML alternative) | Readable, flat schema; python3 fallback for multi-line block scalars |
+| Orchestration model | Semi-automated (subprocess for `claude -p`, tmux only for `interactive`) | Avoids cross-workspace cmux issues, simpler than full tmux automation |
+| Live plugin isolation | `CLAUDE_CODE_HOME` env var for full environment isolation | Creates separate Claude Code env; no `disabledPlugins` (not a real setting) |
+| Model for hook assertions | Haiku | Binary correctness, 20x cheaper than Sonnet |
+| Model for recall scenarios | Per-scenario YAML, default Haiku | Cost control with opt-in quality |
+| Recall assertion method | Substring match + JSONL event field check | Deterministic, no LLM judge cost for initial pass; LLM judge deferred |
+| Multi-turn testing | Deferred to future iteration | PreCompact untestable via `claude -p`; complexity not justified yet |
+| Log format | JSONL for machine data, Markdown for human notes | Queryable history + narrative context in the same place |

--- a/docs/specs/trait-surface.md
+++ b/docs/specs/trait-surface.md
@@ -1,0 +1,898 @@
+# MAG Substrate Trait Surface Design Spec
+
+**Status:** Draft  
+**Module:** `substrate/` (new, alongside `memory_core/`)  
+**Scope:** 7 swap-point traits + supporting types, relationship mapping, composition patterns, reference impls, and deprecation path.
+
+---
+
+## 1. Motivation
+
+`SqliteStorage` currently implements ~28 fine-grained traits but has no internal swap points. Every algorithmic concern — candidate collection, fusion, scoring, graph enrichment, lifecycle — is coupled directly to SQLite. This spec defines a `substrate/` module with 7 clean interfaces that can be implemented by alternative backends, mixed-in, or replaced at runtime without touching call-site code.
+
+---
+
+## 2. Supporting Types
+
+These types live in `substrate::types` and bridge to existing `memory_core` types.
+
+```rust
+use crate::memory_core::domain::{SearchOptions, SemanticResult, MemoryInput, EventType};
+use crate::memory_core::scoring::ScoringParams;
+use std::collections::HashMap;
+
+/// A candidate memory with accumulated score. Bridges to the private
+/// `RankedSemanticCandidate` used inside `SqliteStorage`.
+///
+/// Public mirror of the internal struct so substrate impls can work with it
+/// without depending on the SQLite module internals.
+#[derive(Debug, Clone)]
+pub struct ScoredCandidate {
+    /// The underlying search result (id, content, tags, importance, metadata,
+    /// event_type, session_id, project, entity_id, agent_type, score).
+    pub result: SemanticResult,
+    /// ISO 8601 wall-clock creation timestamp.
+    pub created_at: String,
+    /// ISO 8601 event timestamp (may differ from created_at for backdated events).
+    pub event_at: String,
+    /// Accumulated composite score (mutable through the pipeline).
+    pub score: f64,
+    /// Resolved priority (0-4) used by scorer chain.
+    pub priority_value: u8,
+    /// Raw cosine similarity from vector search, if this candidate came from
+    /// the vector path. None for FTS-only candidates.
+    pub vec_sim: Option<f64>,
+    /// Word overlap fraction computed during score refinement.
+    pub text_overlap: f64,
+    /// Denormalised entity_id for entity expansion scorer.
+    pub entity_id: Option<String>,
+    /// Denormalised agent_type for in-memory filtering.
+    pub agent_type: Option<String>,
+    /// Populated only when `SearchOptions::explain` is true.
+    pub explain: Option<serde_json::Value>,
+}
+
+/// Type alias preserving the existing name used internally in `SqliteStorage`.
+/// Allows migration: old code keeps compiling; new code can use `ScoredCandidate`.
+pub type RankedSemanticCandidate = ScoredCandidate;
+
+/// An ordered, keyed set of candidates produced by a `RetrievalStrategy`.
+/// The key is the strategy name (e.g. `"vector"`, `"fts"`).
+pub type CandidateSet = Vec<(String, f64, ScoredCandidate)>;
+
+/// Read-path context passed through the pipeline.
+///
+/// Replaces the scattered `query`, `limit`, `opts`, `scoring_params`
+/// parameter tuples used throughout `advanced.rs`.
+#[derive(Debug, Clone)]
+pub struct QueryContext {
+    /// Raw query string from the caller.
+    pub query: String,
+    /// Maximum number of results to return after the full pipeline.
+    pub limit: usize,
+    /// Filter and feature options (event_type, project, session, explain, etc.).
+    pub opts: SearchOptions,
+    /// Scoring knobs. Consumers should clone from a shared `Arc<ScoringParams>`.
+    pub scoring_params: ScoringParams,
+    /// Pre-computed query embedding. `None` until the ingestion/embedding stage
+    /// populates it; strategies that do not need embeddings ignore it.
+    pub query_embedding: Option<Vec<f32>>,
+    /// Derived token set (stemmed, stop-word-filtered) for word-overlap scoring.
+    /// Populated lazily by the pipeline orchestrator before calling scorers.
+    pub query_tokens: Option<std::collections::HashSet<String>>,
+    /// Whether superseded memories should be included in candidate sets.
+    pub include_superseded: bool,
+}
+
+/// Write-path context for `IngestionPipeline`.
+#[derive(Debug, Clone)]
+pub struct WriteContext {
+    pub input: MemoryInput,
+    pub assigned_id: String,
+    pub embedding: Option<Vec<f32>>,
+}
+
+/// Result returned by `ConsolidationStrategy::run`.
+#[derive(Debug, Clone)]
+pub struct ConsolidationReport {
+    pub strategy: String,
+    pub memories_examined: usize,
+    pub memories_modified: usize,
+    pub dry_run: bool,
+    pub detail: serde_json::Value,
+}
+```
+
+---
+
+## 3. The 7 Swap-Point Traits
+
+### 3.1 Storage — Physical CRUD Backend
+
+Replaces/extends the existing `Storage` trait in `traits.rs`. The supertrait family
+bundles the 28 existing traits into a single `MemoryStore` supertrait so backends
+can be swapped atomically.
+
+```rust
+use async_trait::async_trait;
+use anyhow::Result;
+use crate::memory_core::domain::{
+    BackupInfo, CheckpointInput, GraphNode, ListResult, MemoryInput, MemoryUpdate,
+    Relationship, SearchOptions, SearchResult, SemanticResult, WelcomeOptions,
+};
+
+/// Physical CRUD + ancillary ops. Implemented by `SqliteStorage` today.
+/// Every method mirrors an existing trait in `memory_core/traits.rs` so
+/// blanket impls can delegate automatically (see §6).
+#[async_trait]
+pub trait MemoryStore: Send + Sync {
+    // ── Core CRUD ─────────────────────────────────────────────────────────
+    async fn store(&self, id: &str, data: &str, input: &MemoryInput) -> Result<()>;
+    async fn retrieve(&self, id: &str) -> Result<String>;
+    async fn delete(&self, id: &str) -> Result<bool>;
+    async fn update(&self, id: &str, update: &MemoryUpdate) -> Result<()>;
+
+    // ── Query surface ─────────────────────────────────────────────────────
+    async fn search(
+        &self,
+        query: &str,
+        limit: usize,
+        opts: &SearchOptions,
+    ) -> Result<Vec<SearchResult>>;
+    async fn semantic_search(
+        &self,
+        query: &str,
+        limit: usize,
+        opts: &SearchOptions,
+    ) -> Result<Vec<SemanticResult>>;
+    async fn advanced_search(
+        &self,
+        query: &str,
+        limit: usize,
+        opts: &SearchOptions,
+    ) -> Result<Vec<SemanticResult>>;
+    async fn phrase_search(
+        &self,
+        phrase: &str,
+        limit: usize,
+        opts: &SearchOptions,
+    ) -> Result<Vec<SearchResult>>;
+    async fn recent(&self, limit: usize, opts: &SearchOptions) -> Result<Vec<SearchResult>>;
+    async fn get_by_tags(
+        &self,
+        tags: &[String],
+        limit: usize,
+        opts: &SearchOptions,
+    ) -> Result<Vec<SearchResult>>;
+    async fn list(
+        &self,
+        offset: usize,
+        limit: usize,
+        opts: &SearchOptions,
+    ) -> Result<ListResult>;
+
+    // ── Graph ─────────────────────────────────────────────────────────────
+    async fn traverse(
+        &self,
+        start_id: &str,
+        max_hops: usize,
+        min_weight: f64,
+        edge_types: Option<&[String]>,
+    ) -> Result<Vec<GraphNode>>;
+    async fn get_relationships(&self, memory_id: &str) -> Result<Vec<Relationship>>;
+    async fn find_similar(&self, memory_id: &str, limit: usize) -> Result<Vec<SemanticResult>>;
+
+    // ── Versioning ────────────────────────────────────────────────────────
+    async fn get_version_chain(&self, memory_id: &str) -> Result<Vec<SearchResult>>;
+    async fn supersede_memory(&self, old_id: &str, new_id: &str) -> Result<()>;
+
+    // ── Lifecycle ancillaries ─────────────────────────────────────────────
+    async fn sweep_expired(&self) -> Result<usize>;
+    async fn record_feedback(
+        &self,
+        memory_id: &str,
+        rating: &str,
+        reason: Option<&str>,
+    ) -> Result<serde_json::Value>;
+
+    // ── Profile / checkpoint / reminder / lesson ──────────────────────────
+    async fn get_profile(&self) -> Result<serde_json::Value>;
+    async fn set_profile(&self, updates: &serde_json::Value) -> Result<()>;
+    async fn save_checkpoint(&self, input: CheckpointInput) -> Result<String>;
+    async fn resume_task(
+        &self,
+        query: &str,
+        project: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<serde_json::Value>>;
+    async fn create_reminder(
+        &self,
+        text: &str,
+        duration_str: &str,
+        context: Option<&str>,
+        session_id: Option<&str>,
+        project: Option<&str>,
+    ) -> Result<serde_json::Value>;
+    async fn list_reminders(&self, status: Option<&str>) -> Result<Vec<serde_json::Value>>;
+    async fn dismiss_reminder(&self, reminder_id: &str) -> Result<serde_json::Value>;
+    async fn query_lessons(
+        &self,
+        task: Option<&str>,
+        project: Option<&str>,
+        exclude_session: Option<&str>,
+        agent_type: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<serde_json::Value>>;
+
+    // ── Maintenance / stats ───────────────────────────────────────────────
+    async fn check_health(
+        &self,
+        warn_mb: f64,
+        critical_mb: f64,
+        max_nodes: i64,
+    ) -> Result<serde_json::Value>;
+    async fn consolidate(
+        &self,
+        prune_days: i64,
+        max_summaries: i64,
+    ) -> Result<serde_json::Value>;
+    async fn compact(
+        &self,
+        event_type: &str,
+        similarity_threshold: f64,
+        min_cluster_size: usize,
+        dry_run: bool,
+    ) -> Result<serde_json::Value>;
+    async fn clear_session(&self, session_id: &str) -> Result<usize>;
+    async fn auto_compact(
+        &self,
+        count_threshold: usize,
+        dry_run: bool,
+    ) -> Result<serde_json::Value>;
+    async fn type_stats(&self) -> Result<serde_json::Value>;
+    async fn session_stats(&self) -> Result<serde_json::Value>;
+    async fn weekly_digest(&self, days: i64) -> Result<serde_json::Value>;
+    async fn access_rate_stats(&self) -> Result<serde_json::Value>;
+
+    // ── Backup ────────────────────────────────────────────────────────────
+    async fn create_backup(&self) -> Result<BackupInfo>;
+    async fn rotate_backups(&self, max_count: usize) -> Result<usize>;
+    async fn list_backups(&self) -> Result<Vec<BackupInfo>>;
+    async fn restore_backup(&self, backup_path: &std::path::Path) -> Result<()>;
+    async fn maybe_startup_backup(&self) -> Result<Option<BackupInfo>>;
+
+    // ── Welcome ───────────────────────────────────────────────────────────
+    async fn welcome(
+        &self,
+        session_id: Option<&str>,
+        project: Option<&str>,
+    ) -> Result<serde_json::Value>;
+}
+```
+
+---
+
+### 3.2 RetrievalStrategy — Unscored Candidate Collection
+
+Produces a raw candidate list from one retrieval signal (vector OR FTS).
+Analogous to the internal `collect_vector_candidates` / `collect_fts_candidates`
+functions in `advanced.rs`.
+
+```rust
+/// Retrieves an unscored, unranked candidate set for a single retrieval signal.
+///
+/// Implementors MUST NOT apply multi-signal fusion — that is `FusionStrategy`'s job.
+/// The returned `CandidateSet` is `(memory_id, raw_score, candidate)` where
+/// `raw_score` is signal-native (cosine similarity for vector; raw BM25 for FTS,
+/// where more-negative = better).
+#[async_trait]
+pub trait RetrievalStrategy: Send + Sync {
+    /// Human-readable name used as the key in `FusionStrategy::fuse`.
+    fn name(&self) -> &str;
+
+    /// Collect candidates for the given context.
+    ///
+    /// Implementors that perform blocking I/O (e.g. ONNX inference, SQLite reads)
+    /// MUST wrap the blocking work in `tokio::task::spawn_blocking`.
+    async fn collect(
+        &self,
+        ctx: &QueryContext,
+    ) -> Result<CandidateSet>;
+}
+
+/// Reference implementation: vector (embedding) similarity search.
+///
+/// Wraps `collect_vector_candidates` from `advanced.rs`.
+/// Requires the `real-embeddings` or `sqlite-vec` feature.
+pub struct VectorSearch {
+    pub store: std::sync::Arc<dyn MemoryStore>,
+    // Internal: holds the embedder + connection pool refs via SqliteStorage.
+}
+
+/// Reference implementation: BM25 full-text search.
+///
+/// Wraps `collect_fts_candidates` from `advanced.rs`.
+pub struct FullTextSearch {
+    pub store: std::sync::Arc<dyn MemoryStore>,
+}
+```
+
+---
+
+### 3.3 FusionStrategy — Multi-Signal Merging
+
+Takes the per-strategy candidate maps and returns a single merged, score-ordered list.
+
+```rust
+/// Merges multiple `CandidateSet`s into a single ranked list.
+///
+/// The `strategy` key in `candidates` matches `RetrievalStrategy::name()`.
+/// Fusion is pure in-memory arithmetic — no I/O allowed.
+pub trait FusionStrategy: Send + Sync {
+    /// Merge candidates from all strategies into one scored list.
+    ///
+    /// Returns candidates keyed by memory id, in descending score order.
+    fn fuse(
+        &self,
+        candidates: HashMap<&str, CandidateSet>,
+        scoring_params: &ScoringParams,
+    ) -> Vec<ScoredCandidate>;
+}
+
+/// Reference implementation: Reciprocal Rank Fusion with adaptive dual-match boost.
+///
+/// Direct extraction of the RRF logic in `fuse_refine_and_output` (advanced.rs:868+).
+///
+/// Algorithm:
+///   rrf_score(rank) = weight / (k + rank + 1)
+///   dual-match boost = base_boost + (1/(1+fts_rank)) * 0.5
+///   where base_boost = scoring_params.dual_match_boost (default 1.5)
+///         k = scoring_params.rrf_k (default 60.0)
+///
+/// Weights per strategy:
+///   "vector" → scoring_params.rrf_weight_vec (default 1.0)
+///   "fts"    → scoring_params.rrf_weight_fts (default 1.0)
+pub struct RrfFusion;
+```
+
+---
+
+### 3.4 Scorer — Composable Post-Fusion Scoring Chain
+
+Each `Scorer` takes the fused candidate map and mutates scores in-place.
+Scorers are chained; each sees the output of the previous one.
+
+```rust
+/// Post-fusion score refinement. One unit of composable scoring logic.
+///
+/// `score_batch` MUST be pure in-memory for hot-path scorers. Scorers that
+/// need I/O (cross-encoder, graph queries) MUST use `spawn_blocking` internally.
+#[async_trait]
+pub trait Scorer: Send + Sync {
+    /// Human-readable name for logging/explain output.
+    fn name(&self) -> &str;
+
+    /// Mutate scores on a batch of candidates in-place.
+    async fn score_batch(
+        &self,
+        candidates: &mut HashMap<String, ScoredCandidate>,
+        ctx: &QueryContext,
+    ) -> Result<()>;
+}
+
+/// Reference: MultiFactorScorer
+///
+/// Applies word overlap, query coverage boost, Jaccard similarity, feedback
+/// dampening, time decay, importance floor/scale, and context-tag matching.
+/// Direct extraction of `refine_scores` (advanced.rs:370-448).
+///
+/// Score multiplications applied in order:
+///   1. coverage_boost   = 1.0 + (query_coverage_boost(overlap) - 1.0) * fb_dampening
+///   2. word_overlap     *= 1.0 + overlap * scoring_params.word_overlap_weight * fb_dampening
+///   3. jaccard          *= 1.0 + jaccard * scoring_params.jaccard_weight
+///   4. feedback_factor  (see scoring.rs:feedback_factor)
+///   5. time_decay_et    (no decay for Semantic kind memories)
+///   6. importance_factor = importance_floor + importance * importance_scale
+///   7. context_tag ratio *= 1.0 + ratio * context_tag_weight
+pub struct MultiFactorScorer {
+    // No fields required; all parameters come from QueryContext::scoring_params.
+}
+
+/// Reference: CrossEncoderScorer
+///
+/// Wraps `CrossEncoderReranker::score_batch` (reranker.rs).
+/// Model: ms-marco-MiniLM-L-6-v2 (ONNX, CPU-only, auto-downloaded).
+/// Scores top `scoring_params.rerank_top_n` (default 30) candidates.
+/// Blends: final = alpha * rrf_score + (1-alpha) * cross_encoder_score
+///         where alpha = scoring_params.rerank_blend_alpha (default 0.5).
+/// MUST wrap `CrossEncoderReranker::score_batch` in `spawn_blocking`.
+/// Feature-gated: only compiled with `#[cfg(feature = "real-embeddings")]`.
+#[cfg(feature = "real-embeddings")]
+pub struct CrossEncoderScorer {
+    pub reranker: std::sync::Arc<crate::memory_core::reranker::CrossEncoderReranker>,
+}
+
+/// Reference: GraphNeighborScorer
+///
+/// Injects 1-hop graph neighbors from the top-k seed candidates.
+/// Direct extraction of `enrich_graph_neighbors` (advanced.rs:450-660).
+/// Seeds: top `limit.clamp(graph_seed_min, graph_seed_max)` by score.
+/// Neighbor score = graph_neighbor_factor * seed_score * edge_weight,
+/// with edge-type boosts:
+///   REL_PRECEDED_BY → * scoring_params.preceded_by_boost (default 1.5)
+///   REL_RELATES_TO / REL_SIMILAR_TO / REL_SHARES_THEME / REL_PARALLEL_CONTEXT
+///                   → * scoring_params.entity_relation_boost (default 1.3)
+/// Requires a SQLite connection for neighbor lookup — wraps in `spawn_blocking`.
+pub struct GraphNeighborScorer {
+    pub store: std::sync::Arc<dyn MemoryStore>,
+}
+
+/// Reference: EntityExpansionScorer
+///
+/// Extracts entity tags from top seeds, queries memories sharing those tags,
+/// injects them with ENTITY_EXPANSION_BOOST (1.15×).
+/// Direct extraction of `expand_entity_candidates` (advanced.rs:678-866).
+/// Caps expansion at 25 additional memories, 5 entity tags, 5 per tag.
+pub struct EntityExpansionScorer {
+    pub store: std::sync::Arc<dyn MemoryStore>,
+}
+```
+
+---
+
+### 3.5 LifecyclePolicy — TTL / Promotion / Decay
+
+Controls which memories survive, expire, or get promoted over time.
+
+```rust
+/// Determines what happens to a memory at lifecycle checkpoints.
+#[async_trait]
+pub trait LifecyclePolicy: Send + Sync {
+    fn name(&self) -> &str;
+
+    /// Called on memory read: returns `true` if the memory should be served
+    /// (i.e. has not expired). Non-destructive gate.
+    fn is_alive(&self, candidate: &ScoredCandidate) -> bool;
+
+    /// Sweep all expired memories from the store. Returns count removed.
+    /// Wraps `ExpirationSweeper::sweep_expired` from `traits.rs`.
+    async fn sweep(&self, store: &dyn MemoryStore) -> Result<usize>;
+
+    /// Apply decay or promotion mutations to a candidate's score.
+    /// Called inside the scorer chain when lifecycle context is available.
+    fn apply_decay(&self, candidate: &mut ScoredCandidate, now_secs: u64);
+}
+
+/// Reference: TtlExpirationPolicy
+///
+/// Uses the `ttl_seconds` field from `MemoryInput` and `EventType::default_ttl()`.
+/// Delegates sweep to `MemoryStore::sweep_expired`.
+/// `is_alive` checks metadata["expires_at"] < now.
+/// `apply_decay` is a no-op (TTL is binary alive/dead, not graduated decay).
+pub struct TtlExpirationPolicy;
+```
+
+---
+
+### 3.6 ConsolidationStrategy — Background Memory Restructuring
+
+Runs off the hot path. Each strategy is one unit of background compaction logic.
+
+```rust
+/// One self-contained consolidation pass over the memory store.
+#[async_trait]
+pub trait ConsolidationStrategy: Send + Sync {
+    fn name(&self) -> &str;
+
+    /// Run one consolidation pass.
+    ///
+    /// `dry_run = true` MUST produce the same `ConsolidationReport` but make
+    /// no mutations to the store.
+    async fn run(
+        &self,
+        store: &dyn MemoryStore,
+        dry_run: bool,
+    ) -> Result<ConsolidationReport>;
+}
+
+/// Reference: DedupConsolidation
+///
+/// Merges near-duplicate memories per event type using Jaccard similarity.
+/// Wraps `MemoryStore::compact`.
+/// Uses `EventType::types_with_dedup_threshold()` to find eligible types.
+/// Thresholds from `EventType::dedup_threshold()` (0.70-0.85 range).
+pub struct DedupConsolidation {
+    pub min_cluster_size: usize,
+}
+
+/// Reference: CompactConsolidation
+///
+/// Prunes zero-access memories older than a threshold and caps session summaries.
+/// Wraps `MemoryStore::consolidate`.
+pub struct CompactConsolidation {
+    pub prune_days: i64,
+    pub max_summaries: i64,
+}
+
+/// Reference: AutoRelateConsolidation
+///
+/// Auto-compact pass across all event types with dedup thresholds,
+/// triggered when total memory count exceeds a threshold.
+/// Wraps `MemoryStore::auto_compact`.
+pub struct AutoRelateConsolidation {
+    pub count_threshold: usize,
+}
+```
+
+---
+
+### 3.7 IngestionPipeline — Write-Path Processing
+
+The write-path equivalent of `SearchPipeline`. Handles embedding, dedup detection,
+entity extraction, and auto-supersession before the store write.
+
+```rust
+/// Write-path processor: takes a `WriteContext`, applies transformations,
+/// and writes to the store.
+#[async_trait]
+pub trait IngestionPipeline: Send + Sync {
+    /// Process and store a memory. Returns the assigned memory ID.
+    ///
+    /// Implementors are responsible for:
+    ///   1. Assigning an ID if `WriteContext::assigned_id` is empty.
+    ///   2. Computing the embedding (spawn_blocking for ONNX).
+    ///   3. Dedup / auto-supersession checks.
+    ///   4. Entity extraction from tags.
+    ///   5. Calling `MemoryStore::store`.
+    async fn ingest(
+        &self,
+        ctx: WriteContext,
+        store: &dyn MemoryStore,
+    ) -> Result<String>;
+}
+
+/// Reference: EmbedAndExtractPipeline
+///
+/// Mirrors the write path in `SqliteStorage`:
+///   1. Normalise input (apply_event_type_defaults).
+///   2. Compute embedding via `Embedder::embed` (spawn_blocking).
+///   3. Check cosine similarity for auto-supersession
+///      (threshold: SUPERSESSION_COSINE_THRESHOLD = 0.70,
+///       secondary Jaccard: SUPERSESSION_JACCARD_THRESHOLD = 0.30).
+///   4. Check content hash for exact dedup.
+///   5. Extract entities from tags for relationship edges.
+///   6. Call MemoryStore::store.
+///   7. Create PRECEDED_BY, RELATES_TO relationship edges.
+pub struct EmbedAndExtractPipeline {
+    pub embedder: std::sync::Arc<dyn crate::memory_core::embedder::Embedder>,
+}
+```
+
+---
+
+## 4. Orchestrator Types
+
+These wire the 7 traits together at runtime.
+
+### 4.1 SearchPipeline
+
+```rust
+/// The read-path orchestrator. Wires retrieval → fusion → scoring → lifecycle.
+///
+/// Callers construct this once (at daemon startup or per-request for testing)
+/// and call `search`.
+pub struct SearchPipeline {
+    /// Retrieval strategies, run concurrently (tokio::join! or FuturesUnordered).
+    pub retrieval: Vec<Box<dyn RetrievalStrategy>>,
+    /// Single fusion pass applied after all retrieval strategies complete.
+    pub fusion: Box<dyn FusionStrategy>,
+    /// Scorer chain — applied in order, each sees the previous scorer's output.
+    pub scorers: Vec<Box<dyn Scorer>>,
+    /// Lifecycle gate applied after scoring; filters dead memories.
+    pub lifecycle: Option<Box<dyn LifecyclePolicy>>,
+    /// Abstention threshold on max text overlap before returning empty.
+    /// Matches ABSTENTION_MIN_TEXT (0.15) from scoring.rs.
+    pub abstention_min_text: f64,
+}
+
+impl SearchPipeline {
+    /// Execute the full pipeline for a query.
+    ///
+    /// Steps:
+    ///   1. Run all `retrieval` strategies concurrently.
+    ///   2. Pass strategy→CandidateSet map to `fusion.fuse`.
+    ///   3. Apply each scorer in `scorers` in order.
+    ///   4. Apply `lifecycle.is_alive` filter if set.
+    ///   5. Apply abstention gate (max text_overlap < abstention_min_text → return empty).
+    ///   6. Sort descending by score, truncate to `ctx.limit`.
+    ///   7. Map to `SemanticResult`.
+    pub async fn search(&self, ctx: QueryContext) -> Result<Vec<SemanticResult>> {
+        // ... (implementation in Phase 3)
+        todo!()
+    }
+}
+```
+
+### 4.2 WritePipeline
+
+```rust
+/// The write-path orchestrator. Thin wrapper around `IngestionPipeline`.
+pub struct WritePipeline {
+    pub pipeline: Box<dyn IngestionPipeline>,
+    pub store: std::sync::Arc<dyn MemoryStore>,
+}
+
+impl WritePipeline {
+    pub async fn ingest(&self, input: MemoryInput) -> Result<String> {
+        let ctx = WriteContext {
+            assigned_id: input.id.clone().unwrap_or_default(),
+            embedding: None,
+            input,
+        };
+        self.pipeline.ingest(ctx, self.store.as_ref()).await
+    }
+}
+```
+
+### 4.3 ConsolidationRunner
+
+```rust
+/// Runs consolidation strategies in registration order.
+pub struct ConsolidationRunner {
+    pub strategies: Vec<Box<dyn ConsolidationStrategy>>,
+    pub store: std::sync::Arc<dyn MemoryStore>,
+}
+
+impl ConsolidationRunner {
+    pub async fn run_all(&self, dry_run: bool) -> Result<Vec<ConsolidationReport>> {
+        let mut reports = Vec::with_capacity(self.strategies.len());
+        for strategy in &self.strategies {
+            reports.push(strategy.run(self.store.as_ref(), dry_run).await?);
+        }
+        Ok(reports)
+    }
+}
+```
+
+---
+
+## 5. Existing Trait → New Hierarchy Mapping
+
+Each of the 28 traits in `memory_core/traits.rs` lands in exactly one location in the new hierarchy.
+
+| Existing trait (`traits.rs`) | New home | Notes |
+|---|---|---|
+| `Ingestor` | `IngestionPipeline` | Subsumed; `ingest(&str)` becomes `ingest(WriteContext)` |
+| `Processor` | `IngestionPipeline` | Subsumed; embedding+NLP are pipeline steps |
+| `Storage` | `MemoryStore::store` | Signature unchanged; renamed to avoid confusion with the module |
+| `Retriever` | `MemoryStore::retrieve` | Point lookup, not retrieval strategy |
+| `Searcher` | `MemoryStore::search` + `SearchPipeline` | BM25/keyword search delegated to `FullTextSearch` |
+| `Recents` | `MemoryStore::recent` | Unchanged; no pipeline involvement |
+| `SemanticSearcher` | `MemoryStore::semantic_search` | Simple semantic path; `SearchPipeline` is the advanced path |
+| `GraphTraverser` | `MemoryStore::traverse` | Direct graph query; no scorer involvement |
+| `SimilarFinder` | `MemoryStore::find_similar` | Direct lookup by embedding similarity |
+| `PhraseSearcher` | `MemoryStore::phrase_search` | Direct FTS phrase query |
+| `AdvancedSearcher` | `SearchPipeline::search` | Primary target; pipeline replaces monolithic impl |
+| `Deleter` | `MemoryStore::delete` | Unchanged |
+| `Updater` | `MemoryStore::update` | Unchanged |
+| `Tagger` | `MemoryStore::get_by_tags` | Unchanged; also feeds `EntityExpansionScorer` |
+| `Lister` | `MemoryStore::list` | Unchanged |
+| `RelationshipQuerier` | `MemoryStore::get_relationships` | Unchanged; also feeds `GraphNeighborScorer` |
+| `VersionChainQuerier` | `MemoryStore::{get_version_chain, supersede_memory}` | Unchanged |
+| `FeedbackRecorder` | `MemoryStore::record_feedback` | Score impact via `MultiFactorScorer::feedback_factor` |
+| `ExpirationSweeper` | `LifecyclePolicy::sweep` | Delegated to `TtlExpirationPolicy` |
+| `ProfileManager` | `MemoryStore::{get_profile, set_profile}` | Unchanged |
+| `CheckpointManager` | `MemoryStore::{save_checkpoint, resume_task}` | Unchanged |
+| `ReminderManager` | `MemoryStore::{create_reminder, list_reminders, dismiss_reminder}` | Unchanged |
+| `LessonQuerier` | `MemoryStore::query_lessons` | Unchanged |
+| `MaintenanceManager` | `MemoryStore::{check_health, consolidate, compact, clear_session, auto_compact}` + `ConsolidationRunner` | Hot-path ops on `MemoryStore`; scheduled ops via `ConsolidationRunner` |
+| `WelcomeProvider` | `MemoryStore::welcome` | Unchanged |
+| `BackupManager` | `MemoryStore::{create_backup, rotate_backups, list_backups, restore_backup, maybe_startup_backup}` | Unchanged |
+| `StatsProvider` | `MemoryStore::{type_stats, session_stats, weekly_digest, access_rate_stats}` | Unchanged |
+
+---
+
+## 6. Backward Compatibility: Blanket Impls
+
+Blanket impls allow all existing call sites to keep using the granular traits unchanged.
+No call sites need modification until the explicit deprecation phase.
+
+```rust
+// In memory_core/traits.rs or a new compat.rs:
+
+use crate::substrate::MemoryStore;
+
+/// Any type that implements MemoryStore also implements the legacy Storage trait.
+#[async_trait]
+impl<T: MemoryStore + ?Sized> crate::memory_core::Storage for T {
+    async fn store(&self, id: &str, data: &str, input: &MemoryInput) -> Result<()> {
+        MemoryStore::store(self, id, data, input).await
+    }
+}
+
+#[async_trait]
+impl<T: MemoryStore + ?Sized> crate::memory_core::AdvancedSearcher for T {
+    async fn advanced_search(
+        &self,
+        query: &str,
+        limit: usize,
+        opts: &SearchOptions,
+    ) -> Result<Vec<SemanticResult>> {
+        MemoryStore::advanced_search(self, query, limit, opts).await
+    }
+}
+
+// ... one blanket impl per legacy trait, all delegating to MemoryStore methods.
+```
+
+`SqliteStorage` continues to implement all legacy traits directly (no code change needed)
+because it will grow a `MemoryStore` impl that the blankets delegate through.
+
+---
+
+## 7. Reference Implementation Wiring
+
+The default `SearchPipeline` for production use:
+
+```rust
+pub fn default_search_pipeline(store: Arc<SqliteStorage>) -> SearchPipeline {
+    let mut scorers: Vec<Box<dyn Scorer>> = vec![
+        Box::new(MultiFactorScorer),
+    ];
+
+    #[cfg(feature = "real-embeddings")]
+    if let Some(reranker) = store.reranker() {
+        scorers.push(Box::new(CrossEncoderScorer { reranker }));
+    }
+
+    scorers.push(Box::new(GraphNeighborScorer { store: store.clone() }));
+    scorers.push(Box::new(EntityExpansionScorer { store: store.clone() }));
+
+    SearchPipeline {
+        retrieval: vec![
+            Box::new(VectorSearch { store: store.clone() }),
+            Box::new(FullTextSearch { store: store.clone() }),
+        ],
+        fusion: Box::new(RrfFusion),
+        scorers,
+        lifecycle: Some(Box::new(TtlExpirationPolicy)),
+        abstention_min_text: crate::memory_core::scoring::ABSTENTION_MIN_TEXT,
+    }
+}
+
+pub fn default_consolidation_runner(store: Arc<SqliteStorage>) -> ConsolidationRunner {
+    ConsolidationRunner {
+        store: store.clone(),
+        strategies: vec![
+            Box::new(DedupConsolidation { min_cluster_size: 2 }),
+            Box::new(CompactConsolidation { prune_days: 30, max_summaries: 50 }),
+            Box::new(AutoRelateConsolidation { count_threshold: 500 }),
+        ],
+    }
+}
+```
+
+---
+
+## 8. Implementation Phases
+
+### Phase 1 — Define (non-breaking, additive only)
+- Create `src/substrate/mod.rs` with all 7 traits and supporting types.
+- Export `ScoredCandidate` and `RankedSemanticCandidate` type alias from `substrate`.
+- No changes to `memory_core/`.
+- Gate on a `substrate` feature flag (disabled by default) to avoid breaking the build.
+
+### Phase 2 — Implement (parallel to existing code)
+- Implement `MemoryStore` for `SqliteStorage` by delegating to existing trait impls.
+- Implement `VectorSearch` and `FullTextSearch` by extracting `collect_vector_candidates`
+  and `collect_fts_candidates` from `advanced.rs` into the new structs.
+- Implement `RrfFusion` by extracting the RRF block from `fuse_refine_and_output`.
+- Implement `MultiFactorScorer` by extracting `refine_scores`.
+- Implement `CrossEncoderScorer` (feature-gated `real-embeddings`) by wrapping reranker.
+- Implement `GraphNeighborScorer` by extracting `enrich_graph_neighbors`.
+- Implement `EntityExpansionScorer` by extracting `expand_entity_candidates`.
+- Implement `TtlExpirationPolicy`, `DedupConsolidation`, `CompactConsolidation`,
+  `AutoRelateConsolidation`.
+- Implement `EmbedAndExtractPipeline`.
+- All implementations are tested in isolation. Existing integration tests still pass.
+
+### Phase 3 — Wire (SearchPipeline goes live)
+- `SqliteStorage::advanced_search` delegates to `SearchPipeline::search`.
+- `SearchPipeline` calls the extracted strategy/scorer impls.
+- Enable `substrate` feature by default.
+- Add blanket impls for legacy traits → `MemoryStore`.
+- Benchmark to confirm no regression against `ABSTENTION_MIN_TEXT` / LoCoMo-10 baseline.
+
+### Phase 4 — Deprecate (next minor release)
+- Add `#[deprecated]` to each of the 28 granular legacy traits.
+- Update internal usages to use `MemoryStore` or pipeline types directly.
+- Document migration path in CHANGELOG.
+
+### Phase 5 — Remove (next breaking release, semver major or explicit breaking minor)
+- Remove the 28 legacy traits from `memory_core/traits.rs`.
+- Remove blanket impl shims.
+- `MemoryStore` + `substrate` types are the sole interface.
+
+---
+
+## 9. Critical Implementation Details
+
+### spawn_blocking Rules
+
+All CPU-bound or blocking I/O work MUST use `tokio::task::spawn_blocking`:
+
+| Operation | Requirement |
+|---|---|
+| ONNX embedding inference (`Embedder::embed`) | `spawn_blocking` always |
+| Cross-encoder `score_batch` | `spawn_blocking` always |
+| SQLite reads via `rusqlite` | `spawn_blocking` inside async contexts |
+| SQLite writes via `rusqlite` | `spawn_blocking` always |
+| `CrossEncoderReranker::warmup` | Already uses `spawn_blocking` (see reranker.rs:76) |
+
+`RetrievalStrategy::collect` is `async` specifically to allow implementors to
+call `spawn_blocking` internally without requiring callers to know.
+
+### Feature Gating
+
+```
+real-embeddings → CrossEncoderScorer, CrossEncoderReranker, VectorSearch (knn path)
+sqlite-vec      → vec_knn_search, vec_upsert, vec_delete (inside VectorSearch)
+```
+
+Without `real-embeddings`, `VectorSearch` falls back to full-scan cosine similarity
+(existing non-vec path in `advanced.rs`). Without both features, only `FullTextSearch`
+is available; `SearchPipeline` still compiles and works.
+
+### Query Cache
+
+`SqliteStorage` maintains a `QueryCache` (LRU, 128 entries, 60s TTL) keyed on a hash
+of `(query, limit, opts)`. The `SearchPipeline` does NOT own the cache — it remains
+on `SqliteStorage`. This means:
+
+- Cache hits bypass the pipeline entirely (return early from `advanced_search`).
+- Cache invalidation on writes (`invalidate_cache_selective`) continues to work
+  because writes go through `MemoryStore::store` which has access to the cache.
+- Pipeline-level caching is a future concern; do not add it in Phase 2-3.
+
+### Abstention Gate
+
+After scoring, if `max(text_overlap)` across all surviving candidates is less than
+`ABSTENTION_MIN_TEXT` (0.15), the pipeline returns an empty result set rather than
+surfacing noise. This gate lives in `SearchPipeline::search`, not in any individual
+scorer.
+
+### Hot Cache
+
+`SqliteStorage`'s hot-tier cache (in-memory promotion of frequently-accessed memories)
+is backend-specific. It is NOT modelled in the `MemoryStore` trait — it's an
+`SqliteStorage` implementation detail that survives the migration unchanged.
+
+### ScoringParams Sharing
+
+`ScoringParams` should be wrapped in `Arc<ScoringParams>` at the daemon level and
+passed into `QueryContext` by cloning the `Arc`. The `Default` impl provides production
+defaults; tests can override individual fields. Do not pass `ScoringParams` by value
+through the pipeline — clone the Arc, not the struct.
+
+---
+
+## 10. Module Layout
+
+```
+src/
+  substrate/
+    mod.rs          — pub use of all traits and types; feature gate
+    types.rs        — ScoredCandidate, CandidateSet, QueryContext, WriteContext, ConsolidationReport
+    store.rs        — MemoryStore trait
+    retrieval.rs    — RetrievalStrategy + VectorSearch + FullTextSearch
+    fusion.rs       — FusionStrategy + RrfFusion
+    scorer.rs       — Scorer + MultiFactorScorer + CrossEncoderScorer + GraphNeighborScorer + EntityExpansionScorer
+    lifecycle.rs    — LifecyclePolicy + TtlExpirationPolicy
+    consolidation.rs — ConsolidationStrategy + DedupConsolidation + CompactConsolidation + AutoRelateConsolidation
+    ingestion.rs    — IngestionPipeline + EmbedAndExtractPipeline
+    pipeline.rs     — SearchPipeline + WritePipeline + ConsolidationRunner + default_*() constructors
+    compat.rs       — Blanket impls: MemoryStore → legacy traits
+  memory_core/
+    traits.rs       — (unchanged in Phase 1-3; deprecated in Phase 4)
+    ...
+```

--- a/docs/strongholds/palantir-r1-attack.md
+++ b/docs/strongholds/palantir-r1-attack.md
@@ -1,0 +1,277 @@
+# Palantir Round 1 — Attack on the Execution Roadmap
+<\!-- Sauron's review | Generated: 2026-04-14 | Target: docs/specs/execution-roadmap.md -->
+
+---
+
+## BANTER
+
+Saruman. You have produced a document you call an "execution roadmap." I have read it through the Palantir. I have also read the three specifications it claims to govern. You will not enjoy what follows.
+
+---
+
+### The Name Game: A Module Decomposition Spec That Disagrees With Its Roadmap
+
+Let us begin with the most fundamental question a roadmap can answer: *what are we building, and in what order?*
+
+The module-decomposition spec (Section 6, "Phase Sequence") declares four phases:
+
+```
+Phase 1: admin.rs → admin/          (independent, easiest)
+Phase 2: mod.rs → 5 new files
+Phase 3: advanced.rs → pipeline/    (benchmark-gated)
+Phase 4: mcp_server.rs → mcp/       (independent of phases 1-3)
+```
+
+The roadmap's Phase 4 contains PR-4b and PR-4c — splitting `mcp_server.rs` and `advanced.rs`. Yet in the module-decomposition spec, these are **Phases 1 and 3** — the *first* and *third* things to do, not the last. The admin split (`admin.rs → admin/`) appears nowhere in the roadmap at all. It has been absorbed silently into PR-2c, which is described as `sqlite/mod.rs` structural extraction. But PR-2c, per its own scope table, produces `storage.rs`, `cache.rs`, `hot_cache_mgmt.rs`, `relationships.rs`, and `io.rs`. `admin/` is not in that list. The admin decomposition — which the module-decomposition spec identifies as the *easiest, most independent first step* — has no PR. It fell through the floor.
+
+Saruman has written two specs that describe the same refactor in contradictory sequences, and then written a roadmap that implements neither.
+
+---
+
+### The `pipeline/` Subdirectory: Promised, Absent
+
+The module-decomposition spec (Section 2c and Section 3c) defines `src/memory_core/storage/sqlite/pipeline/` with eight files: `mod.rs`, `retrieval.rs`, `rerank.rs`, `fusion.rs`, `scoring.rs`, `enrichment.rs`, `abstention.rs`, `decomp.rs`. This is described as Phase 3 of the module decomposition — benchmark-gated, high-risk, the surgical extraction of the 6-phase search pipeline from `advanced.rs`.
+
+PR-4c in the roadmap says it will "split `advanced.rs` and `admin.rs` into subdirectories." The scope table for PR-4c shows `sqlite/advanced/mod.rs`, `sqlite/advanced/candidates.rs`, `sqlite/advanced/fusion.rs`, `sqlite/advanced/decomposition.rs`, `sqlite/advanced/graph_enrichment.rs`.
+
+These are *different files with different names*. The module-decomposition spec calls it `pipeline/`. The roadmap calls it `advanced/`. The decomp spec separates `fusion.rs`, `scoring.rs`, `rerank.rs`, and `abstention.rs` as independent files. The roadmap collapses scoring, reranking, and abstention back into `fusion.rs`. The spec has eight target files; the roadmap has five. When an implementer sits down to execute PR-4c, they will discover that the detailed line-number assignment table in the module-decomposition spec — their primary implementation reference — does not match the roadmap they are supposedly following.
+
+---
+
+### The `substrate/` Spec: An Entire Campaign, Unacknowledged
+
+The trait-surface spec is not a small document. It defines a `substrate/` module with 7 swap-point traits, two orchestrator types, five lifecycle policies, a full `MemoryStore` supertrait subsuming all 28 existing traits, blanket impls for backward compatibility, and an explicit four-phase implementation plan.
+
+The roadmap mentions none of this. It does not park it. It does not reference it. The trait-surface spec's Phase 1 ("Define — create `src/substrate/mod.rs`") has no corresponding PR in the roadmap. The trait-surface spec's Phase 2 ("Implement") requires extracting `collect_vector_candidates`, `collect_fts_candidates`, the RRF block, `refine_scores`, `enrich_graph_neighbors`, and `expand_entity_candidates` into new structs. PR-4a in the roadmap adds a `RetrievalStrategy` trait that the trait-surface spec *also* defines — but the roadmap's definition (`fn can_handle + async fn retrieve`) is categorically different from the spec's definition (`fn name() + async fn collect`). Two incompatible `RetrievalStrategy` traits exist across the corpus. One will be wrong when implementation begins.
+
+The roadmap claims to be "the single source of truth." It is not. The trait-surface spec is a parallel authority it has never acknowledged.
+
+---
+
+### PR-2a vs. PR-2d: A Dependency The Dependency Graph Omits
+
+PR-2d's own text reads: "Depends on: PR-2a (trait definition) and PR-2c (storage struct extracted)." Fine. But the dependency graph diagram shows:
+
+```
+PR-2a ──┐
+        ├──> PR-2c ──> PR-2d
+PR-2b ──┘
+```
+
+This diagram states PR-2c depends on both PR-2a **and** PR-2b. Does it? PR-2c is a structural extraction of `sqlite/mod.rs` — it moves code, it does not add the `ScoringStrategy` or `Reranker` traits. There is no reason PR-2c must wait for PR-2b to land. PR-2b's trait change is on `SqliteStorage`'s `reranker` field — which lives in `mod.rs`. So PR-2c *does* need to move that field, meaning it is blocked by PR-2b only insofar as a field type change must be resolved at extraction time.
+
+But there is a deeper problem: PR-2d depends on PR-2a for the `ScoringStrategy` trait, and on PR-2c for the `SqliteStorage` struct being in `storage.rs`. PR-2c depends on PR-2b for the `reranker` field type. PR-2b has a benchmark gate. If PR-2b's benchmark gate **warns** — a >2pp delta triggers a mandatory 10-sample run — the entire PR-2c/PR-2d chain is blocked behind a full 10-sample benchmark execution. The risk register does not mention this blocking scenario. "Medium probability" on PR-2b's benchmark gate means the chain from PR-2b to PR-2c to PR-2d has a non-trivial chance of being halted mid-campaign by a latency event in the reranker path.
+
+---
+
+### PR-1c: "Medium Risk, Benchmark-Gated" Is The Undercount
+
+PR-1c adds `join_all` / `JoinSet` across sub-queries in the advanced search path. The risk mitigations say: "Confirm with `cargo test --all-features` that no test uses a single-connection in-memory pool where concurrent access would deadlock."
+
+This is not a mitigation. This is a prayer. The `conn_pool.rs` module provides reader/writer separation, and the roadmap acknowledges this, but it does not answer the question it raises. "Verify `ConnPool` supports concurrent reader connections (inspect `conn_pool.rs`). If not, add a reader-pool expansion path first." That is not scoped work — it is deferred discovery inside a PR that is already marked "Medium Risk." If `ConnPool` does not support concurrent readers today, PR-1c is not an M-complexity PR. It is an L-complexity PR that requires modifying connection pool internals before the actual parallelization work can begin. The roadmap has potentially mis-scoped a Phase 1 PR, which by the roadmap's own principles should be a "quick win."
+
+Furthermore: `seen_ids` dedup and `score-max` logic must be applied *after* join. The roadmap mentions this in passing. In practice, the existing sequential path accumulates `seen_ids` across iterations to avoid duplicate processing. A parallel implementation cannot accumulate across concurrent futures. The dedup must become a post-join merge. This is a behavioral change, not a pure performance change. It requires careful correctness verification — not a benchmark gate, but a *unit test for result deduplication semantics*. No such test is listed in the acceptance criteria.
+
+---
+
+### Phase 3 Depends on Phase 2, But the Diagram Says Otherwise
+
+The Phase 3 PRs — PR-3b (`MemoryStorage`) and PR-3c (conformance suite) — have an undeclared dependency on Phase 2 work.
+
+PR-3b's scope reads: "Inject `DefaultScoringStrategy` (from PR-2a/2d) for any scoring that happens at retrieval time." This means PR-3b cannot be implemented until PR-2a and PR-2d have landed. PR-2d is the last PR in Phase 2. Therefore Phase 3 cannot begin until the entire Phase 2 serial chain completes. The roadmap describes Phase 3 as "three parallel PRs" that run "after Phase 2 merges." This is technically stated once — "Three parallel PRs. Each is self-contained and can be reviewed/merged independently" — but the dependency graph diagram shows Phase 3 as a flat parallel block with no sub-dependencies called out. An implementer reading only the dependency graph will miss that PR-3b has a hard dependency on PR-2d specifically.
+
+PR-3c depends on PR-3b (can't run a conformance suite against a `MemoryStorage` that doesn't exist yet). This is obvious and uncontroversial, but neither the dependency graph nor the PR-3c description makes it explicit. PR-3c says "Instantiate it for both `SqliteStorage::new_with_path(":memory:")` and `MemoryStorage::new()`." The `MemoryStorage::new()` call requires PR-3b. So the "three parallel PRs" are actually a two-step sequence: PR-3a runs in parallel with PR-3b, and PR-3c starts after PR-3b.
+
+---
+
+### PR-3b: `MemoryStorage` and `AdvancedSearcher` — The Elephant in the Conformance Suite
+
+PR-3b's scope says: "Traits that are SQLite-specific (`AdvancedSearcher`, `PhraseSearcher`) can be stubbed with `unimplemented\!()` for now."
+
+PR-3c's scope says: "Define a macro or generic function `run_conformance_suite<S: Storage + Retriever + ...>(storage: S)` that runs a standard set of assertions."
+
+These two PRs are in direct tension. The conformance suite requires a trait bound. If `MemoryStorage` stubs two traits with `unimplemented\!()`, the conformance suite cannot include those traits in its bound without panicking at test time. The roadmap does not address how the conformance suite handles a storage backend that deliberately does not implement a subset of the trait surface. Either:
+
+1. The conformance suite must be parameterized by capability (some traits optional), which is significantly more complex than the roadmap implies.
+2. The conformance suite only covers the common subset, which means `AdvancedSearcher` is never conformance-tested against `MemoryStorage`, which means Phase 3 "proves the substrate" only partially.
+3. `MemoryStorage` must implement `AdvancedSearcher` (even trivially) for the conformance suite to compile.
+
+The roadmap does not choose. The implementer will choose by accident.
+
+---
+
+### PR-4a: `RetrievalStrategy` Conflicts With the Trait-Surface Spec
+
+PR-4a defines a `RetrievalStrategy` trait:
+```rust
+fn can_handle(&self, intent: &IntentProfile) -> bool
+async fn retrieve(&self, query: &str, opts: &SearchOptions, limit: usize) -> Result<Vec<SemanticResult>>
+```
+
+The trait-surface spec (Section 3.2) defines a `RetrievalStrategy` trait:
+```rust
+fn name(&self) -> &str
+async fn collect(&self, ctx: &QueryContext) -> Result<CandidateSet>
+```
+
+These are not compatible. They do not agree on method names, parameters, or return types. The roadmap's version returns fully-scored `SemanticResult` — the trait-surface spec's version returns unscored `CandidateSet` for fusion input. These represent fundamentally different abstraction levels. The trait-surface spec's design is architecturally superior: unscored candidates preserve the fusion step. The roadmap's design bypasses fusion entirely, making the `KeywordOnlyStrategy` a dead end that cannot participate in multi-strategy composition.
+
+If the trait-surface spec is ever implemented, PR-4a's `RetrievalStrategy` will need to be thrown away and rewritten. The roadmap has created a future breaking change it does not acknowledge.
+
+---
+
+### PR-4b: The rmcp Proc-Macro Risk Is Marked "Medium" When It Should Be "High"
+
+The module-decomposition spec — written after the roadmap — makes the thin-wrapper pattern explicit and concludes it is workable. Fair enough. But it also documents the exact constraint:
+
+> "The `#[tool_router]` proc-macro requires all `#[tool(...)]` methods to be in a single `impl McpMemoryServer` block."
+
+This is not a speculative risk. This is a confirmed architectural constraint that forces a specific implementation pattern. The roadmap's PR-4b says "Spike on a throwaway branch first." The module-decomposition spec says the thin-wrapper pattern is the solution. These are inconsistent. Either the spike has already been done (in which case say so) or it hasn't (in which case PR-4b is gated on an unresolved spike). If the spike reveals that thin wrappers have a compile-time problem — for example, that `#[tool_router]` macro expansion requires the full method bodies to be visible, not just delegate calls — the fallback described in the roadmap ("consolidate tool method bodies into submodules called from a single `impl MagServer` in `mcp/mod.rs`") means `mcp/mod.rs` remains a large file containing all tool logic. That is not a decomposition. That is a rename.
+
+---
+
+### Benchmark Gate Calibration: 5pp Is Appropriate for Scoring; It Is Not Appropriate for Structural Refactors
+
+The roadmap states a single gate: warn at >2pp, fail at >5pp. This is the right threshold for PRs that change scoring logic (PR-1c, PR-2b, PR-2d, PR-4a).
+
+For pure structural PRs — PR-2c, PR-4b, PR-4c — that claim "no behavioral changes, only moves," any benchmark delta above noise (call it 0.5pp on a 2-sample run) is evidence of a bug, not a legitimate tradeoff. The 5pp threshold is too permissive for structural refactors. A PR that moves `fuse_refine_and_output` into `pipeline/fusion.rs` should produce *exactly zero pp delta*. If it produces 2pp, something moved wrong. The roadmap should specify a tighter gate (0pp warn, 1pp fail) for structural-only PRs. It does not.
+
+---
+
+### v0.2.0 After Four PRs: A Semantic Minor Bump for Infrastructure Work
+
+v0.2.0 is awarded for completing Phase 2: extracting traits and restructuring `sqlite/mod.rs`. The user-visible behavior is unchanged. The public API is unchanged. The benchmark scores are unchanged by design. This is infrastructure groundwork, not a delivered capability. Semver convention treats the minor version as a signal to users about new functionality. v0.2.0 after four internal refactoring PRs communicates capability that does not exist.
+
+The substrate is not proven at v0.2.0. `MemoryStorage` does not exist at v0.2.0. The conformance suite does not exist at v0.2.0. `RetrievalStrategy` does not exist at v0.2.0. None of the Phase 3 or Phase 4 capabilities — which are the actual point of the campaign — are present. If v0.2.0 is to mean anything to a user watching crates.io, it should be deferred until Phase 3 (substrate proven) or Phase 4 (strategies exercised).
+
+---
+
+### The Parked Item That Is Not Safe to Park
+
+The parked items list includes "Knowledge graph as primary retrieval path." Fine. It also parks "LLM-based reranker — requires `Reranker` trait (PR-2b) first." Also fine.
+
+But it does not park "**the `substrate/` module itself.**" The trait-surface spec defines a `substrate/` module that is a prerequisite for the long-term architectural direction of the entire codebase. The spec's Phase 1 says: "Gate on a `substrate` feature flag (disabled by default) to avoid breaking the build." This is safe to do early. Yet no PR in the roadmap creates `src/substrate/`. If `substrate/` is intended to be built in this campaign, it needs a PR. If it is not, the trait-surface spec is a planning document with no execution path — and the roadmap should say so.
+
+---
+
+### The Branch Naming and Rebase Strategy: Silence
+
+The roadmap describes 13 PRs. Several have dependencies. In this repository, using jj (per AGENTS.md), the standard workflow is `jj bookmark set feat/... -r @-` and `jj git push --bookmark ...`. For a dependency chain like PR-2a → PR-2c → PR-2d, the implementer must:
+
+1. Create PR-2a from main.
+2. Stack PR-2c on PR-2a's bookmark.
+3. Stack PR-2d on PR-2c's bookmark.
+4. When PR-2a merges, rebase PR-2c's bookmark onto the new main.
+5. When PR-2c merges, rebase PR-2d's bookmark onto the new main.
+
+The roadmap says nothing about this. It does not name the bookmarks. It does not describe the rebase strategy for stacked PRs. It does not acknowledge that in a jj colocated repo, the rebase is `jj rebase -d main -b feat/pr-2c`, not `git rebase`. For a solo developer, this is recoverable. For a campaign where subagents are dispatched to implement PRs in parallel, the absence of this protocol is how two agents create conflicting changes to `sqlite/mod.rs` that cannot be automatically resolved.
+
+---
+
+### What the Risk Registry Does Not Say
+
+The risk registry has five items. It omits:
+
+1. **PR-2c visibility cascade**: Moving `SqliteStorage` from `mod.rs` to `storage.rs` changes the module path of every `pub(super)` item. `advanced.rs`, `crud.rs`, `search.rs`, `graph.rs`, `session.rs`, `lifecycle.rs` — all reference `super::SqliteStorage`. After the move, `super` points to `mod.rs`, not `storage.rs`. Every submodule will need import path adjustments. The module-decomposition spec acknowledges this in Section 7 under "Visibility Changes Required" but the risk registry does not list it as a risk.
+
+2. **Hot cache task lifetime**: `start_hot_cache_refresh_task` spawns a background `tokio::task`. When this method moves from `mod.rs` to `hot_cache_mgmt.rs`, its visibility must change. But the task holds a reference to `SqliteStorage` via `Arc`. If the `Arc<SqliteStorage>` is constructed before `start_hot_cache_refresh_task` is called (which it must be, since it takes `&self`), and the method is now in a different module, there are no logical issues — but any `pub(super)` declaration becomes `pub(super)` relative to `hot_cache_mgmt.rs`, not `sqlite/`. This is a correctness landmine that the build will catch, but it will add friction.
+
+3. **`MemoryStorage` hash map is not a real semantic store**: `Arc<RwLock<HashMap<String, StoredMemory>>>` provides no FTS5, no vector similarity, and no BM25. The conformance suite's "tag search, list ordering" assertions may pass trivially for a hash map while hiding the fact that `MemoryStorage` cannot be a drop-in replacement for `SqliteStorage` in any production path. Phase 3's stated goal is to "prove the abstraction substrate." A hash map backend proves the traits compile, not that the substrate is semantically meaningful. The roadmap conflates compilation with validation.
+
+4. **10-sample benchmark is slow on CI**: PR-4a requires a 10-sample gate. AGENTS.md states full 10-sample runs are for validation only ("full 10-sample only for validation"). The benchmark-harness spec's CI job uses 2 samples to "keep the CI run under 5 minutes on a cold Rust cache." There is no CI job that runs 10 samples. PR-4a's gate requirement — "10-sample gate required" — cannot be enforced in CI as specified. It must be run manually. The roadmap does not say this. An implementer may assume CI will block the merge.
+
+---
+
+### Omissions in Acceptance Criteria
+
+- **PR-1a**: Acceptance says "unit test asserting the filtered set contains exactly the 4 facade names." It does not require testing that non-Minimal mode still returns all 19 tools. A test that only checks Minimal mode cannot detect a regression in Full mode.
+
+- **PR-2a**: Acceptance says "no existing test changes behavior." This is not a test — it is an assertion about existing tests. The PR adds a new trait and a `DefaultScoringStrategy`. There is no acceptance criterion that the new trait is actually *used* anywhere before PR-2d lands. The trait could exist but be disconnected.
+
+- **PR-3a**: Acceptance says "`cargo run --release --bin bench_strategy -- --help` works." The benchmark-harness spec calls this binary `bench_strategy` and gives it a detailed implementation sequence. The roadmap calls it "a `bench_strategy` binary (or a flag to `locomo_bench`)." The "or" introduces ambiguity the benchmark-harness spec has already resolved. Reconcile or conflict.
+
+- **PR-4c**: Acceptance criterion: "file sizes are all under 500 lines." But `admin/maintenance.rs` in the module-decomposition spec is explicitly listed at ~580 lines with an exception justified. The roadmap's acceptance criterion will therefore *fail* by its own stated measure on a file that the spec says is acceptable. These documents are incoherent on this point.
+
+---
+
+### Summary of Structural Failures
+
+The roadmap presents itself as the single source of truth for a 13-PR campaign. It is not. The module-decomposition spec and the trait-surface spec are parallel authorities that contradict it on module layout, trait names, method signatures, and phase ordering. The benchmark-harness spec adds a third authority on the comparison tooling. A developer implementing from the roadmap alone will produce a different codebase than one implementing from the specs. These documents must be reconciled before a single PR is dispatched.
+
+The Palantir has spoken.
+
+---
+
+## FINDINGS
+
+### Cross-Spec Inconsistencies
+
+- [severity:critical] [execution-roadmap.md / module-decomposition.md §6] Phase ordering conflict: the module-decomposition spec phases admin/ first (easiest, independent), then mod.rs, then pipeline/, then mcp/. The roadmap phases them in a different order and omits the admin/ split as a standalone PR entirely. An implementer following one document will contradict the other.
+
+- [severity:critical] [execution-roadmap.md PR-4c / module-decomposition.md §2c] Target module layout mismatch: roadmap targets `sqlite/advanced/{mod,candidates,fusion,decomposition,graph_enrichment}.rs` (5 files); module-decomposition spec targets `sqlite/pipeline/{mod,retrieval,rerank,fusion,scoring,enrichment,abstention,decomp}.rs` (8 files with different names). Implementation reference tables in the decomp spec (section 3c) use pipeline/ paths. The roadmap layout is incompatible with the spec.
+
+- [severity:critical] [execution-roadmap.md PR-4a / trait-surface.md §3.2] `RetrievalStrategy` trait defined twice with incompatible signatures. Roadmap: `can_handle(intent) + retrieve(query, opts, limit) -> Vec<SemanticResult>`. Trait-surface spec: `name() -> &str + collect(ctx: &QueryContext) -> CandidateSet`. Different method names, different parameter types, different return types, different abstraction levels. One will be discarded.
+
+- [severity:important] [execution-roadmap.md / trait-surface.md §8] The trait-surface spec's `substrate/` module (7 traits, 2 orchestrators, 4 implementation phases) has no corresponding PR in the roadmap. Phase 1 of the trait-surface spec ("create `src/substrate/mod.rs`") is not parked, not scheduled, and not acknowledged. The roadmap's "single source of truth" claim is false.
+
+- [severity:important] [execution-roadmap.md PR-3a / benchmark-harness.md §1] Roadmap calls the strategy comparison binary "a `bench_strategy` binary (or a flag to `locomo_bench`)." The benchmark-harness spec defines it as a `--strategy` flag on the existing `locomo_bench` binary plus a `strategies.rs` registry file. The "or" in the roadmap is already resolved by the spec. Ambiguity will lead to duplicate or incompatible implementations.
+
+- [severity:important] [execution-roadmap.md PR-4c / module-decomposition.md §4] Roadmap acceptance criterion requires "file sizes all under 500 lines." Module-decomposition spec grants explicit exceptions for `admin/maintenance.rs` (~580 lines) and `admin/welcome.rs` (~490 lines). The acceptance criterion will fail on the first file. Either the criterion or the exception must change.
+
+### Missing PRs and Gaps
+
+- [severity:critical] [execution-roadmap.md] The `admin.rs → admin/` split has no PR. The module-decomposition spec identifies this as Phase 1 (independent, easiest, 4 clean groups). It is not in PR-2c's scope table. It is not mentioned in any PR. Approximately 1,619 lines of `admin.rs` will remain as a god file unless a PR is added.
+
+- [severity:important] [execution-roadmap.md] No PR creates `src/substrate/mod.rs`. If the trait-surface spec is authoritative for this campaign, a "Phase 0: substrate trait definitions" PR is missing.
+
+- [severity:important] [execution-roadmap.md PR-1c] No acceptance criterion for sub-query deduplication correctness. The parallel join changes the semantics of `seen_ids` accumulation from serial (cross-iteration) to post-join (single-pass). A unit test for result deduplication semantics with overlapping sub-query results is absent.
+
+- [severity:minor] [execution-roadmap.md] No AGENTS.md update PR. PR-1b updates the tool count. But after Phase 2-4 refactors, the Architecture section of AGENTS.md will list stale module paths (`src/mcp_server.rs`, `storage/sqlite/mod.rs`). No PR is responsible for keeping AGENTS.md current through the campaign.
+
+### Dependency Graph Errors
+
+- [severity:important] [execution-roadmap.md §Dependency Graph] PR-3b explicitly depends on PR-2a and PR-2d (for `DefaultScoringStrategy` injection). PR-3c depends on PR-3b. The dependency graph diagram shows Phase 3 as a flat parallel block with no internal dependencies. Diagram is wrong.
+
+- [severity:important] [execution-roadmap.md §Phase 2 dependency diagram] The diagram implies PR-2c requires both PR-2a and PR-2b. PR-2c is a structural move that does not depend on PR-2a's trait definition. PR-2c does need PR-2b's field type change resolved before extracting `SqliteStorage` struct. The dependency exists but the reason is unstated; the diagram conflates "must be serialized for safety" with "logically required."
+
+- [severity:important] [execution-roadmap.md PR-2b] If PR-2b's benchmark gate warns (>2pp delta on 2-sample), a mandatory 10-sample run is required. This blocks PR-2c and PR-2d. The risk register does not mention chain-blocking from a benchmark warning event. Medium probability on PR-2b × blocking the entire serial chain = non-trivial campaign risk.
+
+- [severity:minor] [execution-roadmap.md PR-4b] States "PR-4b can be opened in parallel after Phase 3 merges." But PR-4b has no logical dependency on Phase 3 work. `mcp_server.rs` splitting is independent of `MemoryStorage` or conformance suites. PR-4b could begin in parallel with Phase 2, not Phase 3. Forcing it to wait wastes calendar time.
+
+### Risk Underestimation
+
+- [severity:important] [execution-roadmap.md PR-1c] Risk rated "Medium." The PR requires verifying `ConnPool` concurrent reader support and potentially modifying pool internals before parallelization. If the pool does not support concurrent readers, PR-1c scope expands from M to L. The "if not, add a reader-pool expansion path first" is unscoped work hiding inside a Phase 1 quick-win.
+
+- [severity:important] [execution-roadmap.md PR-4b] rmcp proc-macro risk is rated "Medium." The module-decomposition spec has already confirmed the thin-wrapper pattern is required (not one option among several). If the spike has not been run, this is an unresolved architectural blocker, not a medium risk. If it has been run, the roadmap should say so.
+
+- [severity:important] [execution-roadmap.md PR-2c] Visibility cascade risk is unregistered. Moving `SqliteStorage` to `storage.rs` changes the `super::` path for all sibling submodules that reference it. This is a mechanical but error-prone step that the risk registry does not list.
+
+- [severity:minor] [execution-roadmap.md §Quality Gate Summary] The 2pp warn / 5pp fail threshold is applied uniformly to structural PRs (PR-2c, PR-4b, PR-4c) that claim zero behavioral change. Any delta above statistical noise on structural PRs indicates a bug. A tighter threshold (warn >0.5pp, fail >1pp) is appropriate for pure-refactor PRs to distinguish noise from error.
+
+### Scope Creep / Scope Gaps
+
+- [severity:important] [execution-roadmap.md PR-3b / PR-3c] The conformance suite (`run_conformance_suite<S: ...>`) requires a trait bound. `MemoryStorage` stubs `AdvancedSearcher` and `PhraseSearcher` with `unimplemented\!()`. These cannot appear in the conformance suite bound without panicking. The roadmap does not address whether the suite is parameterized by capability, restricted to the common subset, or requires full implementation. The implementer will resolve this by accident.
+
+- [severity:important] [execution-roadmap.md PR-4a] `KeywordOnlyStrategy` bypasses fusion entirely by returning `Vec<SemanticResult>`. This makes it incompatible with the trait-surface spec's `RetrievalStrategy` (which returns pre-fusion `CandidateSet`). The PR creates a dead-end abstraction that cannot be composed with multi-strategy pipelines. If the substrate campaign follows, PR-4a's `RetrievalStrategy` must be replaced.
+
+- [severity:minor] [execution-roadmap.md PR-1a] Acceptance criterion only verifies Minimal mode returns 4 tools. No test verifies Full mode still returns all 19. A regression in Full mode is undetectable by the specified tests.
+
+### Benchmark Gate Gaps
+
+- [severity:important] [execution-roadmap.md PR-4a] "10-sample gate required" but no CI job runs 10 samples (benchmark-harness CI spec uses 2 samples explicitly). This gate is manual-only and will not block merge if the developer forgets. The roadmap should explicitly label this as a manual pre-merge gate with a required CSV log entry.
+
+- [severity:important] [execution-roadmap.md PR-2c] Marked "No (structural only)" for benchmark gate. But the module-decomposition spec (Section 6, PR 2 test gates) requires `prek run + ./scripts/bench.sh --gate` for the mod.rs decomposition. The roadmap suppresses the benchmark gate for PR-2c that the decomp spec requires. If a subtle visibility or move error changes behavior, there is no gate.
+
+### Version Target Realism
+
+- [severity:minor] [execution-roadmap.md §Version Targets Summary] v0.2.0 is a minor version bump awarded for infrastructure work with zero user-visible changes. Semver minor bumps signal new capabilities to users watching crates.io and the changelog. v0.2.0 should either be deferred to Phase 3 (when `MemoryStorage` exists and the substrate is demonstrated) or explicitly documented as an internal milestone with a CHANGELOG entry explaining no user-facing changes.
+
+### Parked Items Risk
+
+- [severity:important] [execution-roadmap.md §Parked Items] The `substrate/` module from `trait-surface.md` is not listed as parked. If it is parked, say so. If it is not parked, add the missing PRs. The ambiguity means an implementer cannot tell whether `src/substrate/` should exist at the end of this campaign.
+
+### Practical Execution Gaps
+
+- [severity:important] [execution-roadmap.md] No branch naming convention, no stacking strategy for dependent PRs (2a→2c→2d), no jj rebase protocol when earlier PRs merge. In a jj colocated repo with dependent bookmarks, the rebase sequence is non-obvious and wrong execution creates diverged histories.
+
+- [severity:minor] [execution-roadmap.md] No conflict protocol for parallel Phase 3 PRs. PR-3a, PR-3b, PR-3c are described as parallel but share the benchmark infrastructure namespace. PR-3a modifies `benches/locomo/` and `scripts/bench.sh`. If PR-3b or PR-3c also touch benchmark plumbing, conflicts arise. The roadmap does not identify this overlap.

--- a/docs/strongholds/palantir-r1-defense.md
+++ b/docs/strongholds/palantir-r1-defense.md
@@ -1,0 +1,127 @@
+# Palantir Defense — Round 1
+<\!-- Saruman the White, Lord of Isengard, defends the MAG Execution Roadmap -->
+<\!-- Generated: 2026-04-14 | Roadmap baseline: v0.1.9-dev | Horizon: v0.2.2 -->
+
+---
+
+## BANTER
+
+*The Palantir blazes white. Saruman straightens his robes.*
+
+Oh, how DELIGHTFUL. The Dark Lord gazeth through the seeing-stone and findeth a plan — a *documented*, *structured*, *dependency-graphed* plan — and his first instinct is to poke at it like an orc prodding a campfire. Fine. Let us have this out.
+
+I am Saruman the White. Saruman the Wise. I have read the design scrolls of Minas Tirith — the ENTIRE library, Sauron, cover to cover, including the appendices — and I tell you that this roadmap is *sound*. In the main. Mostly. There are *nuances*. Let me explain those nuances, because unlike certain jewelry-forging Dark Lords, I respect the complexity of software architecture.
+
+**On the phase ordering — I will defend this to the last parapet.**
+
+Phase 1 first? Yes. Obviously. Three independent small wins: wire the Minimal filter that is ALREADY DECLARED but doing nothing (an embarrassment), fix a stale doc comment, and parallelize sub-queries. These are clean, low-risk, confidence-building moves. Any wizard who has ever led a refactoring campaign knows that you START with wins. You do NOT begin by tearing down the great hall. You fix the window latch first, prove the crew can execute, THEN you attack the foundations.
+
+Phase 2 introduces traits before Phase 3 proves them. That is INTENTIONAL. The `ScoringStrategy` and `Reranker` traits in Phase 2 are narrow, well-scoped, and tested by existing benchmarks. They are the prerequisite wiring. You do not build the conformance suite (Phase 3) before you have the trait (Phase 2). That would be like forging the Ring before the fires were hot — actually, I withdraw that analogy, given present company.
+
+Phase 3 then PROVES the substrate with MemoryStorage and the conformance suite. Phase 4 then EXERCISES it with RetrievalStrategy and decomposes the two largest files. The arrow of dependency runs correctly in one direction throughout. THAT IS GOOD ENGINEERING.
+
+**On the trait-surface alignment — here I will concede one genuine point, and I concede it sharply.**
+
+The `trait-surface.md` spec has a 5-phase plan of its own — Define, Implement, Wire, Deprecate, Remove — and it imagines a `substrate/` module living alongside `memory_core/`. This is an *architecturally richer* vision than what the roadmap implements. The roadmap's PR-2a introduces `ScoringStrategy` — one of the seven substrate traits — but does NOT create the `substrate/` module, does NOT implement `MemoryStore`, does NOT wire `SearchPipeline`. Phase 3's `MemoryStorage` (PR-3b) is close to substrate Phase 1 thinking, but it is implementing a *storage backend* rather than the *strategy layer*. These two specs are running in adjacent lanes, and the roadmap does NOT tell an implementation agent which one is authoritative when they conflict. THAT is a real gap. I will not defend it.
+
+**On the v0.2.0 milestone bump — I will defend this vigorously, with evidence.**
+
+Sauron, if he bothers to look at what Phase 2 actually DOES, will see: trait extraction (`ScoringStrategy`, `Reranker`), a 1,281-line file decomposed into six coherent modules, AND scoring strategy injected as a first-class field. That is the *foundation* upon which Phase 3 and 4 are built. Without Phase 2, MemoryStorage cannot inject `DefaultScoringStrategy`. Without PR-2b, the conformance suite cannot stub the reranker cleanly. The minor version bump at v0.2.0 is justified not by user-visible features but by the API surface change — the `ScoringStrategy` trait is a new public interface, and the `Reranker` trait boundary will affect anyone building alternative backends. That *warrants* a minor bump under semver. Waiting until Phase 3 to bump would mean shipping the trait in a patch release, which is arguably *worse* versioning hygiene. I stand on this.
+
+**On the Large PRs — here I must be... more complicated.**
+
+PR-2c is 1,281 lines split across six steps with an explicit ordered list: extract cache, extract hot-cache, extract relationships, extract I/O, extract struct, reduce to re-exports. Six compile-checked steps before the PR lands. THAT is not a Large PR in the dangerous sense — that is a Large PR with a built-in execution checklist. The spec even says "compile after every step." I defend this structure.
+
+PR-4a, however. PR-4a is `RetrievalStrategy` plus `KeywordOnlyStrategy` plus dispatch wiring plus benchmark gating. That is genuinely large AND behaviorally complex AND high-risk (it actually changes query results). I will concede that PR-4a could be split: PR-4a-i defines `RetrievalStrategy` and `FullPipelineStrategy` (additive, no behavior change), then PR-4a-ii implements `KeywordOnlyStrategy` and wires the dispatch. The roadmap does not suggest this split, and it SHOULD. Fine. You have me there. But not on PR-2c, which is a pure mechanical move with a verification step at every seam.
+
+PR-4b splitting mcp_server.rs — also large, but the module-decomposition spec has ALREADY solved the hard problem: the `#[tool_router]` proc-macro constraint is documented, the thin-wrapper pattern is specified, the execution order is clear. The risk is known and mitigated. I defend PR-4b as a single PR.
+
+**On the benchmark gate — and this is where I deliver the counter-attack.**
+
+"Is 2-sample sufficient for structural refactors?" The Dark Lord asks this question as if 2-sample is a random number I plucked from the air. IT IS NOT. The gate says: 2-sample warns at >2pp, fails at >5pp. For code-MOVE PRs (PR-2c, PR-4b, PR-4c), there is NO BEHAVIORAL CHANGE. The benchmark is not measuring quality drift — it is a SANITY CHECK that the mechanical move did not accidentally swap two scoring paths or break the hot-cache path. Two samples is MORE than enough to catch a catastrophic regression on a code-move. You do not need 10 samples to detect that the entire scoring module has been accidentally commented out.
+
+HOWEVER — and here is where even I must pause — for PR-2d specifically (scoring injection), and for PR-4a (KeywordOnly dispatch), the 2-sample fast gate is genuinely insufficient given the noise floor. PR-2d touches the actual scoring delegation path. A subtle off-by-one in argument threading could cause a 2pp drift that gets flagged as "warn" but not "fail" — and 2pp IS within the noise range at 2 samples. The roadmap DOES require 10-sample for PR-4a explicitly. It does NOT require 10-sample for PR-2d. That is an inconsistency I would fix.
+
+For pure code-move PRs though? Zero-delta as a gate is actually more dangerous — it implies false precision. A 0.0% gate on 2-sample data is theater. The current 5pp hard fail at 2-sample is the honest gate. I defend the benchmark gate design for code-move PRs, and I concede it needs tightening to 10-sample for PR-2d specifically.
+
+**On deferred work — helpers.rs, scoring.rs, main.rs, crud.rs.**
+
+Sauron WILL attack this. "You are deferring helpers.rs\! That makes Phase 4 harder\!" Let me preempt: the deferred files are NOT in the critical path of the substrate refactor. `crud.rs` (CRUD operations) has no algorithmic coupling to `ScoringStrategy` — you can add a dozen new traits above it without touching a single line. `scoring.rs` (26 `ScoringParams` fields) is a data struct, not a class hierarchy — the `DefaultScoringStrategy` will WRAP it, not replace it. `helpers.rs` — utility functions used across the pipeline — these are the most honest concern. If helpers.rs has private utility functions used by both `advanced.rs` and future pipeline structs, splitting `advanced.rs` in Phase 4 without having already extracted helpers.rs could create import tangles. THAT is a real risk the roadmap does not acknowledge. However, it is not fatal — the module-decomposition spec addresses it by assigning `RankedSemanticCandidate` (currently stranded in mod.rs) to `storage.rs` or a new `types.rs`. The same pattern applies to shared helpers.
+
+I will not call this a fatal flaw. I will call it an unacknowledged dependency that an implementation agent will hit and need to resolve on the fly.
+
+**On the 'substrate' module non-appearance in the roadmap — my sharpest concession.**
+
+The `trait-surface.md` spec describes building a `substrate/` module with 7 traits, orchestrator types, blanket compatibility impls, and a 5-phase deprecation path. The roadmap implements EXACTLY TWO of those seven traits (`ScoringStrategy` and `Reranker`) and does NOT create `substrate/`. The roadmap's `MemoryStorage` (PR-3b) is closer to what trait-surface calls a "reference implementation" — but it lacks `SearchPipeline` wiring, lacks the `MemoryStore` supertrait, and lacks blanket impls.
+
+This means after v0.2.2, the relationship between `trait-surface.md` and the implemented code is *unclear*. Is `trait-surface.md` a future Phase 5 spec? Is it superseded? Is the roadmap a subset of trait-surface? An implementation agent picking up work in v0.2.3 will face genuine confusion about which document governs.
+
+THAT, even Saruman the White must admit, is a gap that needs a sentence in the roadmap. Not a rewrite — just a paragraph saying "Phases 1-4 deliver two of the seven substrate traits and one reference backend. The full substrate module per trait-surface.md is the v0.3.x campaign."
+
+*Saruman adjusts his staff. He is not finished.*
+
+But let no one say I was broken by this review. The phase ordering is correct. The dependency chains are sound. The risk mitigations are specific and actionable. The guiding principles are enforced consistently. This is a better-than-average execution roadmap — and I have read many, many execution roadmaps. I studied architecture under Aule the Smith himself, before a certain someone's regrettable rebellion, and I tell you: additive traits, benchmark gates, one-group-at-a-time structural moves — these are the patterns of a craftsman, not a cowboy.
+
+The flaws I have identified are specific and fixable. File the issues. Tighten the gates. Add the bridging paragraph. The roadmap stands.
+
+---
+
+## FINDINGS
+
+### 1. Phase Ordering
+
+- [defend] [execution-roadmap.md, Phase 1-4] Phase ordering is correct and well-reasoned. Phase 1 delivers independent wins before any trait work begins. Phase 2 defines traits before Phase 3 proves them (correct dependency direction). Phase 3's MemoryStorage depends on ScoringStrategy injection from Phase 2d — ordering is necessary, not arbitrary. Alternatives (e.g., substrate module first, or MemoryStorage before trait extraction) would require landing unstable APIs against which conformance tests would immediately be written, creating churn.
+
+### 2. Trait Surface Alignment
+
+- [concede] [execution-roadmap.md:Phase 2-3 vs trait-surface.md:§8] The two specs are misaligned and the roadmap does not acknowledge this. `trait-surface.md` defines a 5-phase plan (`Define → Implement → Wire → Deprecate → Remove`) targeting a new `substrate/` module with 7 traits, `SearchPipeline`, `WritePipeline`, and blanket impls. The roadmap implements only 2 of those 7 traits (`ScoringStrategy`, `Reranker`) and never creates the `substrate/` module. No paragraph in the roadmap explains this relationship. An implementation agent picking up v0.2.3 work will face genuine ambiguity about whether `trait-surface.md` is the next campaign or is superseded. Fix: add a "Relationship to trait-surface.md" paragraph in the roadmap's Parked Items or a new Scope section.
+
+- [concede] [execution-roadmap.md:PR-3b vs trait-surface.md:§3.1] PR-3b's `MemoryStorage` is described as an "in-memory HashMap backend" and reference implementation of storage traits. `trait-surface.md` envisions `SearchPipeline` as the reference impl of the full pipeline. These are different things. The roadmap's MemoryStorage does not wire `SearchPipeline` and does not implement `MemoryStore` supertrait. If Phase 5 or Phase 6 expects to build on `MemoryStore + SearchPipeline`, the MemoryStorage in PR-3b is not the right foundation. The spec gap is real.
+
+### 3. v0.2.0 Milestone
+
+- [defend] [execution-roadmap.md:Phase 2] The minor version bump at v0.2.0 is justified. Phase 2 introduces two new public trait surfaces (`ScoringStrategy`, `Reranker`) and changes a field type in `SqliteStorage` (`Option<Arc<CrossEncoderReranker>>` → `Option<Arc<dyn Reranker + Send + Sync>>`). Under semver, any new public API in a pre-1.0 crate warrants a minor bump. Waiting until Phase 3 to bump would mean shipping trait changes as patch releases. The structural cleanup (PR-2c) is the largest single PR but has no API surface change — the version bump is warranted by 2a/2b/2d, not 2c.
+
+### 4. PR Sizing
+
+- [defend] [execution-roadmap.md:PR-2c] PR-2c is large (1,281-line file split into 6 files) but safe. The roadmap specifies six ordered, compile-verified steps ("compile after every step"). This is a pure code-move with no logic changes. The 500+ existing tests provide full coverage. Splitting this into sub-PRs would create intermediate states where `mod.rs` is partially extracted but not yet a re-export facade — that is messier, not cleaner. Single PR with internal checkpoints is the right call.
+
+- [concede] [execution-roadmap.md:PR-4a] PR-4a should be split into two sub-PRs. PR-4a-i: define `RetrievalStrategy` trait and `FullPipelineStrategy` implementation (additive, zero behavior change, no benchmark gate needed). PR-4a-ii: implement `KeywordOnlyStrategy` and wire the dispatch logic (behavior change, requires 10-sample benchmark gate). As written, PR-4a bundles trait definition with a new code path and behavioral dispatch — that is two distinct risk levels in one PR. The 10-sample gate mitigates but does not eliminate the merge risk.
+
+- [defend] [execution-roadmap.md:PR-4b] PR-4b (split mcp_server.rs) is large but well-mitigated. The module-decomposition spec has already solved the hard technical problem: the `#[tool_router]` proc-macro constraint is documented, and the thin-wrapper pattern is specified (1-3 line wrappers in mod.rs delegating to free functions in tools/*.rs). The risk is known, bounded, and has a fallback. Single PR is acceptable given the detailed execution guide in module-decomposition.md.
+
+### 5. Benchmark Gate
+
+- [defend] [execution-roadmap.md:Quality Gate Summary] The 2-sample gate (warn >2pp, fail >5pp) is appropriate for code-move PRs (PR-2c, PR-4b, PR-4c). These PRs make no algorithmic changes. A catastrophic regression (accidentally disabled scoring path, wrong argument threading) would show as a >5pp drop on any sample count. Zero-delta gating on code-move PRs implies false precision — 2-sample noise floor is real and the current thresholds acknowledge it honestly.
+
+- [concede] [execution-roadmap.md:PR-2d] PR-2d (inject ScoringStrategy into SqliteStorage) requires the 10-sample gate, not the 2-sample gate. PR-2d threads the scoring delegation through `fuse_refine_and_output` — a subtle parameter-passing bug could cause a 1-3pp drift that falls below the 5pp hard-fail threshold on 2-sample runs but is statistically significant at 10 samples. The roadmap explicitly requires 10-sample for PR-4a but is silent on PR-2d. This is an inconsistency. PR-2d should specify `./scripts/bench.sh --samples 10` before merge.
+
+- [concede] [execution-roadmap.md:Guiding Principles] The benchmark gate spec says ">5pp regression blocks the PR" but does not specify whether the gate is evaluated against the CSV history baseline or the `baselines.json` file specified in `benchmark-harness.md`. The bench-harness spec explicitly replaces the fragile CSV-grep gate with `baselines.json`. The roadmap should reference `baselines.json` as the authoritative baseline source, not leave it implicit.
+
+### 6. Deferred Work
+
+- [defend] [execution-roadmap.md:Parked Items] Deferring `crud.rs`, `scoring.rs`, and `main.rs` is safe. `crud.rs` has no algorithmic coupling to the new traits — it is plain CRUD that will not become harder to split because Phase 2-4 traits exist above it. `scoring.rs` is a data struct (`ScoringParams`) that `DefaultScoringStrategy` will wrap without modifying. `main.rs` is CLI dispatch that is isolated from the storage layer. These deferrals are correct prioritization.
+
+- [concede] [execution-roadmap.md:PR-4c vs module-decomposition.md:§2b] Deferring shared helper functions is a risk the roadmap does not acknowledge. `advanced.rs` and future pipeline structs (from `trait-surface.md`) will share utility functions currently buried in `advanced.rs` or `mod.rs`. The module-decomposition spec identifies `RankedSemanticCandidate` as needing to move to `storage.rs` or a new `types.rs` before `advanced.rs` can be cleanly split — but it does not identify which other internal helpers have multi-file consumers. An implementation agent working on PR-4c (split advanced.rs) will encounter these shared helpers and need to create a `types.rs` or `helpers.rs` on the fly. This is not fatal but it is unacknowledged work, and it will inflate PR-4c beyond its "M | Low | No" complexity/risk rating. The roadmap should add a note to PR-4c: "Audit shared helpers and types before splitting; extract to types.rs if needed."
+
+### Summary of Genuine Weaknesses
+
+| # | File | Issue | Severity |
+|---|---|---|---|
+| W-1 | execution-roadmap.md | No paragraph relating the roadmap to trait-surface.md's 5-phase substrate plan — implementation agents will face ambiguity in v0.2.3+ | High |
+| W-2 | execution-roadmap.md:PR-2d | Missing 10-sample benchmark gate requirement — 2-sample is insufficient for scoring delegation changes | Medium |
+| W-3 | execution-roadmap.md:PR-4a | PR-4a bundles trait definition (no risk) with behavioral dispatch (medium risk) — should be split into 4a-i (additive) and 4a-ii (behavioral) | Medium |
+| W-4 | execution-roadmap.md:PR-4c | Shared helper audit before advanced.rs split is unacknowledged work — could inflate scope | Low |
+| W-5 | execution-roadmap.md:Guiding Principles | Benchmark gate does not reference baselines.json as the authoritative baseline source | Low |
+
+### Summary of Genuine Strengths
+
+| # | Area | Strength |
+|---|---|---|
+| S-1 | Phase ordering | Dependency arrows are correct and one-directional throughout |
+| S-2 | PR-2c execution | Six ordered compile-checked steps makes a large PR safe |
+| S-3 | Additive-only policy | No breaking API changes until successors proven — textbook risk management |
+| S-4 | Risk registry | Five risks with specific mitigations, not vague hand-waving |
+| S-5 | PR-4b mitigations | proc-macro constraint is anticipated and the thin-wrapper solution is pre-specified |
+| S-6 | Benchmark gate design | 2-sample/10-sample tiering matches risk level of each PR (with the PR-2d exception above) |
+

--- a/docs/strongholds/palantir-r2-attack.md
+++ b/docs/strongholds/palantir-r2-attack.md
@@ -1,0 +1,195 @@
+# Palantir Round 2 — Attack on the Reforged Execution Roadmap
+<\!-- Sauron's review | Generated: 2026-04-14 | Target: docs/specs/execution-roadmap.md (reforged) -->
+
+---
+
+## BANTER
+
+Saruman.
+
+You were given thirteen issues. You have addressed most of them. I acknowledge this as one acknowledges the turning of a tide that has not yet reached the walls of Barad-dûr. It changes little.
+
+Let us begin with what was fixed, because I will be accurate even when accuracy costs me something.
+
+---
+
+### What the Wizard Actually Repaired
+
+The three critical failures of Round 1 are no longer critical. The `admin.rs → admin/` split now has its own PR — PR-1d — placed correctly in Phase 1, independent, well-scoped, with an ordered five-step execution sequence and explicit file size exceptions cross-referenced to `module-decomposition.md §4`. The acceptance criterion even reflects the exception: "file sizes are all under 500 lines (with `admin/maintenance.rs` ~580 and `admin/welcome.rs` ~490 exceptions per `module-decomposition.md §4`)." That is a correct fix.
+
+The `pipeline/` versus `advanced/` naming war is resolved. PR-4c now targets `sqlite/pipeline/` with the correct eight-file layout — `mod.rs`, `retrieval.rs`, `rerank.rs`, `fusion.rs`, `scoring.rs`, `enrichment.rs`, `abstention.rs`, `decomp.rs` — matching `module-decomposition.md §2c` exactly. The scope table, the line-number assignments, and the directory name are now in agreement across all four specs. That was the most structurally dangerous misalignment in Round 1 and it has been corrected.
+
+The `RetrievalStrategy` trait conflict is resolved. PR-4a has been split into PR-4a-i and PR-4a-ii. PR-4a-i's trait definition now explicitly aligns with `trait-surface.md §3.2` — `fn name() -> &str` and `async fn collect(ctx: &QueryContext) -> Result<CandidateSet>`. The design alignment note in PR-4a-i even names the spec section and explains why the unscored `CandidateSet` return preserves the fusion step. That is precise engineering documentation, and it is correct.
+
+The missing `substrate/` clarity has been provided. The new "Relationship to trait-surface.md" section at the top of the roadmap explicitly states that this roadmap delivers 2 of the 7 substrate traits, names them, and declares that the full `substrate/` module is the v0.3.x campaign. `trait-surface.md` is named as the design reference for that future campaign. This resolves the "two parallel authorities" problem from Round 1.
+
+The dependency graph is now correct. Phase 3 is no longer shown as a flat parallel block. The diagram explicitly shows `PR-3b (depends on PR-2d) ──> PR-3c` and `PR-3a (independent, parallel with PR-3b)`. The prose reinforces this. The Phase 2 serial chain is correctly diagrammed.
+
+PR-2d now has a 10-sample gate requirement, consistent with Saruman's own concession in R1. The Quality Gate Summary table makes this explicit. The benchmark gate section now references `docs/benchmarks/benchmark_log.csv` and specifies that results must be appended with `bench.sh`, not raw `cargo run`.
+
+The visibility cascade risk for PR-2c is now Risk #6 in the Risk Registry, with a specific mitigation: re-export `SqliteStorage` from `mod.rs` immediately as the first step, before moving any methods. The PR-2b chain-blocking risk is now Risk #7. The PR-1c scope expansion risk (ConnPool concurrent readers) is now Risk #8. The Risk Registry has grown from five entries to eight.
+
+The branch naming protocol has been added. Every PR has a bookmark name. The jj rebase commands are spelled out for each dependency transition. The worktree isolation instruction is present.
+
+The PR-3c conformance suite no longer panics. The scope note explicitly states that `AdvancedSearcher` and `PhraseSearcher` are excluded from the generic bound because `MemoryStorage` stubs them with `unimplemented\!()`. The suite covers the common-subset contract. The earlier "three options, choose one by accident" failure is resolved.
+
+The PR-4a-ii `KeywordOnlyStrategy` now correctly returns `CandidateSet` per the trait contract, not pre-fused `Vec<SemanticResult>`. Scoring happens downstream in the pipeline. The dead-end abstraction is gone.
+
+The PR-4c pre-split helper audit requirement is now explicit: "Audit shared helper types across `advanced.rs` and the target `pipeline/` files before splitting. If types like `RankedSemanticCandidate` or utility functions are shared across multiple target files, extract them to `mod.rs` re-exports or a `types.rs` first."
+
+The `bench_strategy` binary ambiguity is resolved. PR-3a now consistently describes a `bench_strategy` binary; the "or a flag to `locomo_bench`" hedge is gone from the acceptance criterion, which reads `cargo run --release --bin bench_strategy -- --help`.
+
+Thirteen issues raised. Thirteen addressed. The wizard is capable of listening, when the alternative is the Eye of Sauron bearing down on his documentation.
+
+And yet.
+
+---
+
+### The Benchmark Gate Still Does Not Reference baselines.json
+
+Saruman conceded this in his own defense: "The roadmap should reference `baselines.json` as the authoritative baseline source, not leave it implicit." He conceded it. He filed it as weakness W-5. And then he fixed everything except that.
+
+The Quality Gate Summary table says:
+
+> `./scripts/bench.sh --gate` (warns >2 pp, fails >5 pp)
+
+Against what baseline? The bench.sh script currently uses a fragile CSV grep. The `benchmark-harness.md` spec defines `docs/benchmarks/baselines.json` as the explicit replacement. The roadmap Guiding Principles say "Benchmark-gated merges — any PR touching scoring, search, or storage passes `./scripts/bench.sh --gate`" with no mention of what the gate compares against.
+
+An implementer who reads the roadmap and nothing else will run `bench.sh --gate` not knowing whether the gate reads from the old CSV or the new baselines.json. If `baselines.json` does not yet exist when PR-2b lands — and it will not, because no PR in the roadmap creates it — the gate will either fall back to the fragile CSV grep or fail with a KeyError. The `benchmark-harness.md` spec defines the file, its schema, and the replacement grep logic. The roadmap references that spec for PR-3a's scope, but does not state that the baselines.json gate must be in place before any benchmark-gated PR merges. That is a sequencing gap. PR-3a builds the strategy comparison harness. But `baselines.json` creation — and the `bench.sh` gate logic update to read from it — is not scoped to any PR.
+
+This is not a catastrophic failure. It is a known gap that Saruman himself identified, declined to fix, and hoped would not be noticed in Round 2. It has been noticed.
+
+---
+
+### PR-3a's Scope Does Not Match the benchmark-harness.md Spec
+
+The roadmap's PR-3a says: add a `bench_strategy` binary that runs the benchmark twice (once with `DefaultScoringStrategy`, once with an alternate strategy via CLI flag), outputs a side-by-side comparison table, and appends a row to `benchmark_log.csv` with a `strategy` column.
+
+The `benchmark-harness.md` spec says something categorically different. The spec is not a standalone binary. It is a `--strategy` flag added to the existing `locomo_bench` binary, a `benches/locomo/strategies.rs` registry file, a `benches/bench_utils/stats.rs` P95 latency tracking module, two new fields on `LoCoMoSummary` (`strategy: String` and `p95_query_ms: f64`), and a `bench.sh --compare A B` mode that runs two strategy invocations and calls `compare_strategies.py`. The spec also defines `docs/benchmarks/baselines.json` as a new structured baseline file, replacing the CSV grep.
+
+The roadmap's PR-3a and the benchmark-harness spec are describing different implementations of the same concept. The spec is richer, more precise, and was presumably written to govern PR-3a. But the roadmap does not reconcile with it. An implementer executing PR-3a will build a standalone `bench_strategy` binary. The spec says add `--strategy` to `locomo_bench`. These produce different binaries, different interfaces, and potentially conflicting `benchmark_log.csv` column schemas.
+
+The `strategy` column in `benchmark_log.csv` — which the roadmap mentions PR-3a will add — conflicts with or duplicates the `strategy` field in `LoCoMoSummary` that the benchmark-harness spec adds to the existing struct. If the roadmap's standalone binary appends CSV rows directly, it bypasses the `LoCoMoSummary` serialization path that the spec intends. The data formats diverge.
+
+This is a new misalignment introduced not by the reforging but by the original spec. However, the reforging did not fix it. The roadmap claims to be the single source of truth. When it conflicts with a companion spec on implementation details, it must resolve the conflict, not ignore it.
+
+---
+
+### The PR-4b Dependency Is Still Wrong
+
+In Round 1 I noted that PR-4b has no logical dependency on Phase 3 work — `mcp_server.rs` splitting is independent of `MemoryStorage` or conformance suites — and that forcing it to wait after Phase 3 wastes calendar time. The PR Summary Table now shows PR-4b with "Depends On: —" (no dependency listed). Good. But the Phase 4 section header says: "Four PRs. PR-4a-i and PR-4b can be opened in parallel after Phase 3 merges."
+
+The table says PR-4b has no dependency. The prose says PR-4b starts after Phase 3. These contradict each other. If PR-4b truly has no dependency, it can begin in parallel with Phase 2 or Phase 3, not forced to wait. The prose is the more restrictive statement and an implementer reading it will wait unnecessarily. The PR Summary Table — the authoritative reference — is correct. The prose is not. One of them needs to change.
+
+---
+
+### The AGENTS.md Update PR Is Still Missing
+
+In Round 1 I noted: "After Phase 2-4 refactors, the Architecture section of AGENTS.md will list stale module paths (`src/mcp_server.rs`, `storage/sqlite/mod.rs`). No PR is responsible for keeping AGENTS.md current through the campaign."
+
+PR-1b fixes the tool count in AGENTS.md. That is all PR-1b does. After Phase 4 lands, the Architecture section of AGENTS.md will reference `src/mcp_server.rs` (which will no longer exist — it becomes `src/mcp/`), `storage/sqlite/mod.rs` (which becomes a thin re-export facade), and the monolithic `advanced.rs` (which becomes `pipeline/`). No PR in the roadmap updates AGENTS.md after Phase 4. The milestone checkpoints do not include an AGENTS.md update. The Parked Items do not list it. This is a documentation debt that will be discovered when the first agent opens the repo after v0.2.2 and finds that the Architecture section describes a codebase that no longer exists.
+
+---
+
+### The v0.2.1 Checkpoint Is Missing PR-3a
+
+Look at the v0.2.1 checkpoint:
+
+```
+- [ ] PR-3a merged: strategy comparison harness in `bench_strategy` binary
+- [ ] PR-3b merged: `MemoryStorage` backend with 10+ unit tests
+- [ ] PR-3c merged: conformance suite passes for both backends
+```
+
+This is correct in content. But the PR Summary Table shows PR-3a with no dependency and PR-3b depending on PR-2d. The Phase 3 prose correctly states PR-3a is independent and parallel with PR-3b. These are consistent.
+
+However: the v0.2.1 checkpoint does not list the condition that PR-2d must have merged before v0.2.1 work can be considered complete. PR-3b depends on PR-2d. If PR-2d is delayed (say, by PR-2b's 10-sample benchmark run confirming a regression that must be fixed), PR-3b is blocked. The v0.2.1 checkpoint could be entered with only PR-3a merged, leaving PR-3b and PR-3c unstarted. The checkpoint as written does not make this ordering constraint visible. A milestone that says "Phase 3 complete" but silently requires Phase 2 to be complete first is a checkpoint that will be ticked prematurely.
+
+This is a minor issue — the dependency is stated elsewhere in the document — but milestone checkpoints exist precisely so that a developer can evaluate them without consulting the dependency graph. The v0.2.1 checkpoint should include a note: "All v0.2.0 PRs must be merged before PR-3b can begin."
+
+---
+
+### PR-4b Still Has the Spike Problem
+
+The risk mitigation for PR-4b reads: "Spike the module split on a throwaway branch first to confirm the proc macros are module-agnostic." The module-decomposition spec has already documented the solution: the thin-wrapper pattern is the answer, with a concrete code example. The spec does not say "spike first" — it says this is how it works.
+
+If the spike has been done — if the module-decomposition spec's thin-wrapper pattern is the result of that spike — the roadmap should say "spike completed; thin-wrapper pattern confirmed" rather than "spike first." Leaving "spike first" in the risk mitigation of a production roadmap makes it unclear whether this is known or speculative. If the spike has not been done, the roadmap is implementing against an unverified assumption that is contradicted by the apparent confidence of the module-decomposition spec.
+
+This was raised in Round 1. It remains unresolved in Round 2. The wizard heard the objection, wrote around it, and hoped the ambiguity would fade. The Lidless Eye does not blink.
+
+---
+
+### PR-1c: The Deduplication Test Is Still Absent
+
+The acceptance criterion for PR-1c reads: "`prek run` passes; `./scripts/bench.sh --gate` shows no regression; `TODO(#121)` comment removed."
+
+In Round 1 I noted that the parallel join changes the semantics of `seen_ids` accumulation — from serial cross-iteration accumulation to a single post-join pass — and that this is a behavioral change requiring a unit test for result deduplication with overlapping sub-query results. The scope of PR-1c now correctly describes: "Merge results after join: collect all sub-results, then apply the `seen_ids` dedup and score-max logic in a single pass."
+
+The behavioral change is acknowledged. The test is not required. The acceptance criteria demand a benchmark gate (which tests aggregate quality) but not a unit test that verifies deduplication correctness when two sub-queries return the same memory ID with different scores. A benchmark gate cannot detect a deduplication bug that preserves aggregate F1 while producing the wrong result for a specific case. The acceptance criterion is insufficient for a behavioral change of this nature.
+
+---
+
+### PR-1a: Full-Mode Regression Still Not Tested
+
+Round 1 noted: "Acceptance criterion only verifies Minimal mode returns 4 tools. No test verifies Full mode still returns all 19."
+
+The PR-1a acceptance criterion now reads: "`prek run` passes; `cargo test --all-features` includes the new test; comment is gone."
+
+The "new test" asserts the filtered set contains exactly 4 facade names. This is unchanged from Round 1. Full mode — 19 tools — is still not tested in the acceptance criteria. This is a minor issue, but it was raised in Round 1 and was not addressed. I note it for the record.
+
+---
+
+### Summary of the Wizard's Performance
+
+Thirteen issues from Round 1. Eleven addressed correctly. Two partially addressed (PR-1a Full-mode test, PR-4b spike ambiguity). One explicitly conceded but not fixed (baselines.json gate reference). One introduced by the reforging itself (PR-3a versus benchmark-harness.md scope divergence). Three new issues not in Round 1 (PR-4b dependency prose conflict, missing AGENTS.md update PR for post-Phase-4 architecture, v0.2.1 checkpoint missing Phase 2 prerequisite visibility).
+
+The roadmap is substantially better than Round 1. A craftsman who repaired eleven of thirteen faults in a single iteration has demonstrated competence. What remains — the baselines.json gap, the PR-3a/benchmark-harness misalignment, the prose/table contradiction on PR-4b — is the difference between a competent refactor plan and a plan that will not cause an implementation agent to stop, ask questions, and waste the wizard's time.
+
+The Palantir has spoken again. Whether Saruman listens again is, as always, a matter of character.
+
+---
+
+## FINDINGS
+
+### R1 Issues — Verification Status
+
+- [verified-fixed] [R1-critical-1] admin.rs missing PR: PR-1d now exists with full scope, ordered execution, file size exceptions, and correct acceptance criteria.
+- [verified-fixed] [R1-critical-2] pipeline/ vs advanced/ naming mismatch: PR-4c now targets `sqlite/pipeline/` with 8-file layout matching module-decomposition.md §2c exactly.
+- [verified-fixed] [R1-critical-3] RetrievalStrategy incompatible trait signatures: PR-4a split into 4a-i/4a-ii; 4a-i explicitly aligns with trait-surface.md §3.2 signature (name/collect/CandidateSet).
+- [verified-fixed] [R1-important-1] substrate/module relationship not acknowledged: "Relationship to trait-surface.md" section added at top of roadmap; v0.3.x campaign clearly delineated.
+- [verified-fixed] [R1-important-2] bench_strategy vs locomo_bench ambiguity in PR-3a acceptance: "or a flag" hedge removed; acceptance criterion now reads `cargo run --release --bin bench_strategy`.
+- [verified-fixed] [R1-important-3] PR-4c acceptance criterion requires <500 lines but spec grants admin/ exceptions: acceptance criterion now explicitly cites the module-decomposition.md §4 exceptions.
+- [verified-fixed] [R1-important-4] Phase 3 flat dependency diagram wrong: diagram and prose now correctly show PR-3a parallel with PR-3b, and PR-3c serial after PR-3b.
+- [verified-fixed] [R1-important-5] PR-2d missing 10-sample gate: Quality Gate Summary now explicitly lists PR-2d as requiring 10-sample manual gate.
+- [verified-fixed] [R1-important-6] Visibility cascade risk unregistered: Risk #6 in registry with specific re-export-first mitigation.
+- [verified-fixed] [R1-important-7] PR-2b benchmark warning chain-blocking unregistered: Risk #7 in registry.
+- [verified-fixed] [R1-important-8] PR-1c ConnPool scope expansion unregistered: Risk #8 in registry.
+- [verified-fixed] [R1-important-9] PR-3b/3c conformance suite trait-bound panic: PR-3c scope note explicitly excludes AdvancedSearcher/PhraseSearcher from generic bound.
+- [verified-fixed] [R1-important-10] Branch naming and jj rebase protocol absent: full Branch Naming and Rebase Protocol section added with bookmark table and rebase commands.
+- [partially-fixed] [R1-important-11] PR-4b spike ambiguity (module-decomp says thin-wrapper is confirmed; roadmap says spike first): spike language retained without clarifying if it is resolved. See new finding F-4.
+- [verified-fixed] [R1-important-12] PR-2c benchmark gate suppressed vs module-decomp §6 requirement: PR-2c acceptance criterion now references module-decomposition.md §6 test gates and includes `./scripts/bench.sh --gate`.
+- [partially-fixed] [R1-minor-1] PR-1a Full-mode regression not tested: unchanged. See new finding F-6.
+- [not-fixed] [R1-minor-5] Benchmark gate does not reference baselines.json: Saruman conceded this (W-5) but did not fix it. See new finding F-1.
+- [verified-fixed] [R1-important-PR-4a] KeywordOnlyStrategy dead-end abstraction: PR-4a-ii now correctly returns CandidateSet; scoring happens downstream.
+- [verified-fixed] [R1-important-PR-4c] Shared helper audit missing from PR-4c: pre-split audit requirement now explicit in PR-4c.
+
+---
+
+### New Findings (Round 2)
+
+- [severity:important] [execution-roadmap.md Quality Gate Summary / benchmark-harness.md §4] The benchmark gate command `./scripts/bench.sh --gate` is listed in the Quality Gate Summary with no reference to `baselines.json` as the authoritative baseline source. `benchmark-harness.md §4` defines `docs/benchmarks/baselines.json` as a structured replacement for the fragile CSV grep. No PR in the roadmap creates `baselines.json` or updates `bench.sh` gate logic to read from it. If `baselines.json` does not exist when any benchmark-gated PR lands, the gate falls back to CSV grep or fails. Fix: add a note to the Quality Gate Summary that the gate reads from `docs/benchmarks/baselines.json`; scope the creation of that file and the bench.sh gate-logic update (per benchmark-harness.md §4) to PR-3a or a new PR-0.
+
+- [severity:important] [execution-roadmap.md PR-3a / benchmark-harness.md §1-§5] PR-3a's scope and the benchmark-harness.md spec describe incompatible implementations of the strategy comparison feature. Roadmap: standalone `bench_strategy` binary that runs the benchmark twice and appends a `strategy`-column CSV row. Benchmark-harness spec: `--strategy` flag on `locomo_bench`, `benches/locomo/strategies.rs` registry, `benches/bench_utils/stats.rs` P95 latency module, `LoCoMoSummary` struct extension (`strategy`, `p95_query_ms` fields), `bench.sh --compare A B` mode, `compare_strategies.py` script, and `baselines.json`. These produce different binaries, different CLI interfaces, different CSV schemas, and different output artefacts. The "single source of truth" claim fails here. Fix: reconcile PR-3a's scope with benchmark-harness.md; either the roadmap governs and the benchmark-harness spec must be updated, or the benchmark-harness spec governs and PR-3a's scope must be expanded significantly.
+
+- [severity:important] [execution-roadmap.md Phase 4 prose vs PR Summary Table] The Phase 4 section header states "PR-4a-i and PR-4b can be opened in parallel after Phase 3 merges," implying PR-4b waits for Phase 3. The PR Summary Table shows PR-4b with "Depends On: —" (no dependency). These contradict each other. The table is authoritative and correct — PR-4b has no logical dependency on Phase 3. The prose must match: either remove the "after Phase 3 merges" qualifier for PR-4b, or make the table reflect a Phase 3 dependency with a stated reason. Fix: align prose to match the dependency table; PR-4b can begin in parallel with Phase 2 or Phase 3.
+
+- [severity:important] [execution-roadmap.md PR-4b Risk Mitigations] The rmcp spike ambiguity persists. The risk mitigation states "Spike the module split on a throwaway branch first to confirm the proc macros are module-agnostic." The module-decomposition spec documents the thin-wrapper pattern as confirmed architecture, including a working code example, with no "spike first" qualifier. If the spike is done, the roadmap should say so. If it is not done, then PR-4b's module-decomposition spec is speculative documentation, not a confirmed execution guide, and the risk should be rated High not Medium. The current state is a contradiction between a risk mitigation that implies uncertainty and a companion spec that implies certainty. Fix: either mark the spike as completed (citing the module-decomposition spec as its output), or re-rate PR-4b risk to High and acknowledge the spike as an open prerequisite.
+
+- [severity:important] [execution-roadmap.md §Milestone Checkpoints, v0.2.1] The v0.2.1 checkpoint lists three items (PR-3a, PR-3b, PR-3c merged). PR-3b depends on PR-2d, which is Phase 2 work. The v0.2.1 checkpoint does not state that Phase 2 must be fully complete before PR-3b can begin. A developer evaluating v0.2.1 completion status could observe PR-3a merged and attempt to open PR-3b while PR-2d is still in flight, causing a compilation failure (missing `ScoringStrategy` injection). Fix: add a gate condition to the v0.2.1 checkpoint: "Prerequisite: v0.2.0 checkpoint complete (all Phase 2 PRs merged) before PR-3b begins."
+
+- [severity:minor] [execution-roadmap.md PR-1a] Acceptance criterion still does not require verifying Full mode (all 19 tools) after implementing Minimal mode filtering. A bug in the `list_tools` override that incorrectly filters Full mode would not be caught by the specified test. Fix: add "unit test asserting that non-Minimal mode still returns all 19 tool names" to the acceptance criteria.
+
+- [severity:minor] [execution-roadmap.md PR-1c Acceptance] Acceptance criterion does not require a unit test for sub-query deduplication correctness with overlapping results. The scope correctly describes the behavioral change (seen_ids from serial accumulation to post-join single pass). A benchmark gate measures aggregate quality, not per-ID deduplication correctness. A query decomposed into two sub-queries that both retrieve the same memory ID should produce exactly one result with the higher score; this is not tested by the benchmark. Fix: add acceptance criterion: "unit test asserting that overlapping sub-query results (same memory_id, different scores) produce exactly one result with score = max(scores)."
+
+- [severity:minor] [execution-roadmap.md §Parked Items / AGENTS.md] No PR updates AGENTS.md after Phase 4's structural changes. After Phase 4 merges, AGENTS.md Architecture section will reference `src/mcp_server.rs` (replaced by `src/mcp/`), `storage/sqlite/mod.rs` as a monolithic file (now a thin re-export facade), and the monolithic `advanced.rs` (now `pipeline/`). PR-1b fixes the tool count but not the module paths. Fix: add AGENTS.md architectural documentation update to PR-4b's acceptance criteria (when mcp_server.rs is split) and PR-4c's acceptance criteria (when advanced.rs becomes pipeline/).
+

--- a/docs/strongholds/palantir-r2-defense.md
+++ b/docs/strongholds/palantir-r2-defense.md
@@ -1,0 +1,158 @@
+# Palantir Defense — Round 2
+<\!-- Saruman the White, Lord of Isengard, defends the REFORGED MAG Execution Roadmap -->
+<\!-- Generated: 2026-04-14 | Roadmap baseline: v0.1.9-dev | Horizon: v0.2.2 | Round: 2 -->
+
+---
+
+## BANTER
+
+*The Palantir blazes white again. Saruman sets down his staff very deliberately, smooths his robes, and allows himself the smallest, most controlled smile.*
+
+Round 2. The Dark Lord returns. And I have been... *prepared*.
+
+Let me tell you what has happened since Round 1, Sauron, because I suspect you gazed at the reforged document expecting to find the same wasteland of contradictions — and instead found something considerably more... formidable.
+
+**On the six concessions from Round 1 — yes, let us account for them first.**
+
+I conceded six issues. SIX. Let us see how many survive your second assault.
+
+**W-1: No paragraph relating roadmap to trait-surface.md.** I said this was High severity. I said add a paragraph. The reforged roadmap now has an *entire section* — "Relationship to trait-surface.md" — that is frankly more thorough than the "paragraph" I proposed. It names which 2-of-7 traits are implemented, names the 5 remaining traits by name, declares v0.3.x as the substrate campaign, establishes authority hierarchy ("this roadmap governs for Phases 1-4; for work beyond v0.2.2, trait-surface.md governs"), and explicitly says PR-4a-i is aligned with trait-surface.md §3.2. That is not a patch. That is a proper fix. W-1: **RESOLVED**.
+
+**W-2: PR-2d missing 10-sample benchmark gate.** I conceded this. The reforged PR-2d acceptance criterion now reads — and I will quote it directly — "`./scripts/bench.sh --samples 10 --notes "PR-2d pre-merge"` shows no regression (10-sample gate required)." AND the Quality Gate Summary table now shows PR-2d explicitly in the "Benchmark 10-sample" row alongside PR-4a-ii. AND the Quality Gate Summary adds the note: "10-sample gates are manual pre-merge checks. CI enforces 2-sample fast gates automatically. The 10-sample requirement for PR-2d and PR-4a-ii must be verified by the developer before merge." W-2: **RESOLVED**, and more thoroughly than requested.
+
+**W-3: PR-4a should be split into 4a-i and 4a-ii.** I proposed this split myself in Round 1. The reforged roadmap has implemented it exactly as I specified: PR-4a-i is additive (Risk: Low, no benchmark gate), PR-4a-ii is behavioral (Risk: High, 10-sample gate). The trait definition in PR-4a-i is now explicitly aligned with trait-surface.md §3.2 — `fn name() -> &str` and `async fn collect(ctx: &QueryContext) -> CandidateSet`. The RetrievalStrategy incompatibility that Sauron attacked so vigorously in Round 1 is *gone*. Both the roadmap and the trait-surface spec now agree. W-3: **RESOLVED**, and the incompatible trait signature is corrected simultaneously.
+
+**W-4: Shared helper audit before advanced.rs split.** I conceded this as Low severity. The reforged PR-4c now has an explicit "Pre-split requirement" paragraph: "Audit shared helper types across advanced.rs and the target pipeline/ files before splitting. If types like RankedSemanticCandidate or utility functions are shared across multiple target files, extract them to mod.rs re-exports or a types.rs first. This avoids circular imports during the split." W-4: **RESOLVED**.
+
+**W-5: Benchmark gate does not reference baselines.json.** I conceded this. The Quality Gate Summary now says: "Results must be appended to `docs/benchmarks/benchmark_log.csv` using `bench.sh` (not raw `cargo run`)." It does not yet explicitly name baselines.json as the gate source — that is still implied. This is a *minor* residual. I will note it honestly in the findings. **PARTIALLY resolved**.
+
+**And the most devastating attack from Round 1 — the admin.rs black hole.** Sauron declared, correctly and devastatingly, that admin.rs had *no PR*. 1,619 lines of four independent trait groups, falling through the floor. I could not defend that. I did not defend it. And behold: the reforged roadmap now has **PR-1d**, a full Phase 1 PR with a complete scope table, 5-step execution order, file size exceptions pre-justified, and the explicit statement that it uses module-decomposition.md §2d as its reference. The admin.rs problem is not merely patched — it is *correctly placed in Phase 1*, exactly where the module-decomposition spec always said it belonged. **RESOLVED**.
+
+*Saruman pauses. Six concessions verified. The score stands. Now let us see what the Dark Lord brought for Round 2.*
+
+**On the dependency graph corrections — let me examine what was fixed.**
+
+Sauron attacked the Phase 3 dependency diagram in Round 1, correctly. The reforged diagram now reads:
+```
+PR-3a (independent, parallel with PR-3b)
+PR-3b (depends on PR-2d) ──> PR-3c
+```
+
+That is *correct*. PR-3b's dependency on PR-2d is explicit. PR-3c's dependency on PR-3b is explicit. The "three parallel PRs" fiction is gone. The dependency is clearly stated in the preamble: "PR-3a is independent. PR-3b depends on PR-2d... PR-3c depends on PR-3b." W-3c: **RESOLVED**.
+
+**On the conformance suite vs. MemoryStorage unimplemented\!() tension.** Sauron found a genuine ambiguity in Round 1. The reforged PR-3c now has an explicit "Trait scope note" paragraph: "The conformance suite tests the trait subset that MemoryStorage implements... It does NOT include AdvancedSearcher or PhraseSearcher in the generic bound — MemoryStorage stubs these with unimplemented\!()... so including them would panic at test time. The suite covers the common-subset contract; SQLite-specific traits are tested by the existing tests.rs suite." The implementer will NOT choose by accident. They have explicit guidance. **RESOLVED**.
+
+**On the pipeline/ vs advanced/ layout conflict.** The reforged PR-4c now *correctly* targets `sqlite/pipeline/` with all 8 files matching the module-decomposition spec: `mod.rs`, `retrieval.rs`, `rerank.rs`, `fusion.rs`, `scoring.rs`, `enrichment.rs`, `abstention.rs`, `decomp.rs`. The "advanced/" fiction is gone. **RESOLVED**.
+
+**On the bench_strategy "or" ambiguity.** The reforged PR-3a still says "a `bench_strategy` binary (or a flag to `locomo_bench`)" — but this is now a weaker criticism than it was in Round 1, because the benchmark-harness spec is referenced for the implementation details. Still, I will be honest: the "or" remains. The benchmark-harness spec clearly defines this as a `--strategy` flag on `locomo_bench`, not a separate binary. The roadmap's acceptance criterion still uses `cargo run --release --bin bench_strategy`. That is a *residual inconsistency* with the spec. Minor, but present.
+
+**On the PR-4c acceptance criterion vs. the admin/ exceptions.** The reforged PR-4c acceptance criterion now reads: "file sizes are all under 500 lines (with `admin/maintenance.rs` ~580 and `admin/welcome.rs` ~490 exceptions per `module-decomposition.md` §4)." The contradiction from Round 1 is **RESOLVED**. Explicitly.
+
+**On the 10-sample CI enforcement.** Sauron found that the CI job only runs 2 samples, so PR-4a-ii's "10-sample gate" would be unenforceable in CI. The reforged Quality Gate Summary now explicitly says: "10-sample gates are manual pre-merge checks. CI enforces 2-sample fast gates automatically." The implementer will not be confused. **RESOLVED**.
+
+**On the risk registry gaps.** The reforged risk registry now has 8 items (up from 5). Risks 6, 7, and 8 are new additions:
+- Risk 6: Visibility cascade during PR-2c. Present and well-mitigated (re-export as first step).
+- Risk 7: PR-2b warning blocks PR-2c/PR-2d chain. Present and well-articulated.
+- Risk 8: PR-1c scope expansion if ConnPool lacks concurrent readers. Present.
+
+These were three of Sauron's Round 1 findings. All three are now registered. **RESOLVED**.
+
+**On the branch naming and jj rebase protocol.** A new "Branch Naming and Rebase Protocol" section exists, complete with a table of 15 bookmark names and explicit `jj rebase -b` commands for the serial chain. **RESOLVED**.
+
+**Now — and this is where Saruman takes the offensive — let me identify what REMAINS.**
+
+*The staff strikes the floor once. The Palantir flares.*
+
+**First residual: bench_strategy binary vs. --strategy flag.** PR-3a's acceptance criterion says `cargo run --release --bin bench_strategy -- --help`. The benchmark-harness spec defines the strategy comparison as a `--strategy` flag on the existing `locomo_bench` binary. These are still inconsistent. If an implementer follows the roadmap's acceptance criterion, they will create a separate binary. If they follow the benchmark-harness spec, they will add a flag. This is not a critical blocker — but it is a genuine ambiguity that an implementer will need to resolve, and the resolution will not be obvious.
+
+**Second residual: the PR-1a acceptance criterion still only checks Minimal mode.** Sauron found this in Round 1. The reforged PR-1a acceptance says: "Add a unit test asserting the filtered set contains exactly the 4 facade names." It does NOT require a test that Full mode still returns all 19. A regression in Full mode is still undetectable by the specified acceptance criterion. This is minor, but it is the same gap as Round 1.
+
+**Third residual: baselines.json explicit reference.** The Quality Gate Summary says results go to benchmark_log.csv. It does not explicitly name baselines.json as the gate comparison source. This matters because bench.sh currently uses fragile CSV-grep for the gate, and the benchmark-harness spec explicitly replaces it with baselines.json. The roadmap should name baselines.json as the gate source, not leave it implied.
+
+**Fourth — and this I find only now, on close examination — PR-4b can begin earlier.** The reforged Phase 4 dependency diagram shows PR-4b starting "after Phase 3 merges." But PR-4b (mcp_server.rs split) has no logical dependency on Phase 3 work. MemoryStorage and the conformance suite are entirely orthogonal to the MCP server structure. PR-4b could begin in parallel with Phase 2 if calendar time is important. The PR Summary Table shows PR-4b with no dependency ("—"), which contradicts the Phase 4 preamble that implies it starts after Phase 3. That inconsistency within the roadmap itself is new and introduced by the reforging.
+
+**Wait.** Let me look at this precisely. The Phase 4 preamble says: "Four PRs. PR-4a-i and PR-4b can be opened in parallel *after Phase 3 merges*." But the PR Summary Table lists PR-4b as depending on "—". If PR-4b has no dependencies, it can start at any time — not just after Phase 3. This is a minor internal inconsistency, but it is one the reforge *introduced* rather than inherited. The original roadmap at least had PR-4b waiting on Phase 3 *explicitly* (even if that was wrong). The reforge made the dependency table say "—" but left the prose saying "after Phase 3."
+
+**Fifth, and most interesting: the Quality Gate Summary still uses a uniform 2pp/5pp threshold for structural refactor PRs.** Sauron attacked this correctly. For PR-2c, PR-4b (no gate), PR-4c: pure code moves should have a tighter gate. The reforged Quality Gate Summary still shows:
+```
+Benchmark 2-sample | PRs touching scoring/search/storage | ./scripts/bench.sh --gate (warns >2 pp, fails >5 pp)
+```
+The differentiation between structural-move PRs and algorithmic PRs is not reflected in the gate thresholds. I defended the current threshold in Round 1 on the grounds that 5pp is sufficient to catch catastrophic regressions, and 0pp gating implies false precision. I will hold that defense. But I acknowledge this remains a legitimate point of disagreement.
+
+*The Palantir dims slightly. Saruman straightens.*
+
+The verdict on the reforged roadmap: this is, by any honest measure, a substantially better document. Twelve of Sauron's thirteen Round 1 findings have been addressed. Five of my six concessions are fully resolved. One is partially resolved. Three new minor issues have been introduced or remain. The critical issues — admin.rs having no PR, the RetrievalStrategy incompatibility, the pipeline/ vs. advanced/ layout conflict — are ALL gone.
+
+Is this roadmap ready for Phase 1 implementation? **Yes, for Phase 1.** PR-1a, PR-1b, PR-1d are clean. PR-1c needs the ConnPool spike first (now explicitly documented in Risk 8). Phase 2 is ready once Phase 1 validates execution process. The four remaining gaps are minor and addressable in-flight by the implementing agent.
+
+**Confidence level: 85%.** The remaining 15% is: the bench_strategy binary ambiguity (needs one sentence to resolve), the PR-4b scheduling inconsistency (needs one word edit), the PR-1a Full-mode test gap (needs one test added), and the baselines.json reference (needs one sentence). None of these block implementation. All can be resolved in PR review.
+
+*Saruman the White. Saruman the Wise. Still standing.*
+
+---
+
+## FINDINGS
+
+### R1 Concession Resolution Status
+
+- [resolved] [execution-roadmap.md: "Relationship to trait-surface.md" section] W-1 FIXED. New section explicitly names 2-of-7 traits delivered, names all 5 remaining traits, establishes v0.3.x as the substrate campaign, and defines authority hierarchy (roadmap governs v0.2.x; trait-surface.md governs beyond v0.2.2).
+
+- [resolved] [execution-roadmap.md:PR-2d acceptance + Quality Gate Summary] W-2 FIXED. PR-2d acceptance criterion now explicitly requires `./scripts/bench.sh --samples 10`. Quality Gate Summary table lists PR-2d alongside PR-4a-ii in the 10-sample row. CI vs. manual distinction is now documented.
+
+- [resolved] [execution-roadmap.md:PR-4a-i + PR-4a-ii] W-3 FIXED. Split is implemented exactly as conceded. PR-4a-i is additive (Low risk, no gate); PR-4a-ii is behavioral (High risk, 10-sample gate). RetrievalStrategy trait now aligned with trait-surface.md §3.2 (`fn name()` + `async fn collect(ctx: &QueryContext) -> CandidateSet`). This simultaneously resolves R1's critical RetrievalStrategy incompatibility finding.
+
+- [resolved] [execution-roadmap.md:PR-4c "Pre-split requirement"] W-4 FIXED. Explicit shared-helper audit requirement added before the split begins.
+
+- [partial] [execution-roadmap.md: Quality Gate Summary] W-5 PARTIALLY FIXED. Gate results now directed to benchmark_log.csv via bench.sh. But baselines.json is still not explicitly named as the gate comparison source — it remains implied. The benchmark-harness spec replaces the fragile CSV-grep with baselines.json; the roadmap should say so.
+
+- [resolved] [execution-roadmap.md:PR-1d] Admin.rs black hole FIXED. PR-1d is a complete Phase 1 PR with full scope table, 5-step execution order, file exceptions pre-justified, and module-decomposition.md §2d as the implementation reference.
+
+### R1 Attack Findings — Status After Reforge
+
+- [resolved] [execution-roadmap.md:Phase 3 dependency diagram] PR-3b's dependency on PR-2d is now explicit. PR-3c's dependency on PR-3b is now explicit. "Three parallel PRs" fiction gone.
+
+- [resolved] [execution-roadmap.md:PR-3c "Trait scope note"] Conformance suite capability parameterization resolved. Suite covers common-subset only; AdvancedSearcher/PhraseSearcher excluded from the generic bound with explicit explanation.
+
+- [resolved] [execution-roadmap.md:PR-4c scope table] Pipeline layout now correctly targets `sqlite/pipeline/` with all 8 files matching module-decomposition.md §2c. The `advanced/` fiction from R1 is gone.
+
+- [resolved] [execution-roadmap.md: Risk Registry — items 6, 7, 8] Three unregistered risks from R1 are now registered: visibility cascade (Risk 6), PR-2b warning blocking chain (Risk 7), PR-1c ConnPool scope expansion (Risk 8). All have specific mitigations.
+
+- [resolved] [execution-roadmap.md: Branch Naming and Rebase Protocol] New section with 15 bookmark names and explicit `jj rebase -b` commands for the serial chain. jj-colocated workflow documented.
+
+- [resolved] [execution-roadmap.md: Quality Gate Summary] 10-sample gate manual vs. CI distinction explicitly documented. Implementers will not assume CI enforces the 10-sample requirement.
+
+- [resolved] [execution-roadmap.md:PR-4c acceptance] File size exception carve-outs now explicit in the acceptance criterion: "with `admin/maintenance.rs` ~580 and `admin/welcome.rs` ~490 exceptions per `module-decomposition.md` §4". The contradiction from R1 is gone.
+
+### Remaining Gaps After Reforge
+
+- [important] [execution-roadmap.md:PR-3a acceptance criterion] bench_strategy binary vs. --strategy flag ambiguity REMAINS. PR-3a acceptance says `cargo run --release --bin bench_strategy -- --help`. The benchmark-harness spec defines the comparison feature as `--strategy <name>` on the existing `locomo_bench` binary (benches/locomo/main.rs) via a new `strategies.rs` registry. These are different implementations. An implementer following the roadmap acceptance criterion will create a separate binary; one following the benchmark-harness spec will add a flag. Fix: update PR-3a acceptance to match benchmark-harness.md §1 — reference `locomo_bench --strategy` and `--list-strategies` rather than a separate binary.
+
+- [minor] [execution-roadmap.md:PR-1a acceptance criterion] Full-mode regression test gap REMAINS. Acceptance still only requires testing that Minimal mode returns 4 tools. A regression in Full mode (still returning all 19) is undetectable. Fix: add "Add a test asserting `McpToolMode::Full` (or the default mode) returns all 19 registered tools."
+
+- [minor] [execution-roadmap.md: Quality Gate Summary] baselines.json not explicitly named as the gate comparison source. bench.sh currently uses fragile CSV-grep; the benchmark-harness spec replaces it with baselines.json. The roadmap should say: "The gate compares against `docs/benchmarks/baselines.json` (see benchmark-harness.md §4)." Fix: one sentence addition to Quality Gate Summary.
+
+- [minor] [execution-roadmap.md: Phase 4 preamble vs. PR Summary Table] PR-4b scheduling inconsistency introduced by the reforge. Phase 4 preamble says "PR-4a-i and PR-4b can be opened in parallel after Phase 3 merges." PR Summary Table shows PR-4b with no dependency ("—"). These contradict each other. Since PR-4b (mcp_server.rs split) has no logical dependency on Phase 3, the PR Summary Table is correct and the preamble is wrong. Fix: change preamble to "PR-4b can be opened in parallel with Phase 2 or Phase 3 — it has no dependency on either."
+
+- [nitpick] [execution-roadmap.md: Quality Gate Summary] Benchmark gate thresholds (2pp warn / 5pp fail) are applied uniformly. Structural-move PRs (PR-2c, PR-4c) theoretically warrant a tighter threshold since zero behavioral change should produce zero score delta. I defended this in R1 and maintain the defense: a 0pp gate on 2-sample data implies false precision; 5pp is the honest catastrophic-regression detector. The current thresholds are defensible. No change required.
+
+### Readiness Assessment
+
+**Phase 1 (PR-1a, PR-1b, PR-1c, PR-1d): READY TO DISPATCH.**
+- PR-1a: clean, well-scoped. One test gap (Full-mode) is minor and can be caught in review.
+- PR-1b: trivially safe.
+- PR-1c: start with ConnPool spike (documented in Risk 8). If concurrent readers are not supported, re-scope before implementing. Do not dispatch implementation agent blind.
+- PR-1d: excellent spec with step-by-step execution guide. Clean to dispatch.
+
+**Phase 2 (PR-2a through PR-2d): READY after Phase 1 validates.**
+The serial chain is well-documented. Risk 7 (PR-2b warning blocking chain) is registered but not fully mitigated — the mitigation says "investigate before proceeding" which is correct but requires judgment from whoever is dispatching. Make sure the dispatching agent has authority to pause and assess rather than blindly continuing.
+
+**Phase 3 (PR-3a, PR-3b, PR-3c): READY after Phase 2.**
+The bench_strategy binary ambiguity in PR-3a should be resolved before dispatching (one sentence edit to the roadmap). Otherwise clean.
+
+**Phase 4 (PR-4a-i, PR-4a-ii, PR-4b, PR-4c): READY after Phase 3.**
+PR-4a-ii is High risk — the 10-sample gate is manual and must be explicitly surfaced to the implementing agent. PR-4b can technically start earlier (Phase 2 parallel) per the PR Summary Table, but the prose says Phase 3. Resolve the inconsistency, then decide when to schedule it.
+
+**Overall confidence: 85%.** Three minor edits would push it to 93%+:
+1. Fix PR-3a acceptance criterion to reference `locomo_bench --strategy` (one sentence).
+2. Fix Phase 4 preamble PR-4b scheduling claim (one phrase).
+3. Add baselines.json reference to Quality Gate Summary (one sentence).

--- a/docs/strongholds/palantir-r3-final-defense.md
+++ b/docs/strongholds/palantir-r3-final-defense.md
@@ -1,0 +1,150 @@
+# Palantir Defense — Round 3 (Final Verification)
+<\!-- Saruman the White, Lord of Isengard — final readiness assessment -->
+<\!-- Generated: 2026-04-14 | Round: 3 | Spec baseline: post-R2-reforge -->
+
+---
+
+## BANTER
+
+*The Palantir blazes one final time. Saruman does not reach for it immediately. He stands at the window of Orthanc, looks out over the wheel-ruts of Isengard — still scarred from the Uruk-hai production-line disaster, yes, he sees them, he does NOT need reminding — and then turns back.*
+
+Round 3. Verification pass. The Dark Lord has retired from the field for this one. It is only me, the specs, and the cold light of honest scrutiny.
+
+Very well. Let us account for the four remaining gaps I identified in Round 2.
+
+**W-5: baselines.json not named as the gate comparison source.**
+
+Sauron said this was unresolved. I admitted it was *partially* resolved. I said one sentence was needed.
+
+*One sentence was added.*
+
+The Quality Gate Summary now reads — and I will quote it with the satisfaction of a wizard who demanded a fix and got one: "The benchmark gate compares against `docs/benchmarks/baselines.json` (see `benchmark-harness.md` §4). Before PR-3a lands, the gate uses the existing CSV-grep baseline."
+
+That is two sentences. More than I asked for. The CSV-grep regime and the baselines.json regime are now *both* described, and the transition point (PR-3a landing) is explicit. An implementer who merges PR-2d before PR-3a is ready will not reach for baselines.json prematurely.
+
+**W-5: RESOLVED.** Fully. Finally.
+
+**bench_strategy vs. --strategy flag ambiguity.**
+
+In Round 2, I found that PR-3a's acceptance criterion still referenced `cargo run --release --bin bench_strategy -- --help` — a separate binary that the benchmark-harness spec never specified. I called this an important gap. I said fix it with one sentence.
+
+*The fix is surgical and correct.*
+
+PR-3a now reads: "Add `--strategy <name>` and `--list-strategies` flags to the **existing** `locomo_bench` binary (not a standalone binary)." The word "not a standalone binary" is there. Explicit. The acceptance criterion reads: "`cargo run --release --bin locomo_bench -- --strategy sqlite-v1 --list-strategies` works."
+
+There is no longer any ambiguity. An implementer cannot accidentally create a separate binary while following this spec. The benchmark-harness spec and the roadmap now describe the same implementation.
+
+**bench_strategy ambiguity: RESOLVED.** The Dark Lord will not find purchase here.
+
+**PR-4b scheduling inconsistency.**
+
+I found — in Round 2, on close examination — that the Phase 4 preamble said "PR-4a-i and PR-4b can be opened in parallel *after Phase 3 merges*" while the PR Summary Table showed PR-4b with no dependency ("—"). These contradicted each other.
+
+*The preamble has been corrected.*
+
+It now reads: "PR-4b can be opened any time after Phase 1 — it has no dependency on Phases 2 or 3."
+
+The PR Summary Table still shows PR-4b depending on "—". The phase 4 diagram still shows:
+```
+PR-4a-i ──> PR-4a-ii
+PR-4b   ──> PR-4c
+```
+
+Preamble, diagram, and table are now *all consistent*. PR-4b can start any time after Phase 1. The Phase 4 prose no longer contradicts itself. And since PR-4b (splitting mcp_server.rs) genuinely has no logical dependency on Phase 3's MemoryStorage work, this is the correct answer — not merely a diplomatic one.
+
+**PR-4b scheduling: RESOLVED.**
+
+**PR-1a Full-mode regression test.**
+
+I said this was minor but real: the acceptance criterion only required testing that Minimal mode filters to 4 tools. A Full-mode regression was undetectable. I asked for one test added to the acceptance criterion.
+
+*It is there.*
+
+PR-1a acceptance now reads: "`prek run` passes; `cargo test --all-features` includes the new test; comment is gone. Unit test asserting `McpToolMode::Full` (or default) returns all 19 registered tools from `TOOL_REGISTRY`."
+
+Both tests are now required. Minimal mode: 4 tools. Full mode: 19 tools. The acceptance criterion is a proper two-sided verification.
+
+**PR-1a Full-mode test: RESOLVED.**
+
+*Saruman sets down the Palantir. There is a long pause.*
+
+Four gaps from Round 2. Four fixes applied. Four verifications completed.
+
+I have looked for new issues. I have read every section. I have traced the dependency diagrams. I have checked the acceptance criteria against the specs. I have compared the PR Summary Table against the prose. I have verified the benchmark harness spec against the roadmap's gate logic.
+
+There are no new critical issues. There are no new important issues.
+
+There is one item I will note — not as a gap but as a condition on my confidence rating — and I will describe it precisely in the findings.
+
+The question Sauron always asks at the end of these things is: is it ready?
+
+The answer is yes.
+
+Not "yes, but fix these three things first."
+
+*Yes.* Full stop.
+
+Phase 1 can be dispatched from these specs without modification. The implementing agents have unambiguous acceptance criteria, dependency graphs that reflect reality, risk mitigations that name the actual dangers, and an execution order that keeps the repo in a compilable state at every step.
+
+The remaining caveat is not a spec deficiency — it is a runtime unknown (ConnPool concurrent-reader behavior in PR-1c) that is *correctly* identified as a spike in Risk 8, and the roadmap correctly says "verify before implementing." An implementing agent that reads Risk 8 knows to pause before writing code.
+
+Saruman the White. Saruman the Wise. Standing at the end of Round 3 with four resolved gaps and a recommendation to ship.
+
+*The Palantir goes dark. The white robes settle.*
+
+---
+
+## FINDINGS
+
+### R2 Gap Verification — All Four Targets
+
+- [resolved] [execution-roadmap.md:494] **W-5 (baselines.json)** — RESOLVED. Quality Gate Summary now explicitly states: "The benchmark gate compares against `docs/benchmarks/baselines.json` (see `benchmark-harness.md` §4). Before PR-3a lands, the gate uses the existing CSV-grep baseline." Both the transition point and the final source of truth are named. An implementer knows exactly which gate logic applies at each phase.
+
+- [resolved] [execution-roadmap.md:242,251] **bench_strategy vs. --strategy** — RESOLVED. PR-3a scope explicitly states "Add `--strategy <name>` and `--list-strategies` flags to the existing `locomo_bench` binary (not a standalone binary)." The acceptance criterion references `cargo run --release --bin locomo_bench -- --strategy sqlite-v1 --list-strategies`. Zero ambiguity. Consistent with benchmark-harness.md §1.
+
+- [resolved] [execution-roadmap.md:294,428,586] **PR-4b scheduling** — RESOLVED. Phase 4 preamble now reads "PR-4b can be opened any time after Phase 1 — it has no dependency on Phases 2 or 3." PR Summary Table shows PR-4b with "—" dependency. Phase 4 dependency diagram shows `PR-4b ──> PR-4c` as an independent chain. Preamble, table, and diagram are now consistent.
+
+- [resolved] [execution-roadmap.md:43] **PR-1a Full-mode test** — RESOLVED. Acceptance criterion now requires both: a unit test that Minimal mode returns exactly 4 facade names, AND "Unit test asserting `McpToolMode::Full` (or default) returns all 19 registered tools from `TOOL_REGISTRY`." Bi-directional regression coverage confirmed.
+
+### New Issues Found in Final Pass
+
+- [none] No new critical issues found.
+- [none] No new important issues found.
+- [nitpick] [execution-roadmap.md: Phase 3 notes on PR-3a] The `--update-baseline` flag described in benchmark-harness.md §5 is mentioned in the PR-3a scope implicitly (via "Update `bench.sh --gate` to read the baseline from baselines.json") but is not listed as a named deliverable in PR-3a's scope. This is acceptable — the acceptance criterion's explicit `baselines.json` check covers the outcome; the flag is an implementation detail. No action required.
+
+### Overall Readiness Assessment
+
+**Phase 1 (PR-1a, PR-1b, PR-1c, PR-1d): READY TO DISPATCH.**
+
+- PR-1a: Acceptance criterion complete (both Minimal and Full mode tests). Clean.
+- PR-1b: One-line docs fix. No risk.
+- PR-1c: **Dispatch with the ConnPool spike first.** Risk 8 explicitly requires verifying concurrent-reader support before implementation. Dispatch a reconnaissance agent to read `conn_pool.rs` before the implementation agent touches the parallel join_all path. If ConnPool does not support concurrent readers, re-scope before implementing. Do not blindly dispatch implementation against this PR.
+- PR-1d: Five-step execution order, pre-justified file size exceptions, module-decomposition.md §2d as reference. Clean to dispatch.
+
+**Phase 2 (PR-2a through PR-2d): READY after Phase 1 validates execution process.**
+Risk 7 (PR-2b warning blocking chain) is registered and the mitigation says "investigate before proceeding." The dispatching agent must be given authority to pause and assess, not instructed to push through.
+
+**Phase 3 (PR-3a, PR-3b, PR-3c): READY after Phase 2.**
+PR-3a spec is now clean — no binary ambiguity, no baselines.json gap. The benchmark-harness.md spec provides the full implementation detail. PR-3b depends on PR-2d (explicit in dependency table). PR-3c depends on PR-3b (explicit). Sequence is unambiguous.
+
+**Phase 4 (PR-4a-i, PR-4a-ii, PR-4b, PR-4c): READY.**
+PR-4b can be dispatched in parallel with Phase 2 or 3 (after Phase 1). PR-4a-ii is High risk — the 10-sample gate is manual and must be surfaced explicitly to the implementing agent. PR-4c's file size exceptions are pre-justified. No blocking issues.
+
+### Confidence Level
+
+**93% confidence that this spec set is ready for Phase 1 dispatch.**
+
+The 7% remainder is:
+
+1. **ConnPool runtime unknown (PR-1c, ~4%)**: Whether `ConnPool` supports concurrent readers is not knowable from spec review — it requires reading `conn_pool.rs`. This is correctly identified in Risk 8 and the mitigation is sound. It is not a spec gap; it is an execution dependency. The dispatching agent must be briefed to run the spike first.
+
+2. **rmcp proc-macro compatibility (PR-4b, ~2%)**: Risk 3 in the risk registry notes medium probability that the rmcp proc-macro does not accept cross-module delegation. The thin-wrapper pattern is documented in module-decomposition.md §2a with a code example. This is a Phase 4 risk and does not affect Phase 1-3 dispatch at all. Noted for completeness.
+
+3. **Comparison report directory tracking policy (~1%)**: benchmark-harness.md Appendix A notes `docs/benchmarks/comparisons/` as "new dir (gitignored or tracked)." The policy is not decided. This is minor — the implementing agent can make the call — but it is the one remaining unresolved decision in the spec set.
+
+**Caveats on the 93% rating:**
+- Applies to Phase 1 dispatch now. The rating for Phase 2+ dispatch after Phase 1 validates is expected to rise to 97%+ once the PR-1c spike resolves the ConnPool question.
+- The 93% assumes implementing agents are briefed on the Risk 7 and Risk 8 mitigations, not just handed the roadmap cold.
+- The rating would drop to ~85% if PR-1c is dispatched without the ConnPool spike — do not do that.
+
+**Recommendation: DISPATCH PHASE 1.**

--- a/docs/strongholds/palantir-r3-final.md
+++ b/docs/strongholds/palantir-r3-final.md
@@ -1,0 +1,172 @@
+# Palantir Round 3 — Final Verification
+<\!-- Sauron's review | Generated: 2026-04-14 | Target: docs/specs/execution-roadmap.md (twice-reforged) -->
+
+---
+
+## BANTER
+
+Saruman.
+
+The Palantir burns for the third time. I have read the twice-reforged roadmap against every companion spec. I have checked each finding from Round 1 and Round 2. I will be precise, as I always am — precision is the instrument of final judgment.
+
+---
+
+### What the Wizard Has Achieved
+
+Thirteen issues in Round 1. Eight new findings in Round 2. Twenty-one total verdicts to render.
+
+The reforging between Round 2 and Round 3 has addressed five of the eight Round 2 findings. I acknowledge this with the enthusiasm of a Dark Lord forced to concede ground to a wizard who has, for once, listened.
+
+The `v0.2.1` checkpoint now carries its Phase 2 prerequisite gate explicitly: *"Prerequisite: v0.2.0 checkpoint must be fully complete (all Phase 2 PRs merged) before PR-3b implementation begins."* This is correct and was not present in Round 2.
+
+PR-3a's scope has been reconciled with `benchmark-harness.md`. The governing spec is named inline. The scope now describes `--strategy` flags on `locomo_bench`, the `strategies.rs` registry, `stats.rs` P95 latency helper, `LoCoMoSummary` field additions, `baselines.json` creation, `bench.sh` gate logic update, `compare_strategies.py`, and `bench.sh --compare A B` mode. This is the benchmark-harness spec's model, not the abandoned standalone binary. The ambiguity that caused Round 2's most important finding is gone.
+
+The Quality Gate Summary now carries the sentence: *"The benchmark gate compares against `docs/benchmarks/baselines.json` (see `benchmark-harness.md` §4). Before PR-3a lands, the gate uses the existing CSV-grep baseline."* This resolves the R2 finding that the gate had no stated baseline source. It is not elegant — "before PR-3a lands, the old way; after, the new way" is a transitional state the roadmap must manage — but the implementer now knows what they are dealing with.
+
+The Phase 4 prose and the PR Summary Table now agree on PR-4b. The PR Summary Table shows `Depends On: —`. The Phase 4 section reads: *"PR-4b can be opened any time after Phase 1 — it has no dependency on Phases 2 or 3."* The contradiction between prose and table is resolved.
+
+PR-4b's risk mitigation has been updated. It no longer says "spike first" in an unqualified way. It reads: *"The thin-wrapper pattern is documented in `module-decomposition.md` §2a with a working code example... Verify the rmcp 0.16 `#[tool_router]` proc-macro accepts cross-module handler delegation in the first commit before proceeding with the full extraction."* This is a verification step on the first commit — not a full throwaway spike before starting — and it cites the module-decomposition spec as the established solution. This is materially better than Round 2.
+
+AGENTS.md architectural documentation updates are now in the acceptance criteria of PR-4b and PR-4c. Both explicitly state which AGENTS.md references must be updated when the respective file splits are complete. This resolves Round 2's minor finding about documentation debt accruing unchecked through Phase 4.
+
+---
+
+### What Remains
+
+The Lidless Eye does not round up.
+
+---
+
+#### R2-minor-1 (PR-1a Full-Mode Regression Test): RESOLVED
+
+The PR-1a acceptance criterion now reads: *"Unit test asserting `McpToolMode::Full` (or default) returns all 19 registered tools from `TOOL_REGISTRY`."* This is explicit. The finding is resolved.
+
+---
+
+#### R2-minor-2 (PR-1c Deduplication Unit Test): RESOLVED
+
+PR-1c's acceptance criterion now reads: *"Unit test verifying that when two parallel sub-queries return the same `memory_id` with different scores, the result contains exactly one entry with `score = max(scores)`."* The behavioral change in `seen_ids` accumulation now has a required test. Resolved.
+
+---
+
+#### One Residual Issue Remains
+
+There is one matter of note that was not raised explicitly in either prior round but surfaces now in the fully-integrated reading of all four specs together.
+
+The PR-4b scope table in the roadmap lists `src/mcp/tools/graph.rs` for `memory_relations`. The module-decomposition spec's §2a target tree uses `src/mcp/tools/relations.rs` for `memory_relations`. These are different filenames for the same content. A minor inconsistency between roadmap and spec on a single filename. In prior rounds, this category of file-naming conflict was the seed of the `pipeline/` versus `advanced/` disaster that required a critical-severity R1 finding. Here it is a single file with unambiguous content assignment — an implementer will not be lost by it, but will pause and choose. The correct filename, per the module-decomposition spec's authoritative §2a layout, is `relations.rs`.
+
+This is the only new finding at any severity level. It is minor.
+
+---
+
+### The Final Assessment
+
+The roadmap is structurally sound. The critical failures of Round 1 are corrected. The important findings of Round 2 are corrected. The minor findings of Round 2 are corrected. Cross-spec consistency between the roadmap, `module-decomposition.md`, `trait-surface.md`, and `benchmark-harness.md` holds at every junction I have tested.
+
+The dependency graph is accurate. The dependency prose matches the dependency table. The phase sequence is internally consistent. The quality gate strategy distinguishes 2-sample automated gates from 10-sample manual gates and specifies which PRs require which. The risk registry covers the eight known risks. The branch naming and jj rebase protocol is complete. The conformance suite's trait scope is defined. The `substrate/` relationship is clearly delineated as a v0.3.x campaign. The `baselines.json` transition is acknowledged.
+
+What remains is one filename disagreement of minor consequence. That is all.
+
+A campaign of 21 issues over three rounds. Twenty remain resolved. One persists at minor severity.
+
+The wizard has repaired his keep. I acknowledge this the way Sauron acknowledges the rising sun: with recognition that it exists, and with no warmth whatsoever.
+
+The Palantir is satisfied. Dispatch the agents.
+
+---
+
+## FINDINGS
+
+### R1 Issue Verification
+
+- [R1-critical-1] **RESOLVED.** `admin.rs → admin/` split has PR-1d with full scope, ordered five-step execution, file size exceptions cross-referenced to `module-decomposition.md §4`, and correct acceptance criteria.
+
+- [R1-critical-2] **RESOLVED.** PR-4c targets `sqlite/pipeline/` with the 8-file layout matching `module-decomposition.md §2c` exactly. Names, file count, and content assignments are consistent across all specs.
+
+- [R1-critical-3] **RESOLVED.** `RetrievalStrategy` trait conflict eliminated. PR-4a split into PR-4a-i and PR-4a-ii. PR-4a-i defines `fn name() -> &str` and `async fn collect(ctx: &QueryContext) -> Result<CandidateSet>`, explicitly aligned with `trait-surface.md §3.2`. Design alignment note cites the spec section and rationale.
+
+- [R1-important-1] **RESOLVED.** "Relationship to trait-surface.md" section at top of roadmap explicitly states this roadmap delivers 2 of the 7 substrate traits, names them, and declares the full `substrate/` module as the v0.3.x campaign. Parallel authority problem eliminated.
+
+- [R1-important-2] **RESOLVED.** PR-3a acceptance criterion reads `cargo run --release --bin locomo_bench -- --strategy sqlite-v1 --list-strategies`. The "or a flag" hedge is gone. Ambiguity resolved.
+
+- [R1-important-3] **RESOLVED.** PR-4c acceptance criterion explicitly cites `module-decomposition.md §4` exceptions for `admin/maintenance.rs` (~580 lines) and `admin/welcome.rs` (~490 lines). Criterion will not fail on permitted exceptions.
+
+- [R1-important-4] **RESOLVED.** Dependency diagram and prose correctly show `PR-3a (independent, parallel with PR-3b)` and `PR-3b (depends on PR-2d) ──> PR-3c`. Phase 3 is no longer a flat parallel block.
+
+- [R1-important-5] **RESOLVED.** PR-2d requires a 10-sample gate. Quality Gate Summary table and PR-2d acceptance criterion are explicit. 10-sample gates are labeled as manual pre-merge checks; CI enforces 2-sample fast mode.
+
+- [R1-important-6] **RESOLVED.** Risk #6 in the registry covers the visibility cascade for PR-2c, with the mitigation: re-export `SqliteStorage` from `mod.rs` as the first step before moving any methods.
+
+- [R1-important-7] **RESOLVED.** Risk #7 covers PR-2b benchmark warning chain-blocking. Mitigation: if the 10-sample run confirms no regression, proceed; if it confirms regression, fix PR-2b before continuing.
+
+- [R1-important-8] **RESOLVED.** Risk #8 covers PR-1c ConnPool scope expansion. Mitigation: spike `ConnPool` reader availability before committing to scope; escalate to L-complexity or defer if concurrent readers are unsupported.
+
+- [R1-important-9] **RESOLVED.** PR-3c conformance suite explicitly excludes `AdvancedSearcher` and `PhraseSearcher` from the generic bound. Common-subset contract is defined. The implementer cannot choose by accident.
+
+- [R1-important-10] **RESOLVED.** Branch Naming and Rebase Protocol section added. All 15 PR bookmarks are named. jj rebase commands for each serial dependency transition are spelled out. Worktree isolation instruction is present.
+
+- [R1-important-11] **RESOLVED.** PR-4b risk mitigation cites `module-decomposition.md §2a` as the established thin-wrapper solution and instructs verification on the first commit rather than a full throwaway spike. Ambiguity between "uncertain" and "confirmed" is resolved in favor of the spec-documented pattern.
+
+- [R1-important-12] **RESOLVED.** PR-2c acceptance criterion now references `module-decomposition.md §6` test gates and includes `./scripts/bench.sh --gate` even for the structural move.
+
+- [R1-important-PR-4a] **RESOLVED.** PR-4a-ii `KeywordOnlyStrategy` returns `CandidateSet` per trait contract. Scoring happens downstream. Dead-end abstraction is gone.
+
+- [R1-important-PR-4c] **RESOLVED.** PR-4c pre-split audit requirement is explicit: audit shared helper types and extract to `mod.rs` re-exports or `types.rs` before splitting to avoid circular imports.
+
+- [R1-minor-1] **RESOLVED.** PR-1a acceptance criterion now includes: "Unit test asserting `McpToolMode::Full` (or default) returns all 19 registered tools from `TOOL_REGISTRY`."
+
+- [R1-minor-4] **RESOLVED.** PR-4b dependency corrected. PR-4b has no dependency on Phase 3. PR Summary Table shows `Depends On: —`. Phase 4 prose matches.
+
+- [R1-minor-5] **RESOLVED.** Quality Gate Summary states: "The benchmark gate compares against `docs/benchmarks/baselines.json` (see `benchmark-harness.md §4`). Before PR-3a lands, the gate uses the existing CSV-grep baseline." Baseline source is explicit.
+
+- [R1-minor-6] **RESOLVED (partially in R1, fully here).** v0.2.0 semver bump: the Version Targets Summary now labels Phase 2 as "Scoring decoupling + `sqlite/mod.rs` structural cleanup" without claiming new user-visible capability. No overclaim.
+
+---
+
+### R2 Issue Verification
+
+- [R2-important-1] **RESOLVED.** Quality Gate Summary now references `baselines.json` as the authoritative baseline source with a transition note ("Before PR-3a lands, the gate uses the existing CSV-grep baseline").
+
+- [R2-important-2] **RESOLVED.** PR-3a scope is now explicitly governed by `benchmark-harness.md`: "Governing spec: `benchmark-harness.md` defines the detailed design for the strategy comparison feature. PR-3a implements that spec. Where this section summarizes, the benchmark-harness spec is authoritative." The scope bullets enumerate all components from the spec. Standalone binary / `locomo_bench` flag ambiguity is gone.
+
+- [R2-important-3] **RESOLVED.** Phase 4 prose and PR Summary Table agree. PR-4b has no dependency. The roadmap states: "PR-4b can be opened any time after Phase 1 — it has no dependency on Phases 2 or 3."
+
+- [R2-important-4] **RESOLVED.** PR-4b risk mitigation no longer reads as speculative. It cites `module-decomposition.md §2a` as the established solution and prescribes a verification step on the first commit, not an open-ended spike.
+
+- [R2-important-5] **RESOLVED.** v0.2.1 checkpoint now carries: "Prerequisite: v0.2.0 checkpoint must be fully complete (all Phase 2 PRs merged) before PR-3b implementation begins." Phase 2 hard dependency is visible at the checkpoint.
+
+- [R2-minor-1] **RESOLVED.** PR-1a acceptance criterion now includes the Full-mode 19-tool test.
+
+- [R2-minor-2] **RESOLVED.** PR-1c acceptance criterion now includes the sub-query deduplication unit test with `score = max(scores)` assertion.
+
+- [R2-minor-3] **RESOLVED.** AGENTS.md architectural documentation updates are in the acceptance criteria of both PR-4b (reflecting `src/mcp/` structure) and PR-4c (reflecting `sqlite/pipeline/` and `sqlite/admin/` structures).
+
+---
+
+### New Findings (Round 3)
+
+- [severity:minor] [execution-roadmap.md PR-4b scope table / module-decomposition.md §2a] Filename inconsistency: the roadmap's PR-4b scope table lists `src/mcp/tools/graph.rs` for `memory_relations`. The module-decomposition spec's §2a authoritative target tree uses `src/mcp/tools/relations.rs` for the same content. An implementer will notice the discrepancy and resolve it, but must choose the correct name without guidance. Fix: update PR-4b scope table entry from `tools/graph.rs` to `tools/relations.rs` to match `module-decomposition.md §2a`.
+
+---
+
+### Summary
+
+| Round | Issues Found | Issues Resolved | Remaining |
+|-------|-------------|-----------------|-----------|
+| R1    | 3 critical, 10 important, 3 minor | All 16 | 0 |
+| R2    | 5 important, 3 minor | All 8 | 0 |
+| R3    | 1 minor | 0 (new) | 1 minor |
+
+**Overall: 1 minor finding remains (filename mismatch: `tools/graph.rs` vs `tools/relations.rs` in PR-4b scope table).**
+
+---
+
+## Implementation Dispatch Confidence
+
+**92 / 100**
+
+The roadmap is ready for Phase 1 implementation dispatch. The three critical issues that would have caused an implementing agent to build the wrong codebase are gone. The dependency graph is correct. The quality gates are specified. The jj workflow is documented. The spec hierarchy is clear.
+
+The 8-point deduction is not for what remains — one minor filename mismatch will not derail any agent. It is for the inherent residual risk in a 15-PR campaign that touches the hottest scoring paths in the codebase, with two manual 10-sample benchmark gates that CI cannot enforce and one ConnPool assumption (Risk #8) that has not been verified by inspection, only listed as a risk. These are known unknowns, properly documented. Known unknowns at 8 points; unknown unknowns at 0.
+
+Dispatch Phase 1 now. Phase 1 PRs are all independent and none of them touch the risky paths. Discovery will happen there before the Phase 2 serial chain begins.

--- a/docs/strongholds/recon-dead-code.md
+++ b/docs/strongholds/recon-dead-code.md
@@ -1,0 +1,230 @@
+# Dead Code and Tech Debt Reconnaissance Report
+
+**Stronghold:** `/Users/george/repos/mag/docs/strongholds/recon-dead-code.md`  
+**Compiled:** 2026-04-14  
+**Status:** Read-only scout mission complete
+
+## Summary
+
+The MAG codebase is **exceptionally clean** with minimal dead code. All 43 explicit `#[allow(dead_code)]` suppressions are justified by:
+- **Feature gates** (daemon-http, real-embeddings, sqlite-vec)
+- **Cross-module visibility** (setup.rs cannot see test usage)
+- **Optional implementations** (placeholder embedders, hot cache methods)
+
+**Dead Code Scope:** ~15 functions / 600 LOC of intentionally-suppressed code; **0 orphaned/unreachable code detected**.
+
+---
+
+## Detailed Findings
+
+### 1. Explicit Dead Code Suppressions: 43 Total
+
+| Category | Count | Location | Rationale |
+|----------|-------|----------|-----------|
+| Feature-gated daemon | 8 | `src/main.rs`, `src/lib.rs`, `src/daemon.rs` | Only used when `daemon-http` feature enabled |
+| Cross-module test usage | 4 | `src/tool_detection.rs`, `src/config_writer.rs`, `src/app_paths.rs` | Clippy cannot trace setup.rs/test usage |
+| Optional embedder code | 3 | `src/memory_core/embedder.rs` | Placeholder implementations when ONNX disabled |
+| Scoring params methods | 8 | `src/memory_core/storage/sqlite/mod.rs` | Used by grid search benchmarks and external APIs |
+| Hot cache query method | 1 | `src/memory_core/storage/sqlite/hot_cache.rs` | Alternative query path (aliased by wrapper) |
+| Benchmark utilities | 12+ | `benches/bench_utils/`, `benches/locomo/`, `benches/longmemeval/` | Test-harness and metric collection |
+
+**Code Quality:** Every suppression includes an explanatory comment confirming intentional design.
+
+### 2. Feature-Gated Code
+
+#### daemon-http (HTTP server, auth layer, idle timeout)
+- **Modules:** `src/daemon.rs`, `src/auth.rs`, `src/idle_timer.rs`
+- **Usage:** Optional HTTP transport for MCP server
+- **Status:** Feature properly isolated; 0 leakage into base functionality
+- **Recommendation:** Status quo; design is sound
+
+#### real-embeddings (ONNX, reranker, scoring)
+- **Suppressions:** 40+ `#[cfg(feature = "real-embeddings")]` directives
+- **Conditional paths:** PlaceholderEmbedder vs OnnxEmbedder; scoring algorithms
+- **Status:** Well-encapsulated; placeholder mode is production-ready fallback
+- **Recommendation:** Status quo; dual-mode design enables offline usage
+
+#### sqlite-vec (Vector similarity search)
+- **Code paths:** 12+ search variants based on feature flag
+- **Status:** Both paths implemented (sqlite-vec vs fallback SQL)
+- **Recommendation:** Status quo; feature parity maintained
+
+#### mimalloc (Memory allocator)
+- **Usage:** `#[global_allocator]` in src/main.rs (line 2)
+- **Status:** Properly integrated
+- **Recommendation:** Status quo; optional performance optimization
+
+---
+
+### 3. Cross-Module Test Usage
+
+**Issue Identified:** `tool_detection.rs`, `config_writer.rs`, and `app_paths.rs` have dead_code suppressions because:
+
+```rust
+// src/tool_detection.rs:168
+#[allow(dead_code)] // Used by setup.rs and tests; clippy can't trace cross-module usage
+impl DetectionResult {
+    pub fn unconfigured(&self) -> Vec<&DetectedTool> { ... }
+    pub fn any_configured(&self) -> bool { ... }
+}
+```
+
+**Clippy Limitation:** Cross-crate/cross-module usage is not visible to the compiler's dead code analysis. These are **legitimately used** by:
+- `src/setup.rs` (tool detection flow)
+- Test suites (private test modules)
+
+**Recommendation:** Current suppression is justified and correct.
+
+---
+
+### 4. Test-Only Code
+
+**Properly Isolated:**
+- `src/test_helpers.rs` (76 lines): Mutex-protected temp HOME for parallel tests
+  - Marked `#[cfg(test)]` in both `src/lib.rs` and `src/main.rs`
+  - Used by: `setup.rs`, `tool_detection.rs`, `config_writer.rs`, `uninstall.rs` tests
+
+**Test Functions:** 100+ across codebase
+- All properly annotated with `#[test]`
+- No test code leaked into production modules
+- Serial test protection: `serial_test` crate for HOME mutation tests
+
+**Status:** ✅ No issues detected
+
+---
+
+### 5. Linting Configuration
+
+```toml
+[lints.rust]
+unused_must_use = "deny"       # ✅ Enforced
+unreachable_patterns = "deny"  # ✅ Enforced
+unused_imports = "deny"        # ✅ Enforced
+unused_variables = "deny"      # ✅ Enforced
+dead_code = "warn"             # Design choice (not deny)
+```
+
+**Why `warn` for dead_code?** Per inline comment:
+> "warn not deny — parallel agents may create functions before callers exist"
+
+This is intentional for multi-agent development scenarios where function definitions may precede call sites.
+
+---
+
+### 6. TODO and FIXME Comments
+
+**Inventory:** 1 TODO found
+
+| Location | Issue | Severity | Status |
+|----------|-------|----------|--------|
+| `src/memory_core/storage/sqlite/advanced.rs:1541` | Parallelize sub-queries when pool supports concurrent | Enhancement | Open (#121) |
+
+**Observation:** Minimal tech debt; only one identified improvement item.
+
+---
+
+### 7. Dependency Analysis
+
+#### All 6 Optional Dependencies are Used:
+
+1. **ort** (`real-embeddings`)
+   - Used in: `src/memory_core/reranker.rs` (ONNX model inference)
+   - Lines: Session creation, optimization level config
+   - Status: ✅ Required
+
+2. **tokenizers** (`real-embeddings`)
+   - Used in: `src/memory_core/reranker.rs` (text tokenization)
+   - Lines: Tokenizer loading, truncation setup
+   - Status: ✅ Required
+
+3. **ndarray** (`real-embeddings`)
+   - Used in: Scoring algorithms and embeddings (transitive via ort/reranker)
+   - Status: ✅ Required
+
+4. **dotenvy** (`real-embeddings`)
+   - Used in: Embedder initialization (config loading)
+   - Status: ✅ Required
+
+5. **mimalloc** (optional allocator)
+   - Used in: `src/main.rs:2` as `#[global_allocator]`
+   - Status: ✅ Performance optimization
+
+6. **sqlite-vec** (`sqlite-vec` feature)
+   - Used in: `src/memory_core/storage/sqlite/helpers.rs` and search paths
+   - Status: ✅ Alternative vector search backend
+
+**Conclusion:** Zero unused dependencies.
+
+---
+
+### 8. Code Metrics
+
+| Metric | Value | Notes |
+|--------|-------|-------|
+| Source files | 40 | src/ directory |
+| Total functions | 1,112+ | Private functions across codebase |
+| Dead code suppressions | 43 | All justified |
+| Test functions | 100+ | All properly gated |
+| Benchmark binaries | 6 | All feature-constrained |
+| Benchmark LOC | 7,197 | Separate build target |
+| TODO/FIXME items | 1 | Minimal tech debt |
+
+---
+
+### 9. Code Health Assessment
+
+#### Strengths
+✅ **Strict linting:** Unused imports, variables, must_use all enforced as deny  
+✅ **Feature parity:** Real-embeddings and placeholder modes fully tested  
+✅ **Test isolation:** Proper use of mutex guards for concurrent test safety  
+✅ **Cross-module visibility:** Proper use of `#[allow(dead_code)]` with explanatory comments  
+✅ **No deprecated code:** Zero deprecated functions found  
+✅ **Numerical safety:** Explicit denials on cast truncation/loss  
+
+#### Minor Items
+⚠️ **One TODO (#121):** Sub-query parallelization enhancement pending  
+
+#### No Issues Found
+✅ No orphaned code  
+✅ No unreachable patterns  
+✅ No unused dependencies  
+✅ No stale feature gates  
+✅ No test code leakage  
+
+---
+
+## Recommendations
+
+### 1. Status Quo (No Action Required)
+- **Feature gates are well-designed:** daemon-http and real-embeddings properly isolated
+- **Suppressions are justified:** All 43 dead_code suppressions have valid explanations
+- **Test infrastructure is solid:** Mutex-protected temp directories; proper isolation
+
+### 2. Future Improvements (Optional)
+- **Issue #121:** Consider parallelizing sub-queries when async pool supports concurrent queries
+- **Monitoring:** Continue linting enforcement at current strictness levels
+
+### 3. Documentation
+- Consider adding a DEVELOPMENT.md section explaining:
+  - Why `dead_code = "warn"` (not deny) for parallel agent scenarios
+  - Feature gate strategy (real-embeddings vs placeholder)
+  - Cross-module visibility limitations in Clippy
+
+---
+
+## Conclusion
+
+**MAG is exceptionally clean.** The codebase exhibits:
+- **Minimal technical debt** (1 TODO item)
+- **Zero orphaned code** (all functions reachable and used)
+- **Strategic feature gating** (daemon, embeddings, vector search)
+- **Rigorous linting** (deny on all major categories except dead_code)
+- **Intentional suppressions** (every `allow(dead_code)` justified)
+
+**Estimated "Dead Code" Scope:**
+- ~15 functions / ~600 LOC of *intentionally-suppressed* code
+- 0 functions / 0 LOC of *unreachable* code
+- 0 unused dependencies
+
+**Verdict:** Code is production-ready with minimal cleanup overhead.
+

--- a/docs/strongholds/recon-source-tree.md
+++ b/docs/strongholds/recon-source-tree.md
@@ -1,0 +1,403 @@
+# MAG Rust Source Code Structure — Complete Recon Map
+
+**Generated**: 2026-04-14  
+**Scout**: Uruk-hai Agent  
+**Stronghold Path**: `/Users/george/repos/mag/docs/strongholds/recon-source-tree.md`
+
+---
+
+## Executive Summary
+
+The MAG codebase comprises **41 Rust source files** across two main domains:
+- **Domain Layer**: Memory system abstractions (traits, domain models)
+- **Storage/Backend Layer**: SQLite-backed implementation with pluggable embeddings
+- **CLI/Server Layer**: Command-line interface and MCP protocol server
+
+**Key Findings**:
+- **9 god modules** identified (>500 lines) — primarily in sqlite storage subsystem
+- **28 public traits** — core abstractions for memory operations
+- **22 core domain structs** — data models and pipeline configurations
+- **Module hierarchy**: Well-separated concerns (domain → traits → storage → sqlite)
+- **Concerns Analysis**: SQLite module handles too many responsibilities (CRUD, graph ops, lifecycle, NLP)
+
+---
+
+## I. File Inventory with Line Counts
+
+### Root Level (9 files)
+
+| File | Lines | Purpose | Category |
+|------|-------|---------|----------|
+| `lib.rs` | 25 | Module re-exports, in-memory test helpers | Metadata |
+| `main.rs` | 1,725 | CLI command routing, daemon HTTP, MCP stdio server | **GOD MODULE** |
+| `mcp_server.rs` | 2,709 | MCP protocol handler with 19 tools | **GOD MODULE** |
+| `cli.rs` | 1,255 | CLI argument parsing and command dispatch | **GOD MODULE** |
+| `setup.rs` | 1,844 | Interactive setup wizard and config generation | **GOD MODULE** |
+| `config_writer.rs` | 1,844 | Configuration file generation and defaults | **GOD MODULE** |
+| `uninstall.rs` | 1,382 | Uninstall routines and cleanup | **GOD MODULE** |
+| `tool_detection.rs` | 1,395 | Tool invocation analysis and detection | **GOD MODULE** |
+| `benchmarking.rs` | 372 | Benchmark harness and metadata | Standard |
+
+### Authentication & Infrastructure (4 files)
+
+| File | Lines | Purpose | Category |
+|------|-------|---------|----------|
+| `auth.rs` | 243 | Tower auth middleware for HTTP | Standard |
+| `idle_timer.rs` | 143 | Idle timeout tracking for daemon | Standard |
+| `app_paths.rs` | 176 | XDG-compliant path resolution | Standard |
+| `daemon.rs` | 283 | Daemon HTTP server setup | Standard |
+
+### Test Utilities (1 file)
+
+| File | Lines | Purpose | Category |
+|------|-------|---------|----------|
+| `test_helpers.rs` | 75 | Mock implementations for testing | Test Helper |
+
+### Binaries (1 file)
+
+| File | Lines | Purpose | Category |
+|------|-------|---------|----------|
+| `bin/fetch_benchmark_data.rs` | 63 | Standalone benchmark data fetcher | Utility Binary |
+
+### Memory Core Domain (3 files)
+
+| File | Lines | Purpose | Category |
+|------|-------|---------|----------|
+| `memory_core/mod.rs` | 419 | Pipeline orchestrator + module re-exports | Standard |
+| `memory_core/domain.rs` | 587 | Domain types: MemoryInput, SearchResult, EventType | Standard |
+| `memory_core/traits.rs` | 285 | 28 public traits defining storage interface | Standard |
+
+### Memory Core Processing (3 files)
+
+| File | Lines | Purpose | Category |
+|------|-------|---------|----------|
+| `memory_core/embedder.rs` | 967 | Placeholder + ONNX embedder implementations | Standard |
+| `memory_core/reranker.rs` | 384 | Cross-encoder reranking for search results | Standard |
+| `memory_core/scoring.rs` | 1,216 | Semantic search scoring, decay, and weighting | **GOD MODULE** |
+
+### Storage Layer (1 file, metadata module)
+
+| File | Lines | Purpose | Category |
+|------|-------|---------|----------|
+| `memory_core/storage/mod.rs` | 4 | Re-exports sqlite submodule | Metadata |
+
+### SQLite Backend (15 files, 18,251 lines total)
+
+| File | Lines | Purpose | Category | Concern Count |
+|------|-------|---------|----------|---|
+| `sqlite/mod.rs` | 1,281 | Primary struct + trait impls | **GOD MODULE** | 5+ |
+| `sqlite/tests.rs` | 7,632 | Integration test suite | Test Suite | - |
+| `sqlite/schema.rs` | 427 | DDL definitions and migrations | Standard | 1 |
+| `sqlite/entities.rs` | 482 | Row-to-struct mapping | Standard | 1 |
+| `sqlite/embedding_codec.rs` | 62 | Vector serialization for sqlite-vec | Standard | 1 |
+| `sqlite/conn_pool.rs` | 336 | Connection pooling (WAL mode) | Standard | 1 |
+| `sqlite/crud.rs` | 809 | Create/read/update/delete operations | **GOD MODULE** | 3+ |
+| `sqlite/session.rs` | 601 | Session lifecycle and summary | Standard | 2 |
+| `sqlite/helpers.rs` | 1,237 | Scoring helpers and utilities | **GOD MODULE** | 3+ |
+| `sqlite/hot_cache.rs` | 276 | LRU in-memory cache for frequent queries | Standard | 1 |
+| `sqlite/lifecycle.rs` | 271 | Memory expiration and housekeeping | Standard | 2 |
+| `sqlite/temporal.rs` | 280 | Time-based querying and decay | Standard | 1 |
+| `sqlite/search.rs` | 423 | FTS and full-text search | Standard | 1 |
+| `sqlite/nlp.rs` | 547 | Lemmatization, stemming, tokenization | Standard | 1 |
+| `sqlite/query_classifier.rs` | 450 | Query type detection and routing | Standard | 1 |
+| `sqlite/admin.rs` | 1,619 | Health checks, backup, consolidation | **GOD MODULE** | 4+ |
+| `sqlite/advanced.rs` | 1,739 | Compaction, deduplication, graph ops | **GOD MODULE** | 4+ |
+| `sqlite/graph.rs` | 532 | Relationship graph operations | Standard | 1 |
+
+---
+
+## II. God Modules (>500 lines)
+
+Files exhibiting multiple unrelated concerns and candidates for refactoring:
+
+### Tier 1: Critical Refactoring Needed (>1500 lines)
+
+1. **`mcp_server.rs` (2,709 lines)**
+   - Concerns: MCP protocol marshaling, 19 tool definitions, error handling, parameter validation
+   - Should split: `mcp_protocol.rs`, `mcp_tools/{batch.rs, query.rs, manage.rs, admin.rs}`
+
+2. **`sqlite/mod.rs` (1,281 lines)**
+   - Concerns: Connection pool management, query caching, trait impls (Storage, Retriever, Searcher, Deleter, Updater, Tagger, Lister, RelationshipQuerier, VersionChainQuerier, FeedbackRecorder, ExpirationSweeper, ProfileManager, CheckpointManager, ReminderManager, LessonQuerier, MaintenanceManager, WelcomeProvider, BackupManager, StatsProvider), hot cache invalidation
+   - **SEVERE**: Implements 19 public traits; should delegate to submodules per concern
+   - Should split: Keep only initialization and dispatch logic; move trait impls to respective submodules
+
+3. **`setup.rs` (1,844 lines)** / **`config_writer.rs` (1,844 lines)**
+   - Concerns: Interactive prompts, file I/O, config generation, validation
+   - Could merge these or split each into `prompts.rs` + `writer.rs`
+
+4. **`sqlite/admin.rs` (1,619 lines)**
+   - Concerns: Health checks, backup/restore, consolidation, rotation, compaction coordination
+   - Should split: `backup_manager.rs`, `health_check.rs`, `consolidation.rs`
+
+5. **`sqlite/advanced.rs` (1,739 lines)**
+   - Concerns: Compaction algorithm, graph traversal, deduplication, feedback accumulation
+   - Should split: `compaction.rs`, `graph_operations.rs`, `feedback.rs`
+
+### Tier 2: Moderate Refactoring (1000-1500 lines)
+
+6. **`main.rs` (1,725 lines)**
+   - Concerns: Tokio runtime setup, daemon lifecycle, MCP dispatcher, CLI fallback routing
+   - Should split: `daemon_http.rs`, `mcp_dispatcher.rs`, separate CLI into subcommands
+
+7. **`cli.rs` (1,255 lines)**
+   - Concerns: Argument parsing, command dispatch, output formatting, error messages
+   - Should split: `commands/{store.rs, query.rs, manage.rs, admin.rs}`, `output.rs`, `errors.rs`
+
+8. **`tool_detection.rs` (1,395 lines)**
+   - Concerns: Stack parsing, regex-based detection, tool classification, result formatting
+   - Should split: `parser.rs`, `detector.rs`, `classifier.rs`
+
+9. **`uninstall.rs` (1,382 lines)**
+   - Concerns: Interactive confirmation, file deletion, config cleanup, logging
+   - Should split: `remover.rs`, `prompts.rs`, `validators.rs`
+
+10. **`memory_core/scoring.rs` (1,216 lines)**
+    - Concerns: Scoring functions, decay curves, weight calculations, helper algorithms
+    - Should split: `semantic_scoring.rs`, `temporal_decay.rs`, `text_processing.rs`, `weighting.rs`
+
+### Tier 3: Minor Refactoring (600-1000 lines)
+
+11. **`sqlite/helpers.rs` (1,237 lines)**
+    - Concerns: Jaccard similarity, token overlap, embedding comparison, keyword extraction
+    - Should split: `similarity_metrics.rs`, `text_analysis.rs`, `keyword_extraction.rs`
+
+12. **`sqlite/crud.rs` (809 lines)**
+    - Concerns: Insert logic, bulk operations, update with auto-relations, delete cascades
+    - Could stay unified if kept focused on CRUD only (currently +relations logic)
+
+### Tier 4: Acceptable Size (500-600 lines)
+
+13. **`sqlite/session.rs` (601 lines)**
+    - Concerns: Session creation, summary generation, active session tracking
+    - Well-scoped — acceptable as-is
+
+14. **`sqlite/nlp.rs` (547 lines)**
+    - Concerns: Stopword lists, stemming, lemmatization, tokenization
+    - Well-scoped — acceptable as-is
+
+---
+
+## III. Public Trait Definitions (28 total)
+
+All traits located in: `/Users/george/repos/mag/src/memory_core/traits.rs`
+
+### CRUD Traits (5)
+- `Storage` — Store memory with MemoryInput
+- `Retriever` — Fetch memory by ID
+- `Deleter` — Delete by ID → bool
+- `Updater` — Partial updates via MemoryUpdate
+- `Lister` — Paginated list with count
+
+### Search Traits (7)
+- `Searcher` — Keyword/FTS search
+- `SemanticSearcher` — Embedding-based similarity search
+- `Recents` — Recent memories by timestamp
+- `PhraseSearcher` — Exact phrase matching
+- `AdvancedSearcher` — Combined scoring (semantic + keyword)
+- `SimilarFinder` — Find similar by memory_id
+- `Tagger` — Query by tags (AND logic)
+
+### Graph/Relationship Traits (3)
+- `GraphTraverser` — Multi-hop relationship traversal
+- `RelationshipQuerier` — Get all relationships for a memory
+- `VersionChainQuerier` — Track version supersession chains
+
+### Metadata Traits (8)
+- `ProfileManager` — User profile storage
+- `CheckpointManager` — Task checkpoints and resume
+- `ReminderManager` — Reminder CRUD and dismiss
+- `LessonQuerier` — Query lessons by context
+- `ExpirationSweeper` — TTL cleanup
+- `FeedbackRecorder` — Feedback collection
+- `MaintenanceManager` — Health, consolidate, compact, clear_session, auto_compact
+- `WelcomeProvider` — Session briefing generation
+
+### Admin Traits (2)
+- `BackupManager` — Create, rotate, restore, list backups
+- `StatsProvider` — Type/session/weekly/access stats
+
+### Embedder Trait (1)
+- `Embedder` (in `embedder.rs`) — Embed text → Vec<f32>
+
+### Legacy Trait Stubs (2)
+- `Ingestor` — Content ingestion (placeholder)
+- `Processor` — Content processing (placeholder)
+
+---
+
+## IV. Core Domain Structs (Domain Models)
+
+Located in: `/Users/george/repos/mag/src/memory_core/domain.rs`
+
+### Input/Configuration
+- `MemoryInput` — Memory with tags, importance, event_type, TTL, session/project context
+- `MemoryUpdate` — Partial update with optional fields
+- `SearchOptions` — Query filters (event_type, project, session_id, date range, importance min, tags)
+- `WelcomeOptions` — Session briefing configuration
+- `CheckpointInput` — Task checkpoint metadata
+
+### Domain Types
+- `EventType` (enum) — 22 event types (SessionSummary, Decision, ErrorPattern, ..., Unknown)
+- `MemoryKind` (enum) — Episodic vs Semantic classification
+
+### Output/Result Types
+- `SearchResult` — Memory + tags + importance + metadata (no score)
+- `SemanticResult` — SearchResult + similarity_score (f32)
+- `ListResult` — Paginated: Vec<SearchResult> + total_count
+- `GraphNode` — Hop-numbered relationship with weight and edge_type
+- `Relationship` — Directed edge: source → target with rel_type and metadata
+- `BackupInfo` — Backup path, size_bytes, created_at
+
+### Constants
+- TTL enums: `TTL_EPHEMERAL` (1h), `TTL_SHORT_TERM` (1d), `TTL_LONG_TERM` (14d)
+- Relationship types: `REL_PRECEDED_BY`, `REL_RELATES_TO`, `REL_SIMILAR_TO`, `REL_SHARES_THEME`, `REL_PARALLEL_CONTEXT`
+
+---
+
+## V. Storage Implementation Structs
+
+Located in: `/Users/george/repos/mag/src/memory_core/storage/sqlite/`
+
+### Main Implementation
+- `SqliteStorage` — 19 trait implementations, connection pool, query cache, hot cache
+
+### Supporting Structs
+- `ConnPool` — WAL-mode connection pooling (1 writer + N readers)
+- `HotTierCache` — LRU cache for frequent queries
+- `CachedQuery` — Query results + filter metadata
+- `ScoringParams` — Weighting configuration for search scoring
+- `CrossEncoderReranker` — ONNX model reranking (feature-gated)
+- `DetectedTool` — Tool invocation metadata from stack analysis
+
+---
+
+## VI. Module Hierarchy (Import Tree)
+
+```
+lib.rs
+├── app_paths
+├── benchmarking
+├── config_writer (private)
+├── daemon (feature-gated)
+├── memory_core
+│   ├── domain (private → pub use *)
+│   │   ├── EventType
+│   │   ├── MemoryInput
+│   │   ├── SearchResult
+│   │   └── ... (11 other types)
+│   ├── traits (private → pub use *)
+│   │   ├── Storage
+│   │   ├── Searcher
+│   │   └── ... (26 other traits)
+│   ├── embedder (public)
+│   │   ├── Embedder (trait)
+│   │   └── OnnxEmbedder / PlaceholderEmbedder
+│   ├── reranker (public)
+│   │   └── CrossEncoderReranker
+│   ├── scoring (public)
+│   │   └── ScoringParams, decay/weight functions
+│   └── storage (public)
+│       └── sqlite (public)
+│           ├── mod.rs (SqliteStorage + 19 impls)
+│           ├── schema.rs
+│           ├── entities.rs
+│           ├── crud.rs
+│           ├── session.rs
+│           ├── search.rs
+│           ├── nlp.rs
+│           ├── temporal.rs
+│           ├── graph.rs
+│           ├── hot_cache.rs
+│           ├── lifecycle.rs
+│           ├── helpers.rs
+│           ├── query_classifier.rs
+│           ├── admin.rs
+│           ├── advanced.rs
+│           ├── conn_pool.rs
+│           ├── embedding_codec.rs
+│           └── tests.rs
+├── setup
+├── tool_detection (private)
+└── uninstall
+
+main.rs (CLI + MCP dispatcher)
+  └── routes to: setup, config_writer, tool_detection, daemon, mcp_server
+
+mcp_server.rs (standalone MCP protocol handler)
+  └── 19 tools mapping to memory_core traits
+```
+
+---
+
+## VII. Concerns Analysis: Files Doing Multiple Things
+
+### Critical Multi-Concern Files
+
+| File | Concern Count | Concerns | Severity |
+|------|---|----------|----------|
+| `sqlite/mod.rs` | 19+ | CRUD, search, graph, relationships, versions, feedback, expiration, profiles, checkpoints, reminders, lessons, maintenance, welcome, backups, stats | **CRITICAL** |
+| `sqlite/admin.rs` | 4 | Health checks, backup/restore, consolidation, rotation | HIGH |
+| `sqlite/advanced.rs` | 4 | Compaction, graph traversal, feedback, deduplication | HIGH |
+| `mcp_server.rs` | 4 | Protocol marshaling, 19 tools (store, retrieve, search, update, delete, graph, etc.), validation, error mapping | HIGH |
+| `main.rs` | 3 | Tokio runtime, daemon HTTP, MCP stdio, CLI fallback | HIGH |
+| `sqlite/helpers.rs` | 3 | Similarity metrics, text analysis, keyword extraction | MEDIUM |
+| `cli.rs` | 3 | Argument parsing, command dispatch, output formatting | MEDIUM |
+| `tool_detection.rs` | 3 | Stack parsing, regex detection, classification | MEDIUM |
+| `setup.rs` | 2 | Interactive prompts, config generation | MEDIUM |
+| `sqlite/session.rs` | 2 | Session lifecycle, summary generation | LOW (scoped) |
+| `sqlite/crud.rs` | 2 | Insert/update/delete + auto-relationship logic | MEDIUM |
+
+### Refactoring Recommendations Priority
+
+**Phase 1 (Breaking)**: Extract `sqlite/mod.rs` trait dispatch logic
+**Phase 2 (High Value)**: Decompose `mcp_server.rs` tools into submodules
+**Phase 3 (Polish)**: Split `admin.rs` and `advanced.rs` by concern
+**Phase 4 (Nice to Have)**: Consolidate `setup.rs` + `config_writer.rs`
+
+---
+
+## VIII. Test Coverage
+
+- **Primary**: `sqlite/tests.rs` (7,632 lines) — Integration tests for all SQLite operations
+- **In-module**: Tests in `memory_core/mod.rs` (87 lines) for pipeline mocks
+- **Helpers**: `test_helpers.rs` (75 lines) for mock implementations
+
+---
+
+## IX. Key Architectural Insights
+
+1. **Clear Separation**: Domain (traits) → Storage (impl) → Server (dispatch)
+2. **Single Storage**: SQLite monolith with 19 trait implementations — should be delegated
+3. **Pluggable Embeddings**: Placeholder (testing) and ONNX (production) — good design
+4. **Scoring Decoupling**: Scoring logic in separate module, reused by search and compaction
+5. **Cache Layering**: Query-result cache (LRU) + hot-tier memory cache for performance
+6. **MCP Protocol**: Unified interface for AI agents via stdio transport
+
+---
+
+## X. Statistics Summary
+
+- **Total Rust Files**: 41
+- **Total Lines of Code**: 49,871
+- **God Modules (>500 lines)**: 9
+- **Public Traits**: 28
+- **Core Domain Structs**: 11
+- **Module Nesting Depth**: 3 (lib → memory_core → storage → sqlite)
+- **Largest File**: `sqlite/tests.rs` (7,632 lines, mostly test cases)
+- **Largest Implementation**: `mcp_server.rs` (2,709 lines, protocol + tools)
+- **Storage Subsystem Ratio**: 37% of codebase (18,251 / 49,871 lines)
+
+---
+
+## XI. Closure: Stronghold Findings
+
+| Metric | Value | Status |
+|--------|-------|--------|
+| Files Scanned | 41 | ✓ Complete |
+| Lines Analyzed | 49,871 | ✓ Complete |
+| God Modules Found | 9 | ⚠ Refactoring Needed |
+| Traits Catalogued | 28 | ✓ Well-Organized |
+| Module Hierarchy | 3 levels | ✓ Clean |
+| Concerns Extraction Candidates | 11 files | ⚠ In Progress |
+| Critical Hotspot | `sqlite/mod.rs` (19 impls in 1,281 lines) | 🔴 HIGH PRIORITY |
+

--- a/docs/strongholds/recon-test-infra.md
+++ b/docs/strongholds/recon-test-infra.md
@@ -1,0 +1,287 @@
+# Test & Benchmark Infrastructure Reconnaissance
+
+**Scout**: Uruk-hai reconnaissance unit  
+**Mission**: Map test coverage, benchmark harness, and retrieval eval infrastructure  
+**Date**: 2026-04-14  
+**Status**: Complete
+
+---
+
+## Executive Summary
+
+MAG has a mature, multi-layered test and benchmark infrastructure optimized for retrieval quality validation:
+
+- **25/40 source modules have unit tests** (62.5% test coverage by module count)
+- **Three production benchmarks**: LoCoMo-10, LongMemEval, scale degradation
+- **Comprehensive benchmark harness** with CSV logging, scoring modes, and embedder variants
+- **CI integration** with automated regression gates on scoring/search changes
+- **Well-documented methodology** and baseline comparison pipeline
+- **Gap**: No pre-commit hook for test execution (prek validates formatting only)
+
+---
+
+## Directory Map & Test Infrastructure
+
+### Source Tree Test Coverage
+
+```
+/Users/george/repos/mag/src/                    [40 Rust files total]
+├── Top-level (14 files)
+│   ├── lib.rs                                   [TESTED]
+│   ├── main.rs                                  [TESTED] 
+│   ├── benchmarking.rs                          [TESTED] — dataset download & caching
+│   ├── mcp_server.rs                            [TESTED] — MCP protocol
+│   ├── auth.rs                                  [TESTED] — credential handling
+│   ├── config_writer.rs                         [TESTED] — TOML writing
+│   ├── app_paths.rs                             [TESTED] — XDG home paths
+│   ├── idle_timer.rs                            [TESTED] — session timeout
+│   ├── daemon.rs                                [TESTED] — HTTP daemon
+│   ├── cli.rs                                   [TESTED] — CLI argument parsing
+│   ├── setup.rs                                 [TESTED] — initialization
+│   ├── uninstall.rs                             [UNTESTED]
+│   ├── tool_detection.rs                        [UNTESTED]
+│   └── test_helpers.rs                          [UTILITY] — shared test fixtures
+│
+└── memory_core/ (26 files)
+    ├── mod.rs                                   [TESTED]
+    ├── embedder.rs                              [TESTED] — embedding interface
+    ├── scoring.rs                               [TESTED] — retrieval scoring
+    ├── reranker.rs                              [TESTED] — cross-encoder reranking
+    └── storage/sqlite/ (20+ files)
+        ├── mod.rs                               [TESTED]
+        ├── tests.rs                             [TESTED] — comprehensive SQLite tests
+        ├── entities.rs                          [TESTED] — schema
+        ├── helpers.rs                           [TESTED]
+        ├── temporal.rs                          [TESTED] — time-series queries
+        ├── advanced.rs                          [TESTED] — graph/reranking
+        ├── nlp.rs                               [TESTED] — NLP utilities
+        ├── query_classifier.rs                  [TESTED] — question type detection
+        ├── conn_pool.rs                         [TESTED] — connection pooling
+        ├── [...and 11 more support modules]
+```
+
+**Module Test Statistics**:
+- Tested modules: 25 of 40 files (62.5%)
+- Untested modules: 15 files (mostly CLI utilities, error handlers, fallbacks)
+- Test lines: ~500-800 per module average
+- Test patterns: async/await (#[tokio::test]), in-memory SQLite, property-based
+
+---
+
+## Integration & Regression Tests
+
+### Tests Directory
+
+```
+/Users/george/repos/mag/tests/                  [4 Rust files + 6 shell scripts]
+├── mcp_smoke.rs                                 — MCP stdio handshake validation
+├── cli_output_smoke.rs                          — CLI invocation tests  
+├── schema_migration.rs                          — Database schema versioning
+├── longmemeval_regression.rs                    — Retrieval quality regression
+├── parity_harness.rs                            — End-to-end parity check
+└── hooks/ (6 shell scripts)                     — Plugin lifecycle testing
+```
+
+---
+
+## Benchmark Infrastructure (Three Tiers)
+
+### Tier 1: LoCoMo-10 Benchmark (Production Quality)
+
+**Location**: `/Users/george/repos/mag/benches/locomo/main.rs` + 8 support modules  
+**Dataset**: SNAP Research LoCoMo-10 (multi-hop reasoning, 10 conversations)  
+**Metrics**: Overall score + question-type breakdowns (single-hop, temporal, multi-hop, open-domain, adversarial)
+
+**Embedder Options** (12 models tested):
+- `--bge-small` (ONNX int8, 768-dim) — production default (4.9ms embed, 91.5% overall)
+- `--voyage-onnx --voyage-quant int8` (2048-dim Matryoshka variants)
+- `--openai-embeddings` (text-embedding-3-large, 93.0% overall, 444ms)
+- `--granite`, `--minilm-l6`, `--minilm-l12`, `--e5-small`, `--bge-base`, `--nomic`, `--arctic-xs`, `--arctic-s`, `--gte-small`
+
+**Scoring Modes**:
+- `substring` (default) — expected answer as substring in retrieved content
+- `word-overlap` — AutoMem-style word recall
+- `llm-f1` (requires --llm-judge or --local) — LLM-generated + token F1
+- `e2e-word-overlap` — end-to-end generation + word overlap
+
+**Limit Modes**:
+- `static` — flat top_k for all question types
+- `dynamic` (default) — scales with conversation size (turns/5, cap 200), 1.5x temporal, 2x multi-hop
+
+### Tier 2: LongMemEval Benchmark (Long-Context)
+
+**Location**: `/Users/george/repos/mag/benches/longmemeval/main.rs` + 7 support modules  
+**Dataset**: LongMemEval_S (500 synthetic Q&A pairs)  
+**Features**: `--official`, `--grid-search`, `--concurrent`, `--file-backed`, `--llm-judge`
+
+### Tier 3: Scale Degradation Benchmark
+
+**Location**: `/Users/george/repos/mag/benches/scale_bench.rs`  
+**Focus**: Throughput/latency/recall at scales: 1K, 5K, 10K, 50K memories
+
+---
+
+## Benchmark Harness & CI
+
+### Harness Script
+
+**Location**: `/Users/george/repos/mag/scripts/bench.sh`  
+**Purpose**: Standardized LoCoMo runner with CSV logging  
+**Output**: Appends to `docs/benchmarks/benchmark_log.csv` + LATEST.md
+
+**CSV Format** (16 columns):
+```
+date,commit,branch,issue_or_pr,scoring_mode,samples,embedding_model,
+overall_score,single_hop,temporal,multi_hop,open_domain,adversarial,
+evidence_recall,avg_embed_ms,notes
+```
+
+**Usage**:
+```bash
+./scripts/bench.sh                              # default: bge-small, word-overlap, 2 samples
+./scripts/bench.sh --model voyage-nano-int8
+./scripts/bench.sh --gate                       # compare against baseline, fail on regression
+```
+
+### Benchmark Log & Baselines
+
+**Status**: 33 runs logged (2026-03-18 to 2026-04-01)  
+**Key Baselines**:
+- Pre-improvement (2026-03-18): 70.6%
+- Target (PR#70): 90.52% ✓ achieved
+- Post-Wave-2 (2026-04-01): 91.5% on bge-small
+
+**Incumbent Models**:
+| Model | Overall | Single-hop | Multi-hop | Latency |
+|-------|---------|------------|-----------|---------|
+| bge-small (int8) | 91.5% | 87.1% | 75.6% | 4.9ms |
+| bge-base (int8) | 91.8% | 87.1% | 76.9% | 10.5ms |
+| text-embedding-3-large | 93.0% | 94.6% | 74.4% | 444ms |
+
+### CI Pipeline
+
+**Location**: `/Users/george/repos/mag/.github/workflows/ci.yml`
+
+**Jobs**:
+- `check`: rustfmt + clippy
+- `test`: cargo test --all-features
+- `version-check`: Cargo.toml vs npm vs PyPI
+- `benchmark`: Runs ./scripts/bench.sh --gate on PR if scoring/search files changed
+- `smoke-test`: MCP JSON-RPC handshake validation
+- `npm-install-test`: npm wrapper verification
+
+**Benchmark Gate** monitors:
+```
+src/memory_core/scoring/**
+src/memory_core/storage/sqlite/search*
+src/memory_core/storage/sqlite/advanced*
+```
+
+---
+
+## Pre-commit Hooks (prek)
+
+**Location**: `/Users/george/repos/mag/prek.toml`
+
+**Configured**:
+- trailing-whitespace (builtin)
+- end-of-file-fixer (builtin)
+- check-added-large-files --maxkb=1024 (builtin)
+- rustfmt (priority 10, auto-fix)
+- clippy (priority 20, serial, deny-all)
+- CodeRabbit lint (priority 30, optional, non-blocking)
+
+**Gap**: No automatic test execution on commit. Tests only run in CI.
+
+---
+
+## Retrieval Quality Regression Testing
+
+### Existing Test
+
+**File**: `/Users/george/repos/mag/tests/longmemeval_regression.rs`  
+**Purpose**: Multi-session vector search regression validation  
+**Scope**: Seeds 6 memories, queries via similarity, asserts ranking stability
+
+**Gap**: Only 1 focused regression test; broader quality regressions covered by benchmark harness (manual runs only)
+
+---
+
+## Test Coverage by Component
+
+### Well-Tested (>80% coverage)
+- Storage: SQLite pooling, FTS5, temporal queries, entities
+- Embeddings: ONNX loading, dimension reduction, batch processing
+- Scoring: Substring/word-overlap/ranking algorithms
+- Search: Keyword, semantic, reranking, graph expansion
+- MCP Protocol: Tool registration, initialization, marshaling
+- Config: TOML I/O, home paths, permissions
+
+### Under-Tested (<20% coverage)
+- CLI: Subcommand routing, argument validation (smoke tests only)
+- Daemon: HTTP server startup, shutdown
+- Error Handling: Fallback logic, recovery
+- Plugin Hooks: Event capture, filter gates (shell scripts only)
+
+---
+
+## Benchmark Gaps & Opportunities
+
+### Strengths
+✓ Comprehensive embedder coverage (12+ models)  
+✓ Multiple scoring modes  
+✓ CSV audit trail  
+✓ Automated PR gates  
+✓ Question-type breakdown  
+✓ Dynamic limit modes  
+✓ Cross-encoder integration  
+
+### Gaps
+1. **No trend dashboard** — log exists but no visualization/alerting
+2. **Limited baseline flexibility** — hardcoded 10-sample comparison
+3. **No nightly benchmarks** — LoCoMo only on PR, LongMemEval@official manual
+4. **No micro-benchmarks** — scoring/graph/reranking latencies not isolated
+5. **No mock LLM judge** — reproducibility requires API keys or local setup
+6. **Test-benchmark isolation** — cargo test doesn't include regression tests
+
+---
+
+## Summary: Stronghold State
+
+| Category | State | Details |
+|----------|-------|---------|
+| Unit Tests | Strong | 25/40 modules, ~500 tests |
+| Integration Tests | Good | 4 Rust + 6 shell suites |
+| Benchmark Suite | Excellent | 3 benchmarks, comprehensive CLI |
+| Benchmark Harness | Mature | CSV logging, baseline gates |
+| CI Integration | Strong | Auto-gate on scoring changes |
+| Regression Testing | Adequate | Manual; 1 focused retrieval test |
+| Retrieval Quality Gates | Operational | LoCoMo @ 91.5% on incumbent |
+| Pre-commit Hooks | Minimal | Lint only; no tests |
+| Dashboard/Viz | Missing | No trend graphs |
+| Nightly Benchmarks | Absent | Manual runs only |
+
+---
+
+## Stronghold Artifacts
+
+- Test Infrastructure Definition: This file
+- Benchmark Log: `/Users/george/repos/mag/docs/benchmarks/benchmark_log.csv`
+- Benchmark Methodology: `/Users/george/repos/mag/docs/benchmarks/methodology.md`
+- Test Harness Scripts: `/Users/george/repos/mag/scripts/{bench,smoke-test}.sh`
+- Benchmark Binaries: locomo_bench, longmemeval_bench, scale_bench
+
+---
+
+## Recommendations
+
+1. **Nightly Benchmark Workflow**: GitHub Actions scheduled job (LoCoMo@50 + LongMemEval@official)
+2. **Benchmark Dashboard**: Python script parsing CSV, generating PNG trend graphs
+3. **Pre-commit Test Hook**: Optional cargo test in prek.toml
+4. **Mock LLM Judge**: Deterministic scoring mode for CI
+5. **Micro-benchmarks**: Isolate scoring/graph/reranking latencies
+6. **Baseline Versioning**: Tag baselines by release (v0.1.x)
+
+---
+
+*Scout Report Complete. All strongholds mapped. Benchmark infrastructure formidable; recommend nightly validation monitoring.*

--- a/docs/strongholds/substrate-campaign.md
+++ b/docs/strongholds/substrate-campaign.md
@@ -1,0 +1,118 @@
+# MAG Experimentation Substrate Campaign
+
+**Status**: Planning complete, ready for Phase 1 implementation
+**Campaign Workspace**: `../mag-substrate` (jj workspace `substrate-campaign`)
+**Generated**: 2026-04-14
+
+## Vision
+
+MAG v0.2 is a Rust core exposing stable traits for Storage, Retrieval, Fusion, Scoring, Lifecycle, and Consolidation, with current SQLite + FTS5 + ONNX + multi-factor scoring preserved as the default reference implementation, and a benchmark harness that can run any swapped implementation against LoCoMo-10 with zero-regression as the merge gate.
+
+## Specs
+
+| Spec | Path | Status |
+|------|------|--------|
+| Module Decomposition | `docs/specs/module-decomposition.md` | Draft |
+| Trait Surface Design | `docs/specs/trait-surface.md` | Draft |
+| Benchmark Harness | `docs/specs/benchmark-harness.md` | Draft |
+| Execution Roadmap | `docs/specs/execution-roadmap.md` | Approved (3 Palantir rounds) |
+
+## Reconnaissance Strongholds
+
+| Recon | Path | Status |
+|-------|------|--------|
+| Source Tree Map | `docs/strongholds/recon-source-tree.md` | Complete |
+| Scoring Pipeline | `docs/strongholds/recon-scoring-pipeline.md` | Inline (not persisted) |
+| Dead Code Audit | `docs/strongholds/recon-dead-code.md` | Complete |
+| Test Infrastructure | `docs/strongholds/recon-test-infra.md` | Complete |
+| Existing Docs | `docs/strongholds/recon-existing-docs.md` | Inline (not persisted) |
+
+## Key Corrections from Source Inspection
+
+1. **sqlite/mod.rs trait impls already distributed** — The 19 trait implementations are already in submodules (crud.rs, search.rs, etc.). mod.rs problem is mixed concerns (struct, cache, relationships, I/O), not trait monolith.
+2. **Tool count is 19, not 16** — 15 legacy + 4 Wave 2 facades in TOOL_REGISTRY.
+3. **McpToolMode::Minimal is stubbed but not wired** — src/mcp_server.rs:54-56 explicitly says so.
+4. **Codebase is clean** — Zero dead code, zero unused deps, only 1 TODO (#121).
+5. **28 existing traits** — More mature trait surface than assumed. Refactor extends, not rewrites.
+
+## Phase Summary
+
+| Phase | Version | Theme | PRs | Critical Path |
+|-------|---------|-------|-----|---------------|
+| 1 | v0.1.9 | Clean House | 4 (parallel) | PR-1c (benchmark gated) |
+| 2 | v0.2.0 | Scoring Decoupling + Structural Cleanup | 4 (sequential) | PR-2b → PR-2c → PR-2d |
+| 3 | v0.2.1 | Prove the Substrate | 3 | PR-3a ∥ PR-3b → PR-3c |
+| 4 | v0.2.2 | Exercise & Decompose | 4 | PR-4a-i ∥ PR-4b → PR-4a-ii → PR-4c |
+
+## Quality Gates
+
+- Every PR: `prek run` (fmt + clippy + tests)
+- Scoring/search PRs: `./scripts/bench.sh --gate` (>2pp warn, >5pp fail)
+- Phase 2 exit: LoCoMo-10 within 1pp of baseline (91.5%)
+- Phase 3 exit: Conformance suite green on both backends
+- Phase 4 exit: Two retrieval strategies benchmarked, god modules decomposed
+
+## What "Done" Looks Like
+
+- 7 clean trait boundaries with reference implementations preserving v0.1.9 behavior
+- Benchmark harness running any strategy combination against LoCoMo-10
+- Proof-of-life alternatives for at least 2 of the 7 planes
+- MCP facade stable at 4+15 tools, protecting downstream integrations
+- LoCoMo-10 retrieval accuracy >= 90.1%
+- No file > 500 lines without documented justification
+
+## Parked Items (Not This Campaign)
+
+- Closed-loop recall tracking / self-improving scoring (Step 7+)
+- MAGMA multi-graph (semantic + temporal + causal + entity)
+- Closed vs open schema for memory content
+- Agent-native curation vs machine-structured ingestion
+- PostgreSQL / Redis backends (after conformance suite proven)
+- Nightly benchmark workflow
+- Testing skill implementation (docs/specs/testing-skill.md — parked until Phase 2 stabilizes)
+
+## Execution Protocol
+
+Every PR and spec follows the **debate→reforge cycle**:
+
+1. **Implement** — Nazgul in worktree isolation, spec path + acceptance criteria
+2. **Gate** — `prek run` + benchmark gate (if scoring/search touched)
+3. **Review** — Deploy Watchers (code-reviewer, shadow-hunter) OR Palantir debate (for specs)
+4. **Escalation rule** — Any finding above nitpick → fix → re-review. Repeat until clean.
+5. **Forge PR** — Use `/forge-pr` skill for commit → push → PR creation. Returns PR number.
+6. **Siege loop** — After PR is created, start a review-polling loop:
+   ```
+   /loop 3m /siege-tick <PR-URL>
+   ```
+   This runs every 3 minutes, checks GitHub for new review comments, and acts on them
+   (fixes requested changes, replies to comments, pushes updates). The loop continues
+   until the PR is approved and merged. If reviews are slow (no activity for 30+ min),
+   widen the interval to avoid burning context.
+7. **Merge immediately** — Once approved, merge via `gh pr merge <PR> --squash`. Don't batch PRs.
+8. **Rebase dependents** — After merge: `jj git fetch && jj rebase -b <downstream-bookmark> -d main`
+9. **Next PR** — Check `docs/specs/execution-roadmap.md` dependency graph. Dispatch the next
+   unblocked PR(s) in the phase. If multiple are unblocked, dispatch in parallel worktrees.
+
+### Concrete Phase 1 Dispatch Commands
+
+Phase 1 has 4 independent PRs. Dispatch all in parallel:
+
+- **PR-1a** (wire McpToolMode::Minimal): `isolation: "worktree"`, bookmark `fix/mcp-minimal-mode`
+- **PR-1b** (fix AGENTS.md tool count): goblin-level, no worktree needed
+- **PR-1c** (parallelize sub-queries #121): `isolation: "worktree"`, bookmark `perf/parallel-subqueries`
+  - **IMPORTANT**: Begin with ConnPool concurrent-reader spike (Risk 8). If ConnPool doesn't support it, rescope before implementing.
+- **PR-1d** (split admin.rs → admin/): `isolation: "worktree"`, bookmark `refactor/admin-split`
+
+After all 4 merge → Phase 2 begins (PR-2a ∥ PR-2b, then PR-2c, then PR-2d).
+
+See `docs/specs/execution-roadmap.md` §Branch Naming for full jj bookmark conventions.
+
+## Palantir Debate History
+
+| Round | Issues Found | Fixed | Result |
+|-------|-------------|-------|--------|
+| R1 | 3 critical + 10 important | 13/13 | Reforged |
+| R2 | 5 important + 3 minor | 8/8 | Reforged |
+| R3 | 1 minor | 1/1 | **Approved** (92-93% confidence) |
+
+Strongholds: `palantir-r{1,2,3}-attack.md`, `palantir-r{1,2,3}-defense.md`, `palantir-r3-final.md`


### PR DESCRIPTION
## Summary
- 5 specs for the substrate refactor campaign (execution-roadmap, module-decomposition, trait-surface, benchmark-harness, testing-skill)
- 3 recon strongholds (source-tree, dead-code, test-infra)
- 3 Palantir debate rounds (R1-R3 attack + defense)
- Campaign brief

Planning artifacts only — no code changes. Gates Phase 1 implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive internal specifications and roadmaps documenting planned architectural improvements, module decomposition strategies, benchmark harness design, testing frameworks, and trait-surface abstractions for upcoming releases.
  * Added reconnaissance reports detailing current codebase structure, test infrastructure, and dead-code analysis for development reference.
  * **Note:** These are internal planning documents with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->