### PR TITLE
docs: update MCP tool count 16→19 across all docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,12 +57,12 @@ cargo run --release --bin locomo_bench -- --llm-judge --samples 2               
 
 ## Architecture
 
-Rust MCP memory server — stores memories in SQLite with ONNX embeddings (bge-small-en-v1.5, 384-dim) for semantic search. 16 MCP tools exposed via stdio protocol. No external services required.
+Rust MCP memory server — stores memories in SQLite with ONNX embeddings (bge-small-en-v1.5, 384-dim) for semantic search. 19 MCP tools exposed via stdio protocol. No external services required.
 
 ### Key modules
 
 - `src/main.rs` — CLI dispatch via clap
-- `src/mcp_server.rs` — MCP stdio server (16 tools), `TOOL_REGISTRY` const array
+- `src/mcp_server.rs` — MCP stdio server (19 tools), `TOOL_REGISTRY` const array
 - `src/memory_core/mod.rs` — 27+ traits defining the pipeline interface
   - `domain.rs` — `EventType`, `MemoryKind`, TTL constants, relationship type constants
   - `traits.rs` — 27+ trait definitions for the pipeline interface

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Per-tool setup guides: [Claude Desktop](docs/setup/claude-desktop.md) | [Cursor]
 
 ## Learn More
 
-- [MCP Tools](docs/mcp-tools.md) - all 16 tools MAG exposes over MCP
+- [MCP Tools](docs/mcp-tools.md) - all 19 tools MAG exposes over MCP
 - [Architecture](docs/architecture.md) - search pipeline, scoring, modules
 - [Benchmarks](docs/benchmarks/) - full results, model comparisons, methodology
 - [Security](SECURITY.md) - data-flow audit, threat model

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -102,7 +102,7 @@ claude mcp add mag -- mag serve
 After configuring, verify MAG is working:
 
 1. Open your AI tool
-2. Ask it: "What MCP tools are available?" — it should list MAG's 16 tools (memory_store, recall_memory, etc.)
+2. Ask it: "What MCP tools are available?" — it should list MAG's 19 tools (memory_store, recall_memory, etc.)
 3. Test a store and recall:
    - "Remember that I prefer dark mode in all my editors"
    - "What are my editor preferences?"
@@ -171,7 +171,7 @@ Before starting work, recall memories for the current project to load context.
 
 ## More Resources
 
-- [MCP Tools Reference](mcp-tools.md) — all 16 tools MAG exposes
+- [MCP Tools Reference](mcp-tools.md) — all 19 tools MAG exposes
 - [What to Store](what-to-store.md) — 10 system prompt patterns
 - [Architecture](architecture.md) — how the search pipeline works
 - [Security](../SECURITY.md) — data-flow audit
@@ -282,7 +282,7 @@ claude mcp add mag -- mag serve
 After configuring, verify MAG is working:
 
 1. Open your AI tool
-2. Ask it: "What MCP tools are available?" — it should list MAG's 16 tools (memory_store, memory_search, etc.)
+2. Ask it: "What MCP tools are available?" — it should list MAG's 19 tools (memory_store, memory_search, etc.)
 3. Test a store and recall:
    - "Remember that I prefer dark mode in all my editors"
    - "What are my editor preferences?"
@@ -351,7 +351,7 @@ Before starting work, recall memories for the current project to load context.
 
 ## More Resources
 
-- [MCP Tools Reference](mcp-tools.md) — all 16 tools MAG exposes
+- [MCP Tools Reference](mcp-tools.md) — all 19 tools MAG exposes
 - [What to Store](what-to-store.md) — 10 system prompt patterns
 - [Architecture](architecture.md) — how the search pipeline works
 - [Security](../SECURITY.md) — data-flow audit

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -1,7 +1,7 @@
 # MCP Tools Reference
-<!-- Last verified: 2026-03-28 | Valid for: v0.1.2+ -->
+<!-- Last verified: 2026-04-14 | Valid for: v0.1.9+ -->
 
-MAG exposes 16 tools via the Model Context Protocol. Any MCP-compatible client can use these tools.
+MAG exposes 19 tools via the Model Context Protocol. Any MCP-compatible client can use these tools.
 
 ## Storage
 

--- a/python/README.md
+++ b/python/README.md
@@ -2,7 +2,7 @@
 
 PyPI wrapper for [mag](https://github.com/George-RD/mag), a Rust-based MCP memory server.
 
-mag stores memories in SQLite with ONNX embeddings for semantic search, exposing 16 MCP tools via stdio protocol. No external services required.
+mag stores memories in SQLite with ONNX embeddings for semantic search, exposing 19 MCP tools via stdio protocol. No external services required.
 
 ## Installation
 

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -34,9 +34,9 @@ src/
 
 `ingest`, `process`, `retrieve`, `delete`, `update`, `list`, `relations`, `search`, `semantic-search`, `recent`, `stats`, `export`, `import`, `feedback`, `sweep`, `checkpoint`, `resume-task`, `profile`, `remind`, `lessons`, `download-model`, `advanced-search`, `similar`, `traverse`, `phrase-search`, `maintain`, `welcome`, `protocol`, `stats-extended`, `serve`
 
-### MCP Tools (16)
+### MCP Tools (19)
 
-`memory_store`, `memory_store_batch`, `memory_retrieve`, `memory_delete`, `memory_update`, `memory_search`, `memory_list`, `memory_relations`, `memory_feedback`, `memory_lifecycle`, `memory_checkpoint`, `memory_remind`, `memory_lessons`, `memory_profile`, `memory_admin`, `memory_session_info`
+`memory_store`, `memory_store_batch`, `memory_retrieve`, `memory_delete`, `memory_update`, `memory_search`, `memory_list`, `memory_relations`, `memory_feedback`, `memory_lifecycle`, `memory_checkpoint`, `memory_remind`, `memory_lessons`, `memory_profile`, `memory_admin`, `memory_session_info`, `memory`, `memory_manage`, `memory_session`
 
 **Migration note (from pre-consolidation tool set):**
 Four tools were merged into the two consolidated tools above:


### PR DESCRIPTION
## Summary
- Wave 2 added 3 unified facade tools (`memory`, `memory_manage`, `memory_session`) but documentation still referenced the old count of 16
- Updated tool count in: AGENTS.md, src/AGENTS.md, README.md, python/README.md, docs/mcp-tools.md, docs/SETUP.md
- Added the 3 missing tools to the src/AGENTS.md tool list
- Updated mcp-tools.md version comment to v0.1.9+

## Test plan
- [ ] Verify `cargo test tool_registry_has_expected_count` still passes (already asserts 19)
- [ ] Spot-check docs render correctly

**Substrate Campaign: PR-1b (Phase 1 — Clean House)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated documentation to reflect that the MCP memory server now exposes 19 tools instead of 16
* Documented three new memory management tools now available through the MCP interface
* Updated tool reference materials, setup guides, and verification steps across all documentation to reflect the expanded capability set and latest version information (v0.1.9+)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->