### PR TITLE
fix: address review comments on Phase 1 PRs (#291, #293)

### DIFF
--- a/src/mcp_server.rs
+++ b/src/mcp_server.rs
@@ -84,7 +84,7 @@ const MCP_INSTRUCTIONS: &str = "\
 MAG — persistent memory for AI agents. Stores, searches, and recalls context across sessions.\n\
 \n\
 ## 99999 — SESSION START (do this FIRST, every session)\n\
-Call memory_session(action=\"info\", mode=\"welcome\") BEFORE your first substantive response.\n\
+Call memory_session(action=\"info\", info_mode=\"welcome\") BEFORE your first substantive response.\n\
 This returns recalled context, active project, and session state.\n\
 Do NOT skip this. Without it you are operating without memory.\n\
 \n\
@@ -105,7 +105,7 @@ Never say \"let me check my memory\" or \"I'll store that\". Just do it silently
 Weave recalled context naturally into your responses as if you simply know it.\n\
 \n\
 ## 999 — TOOL REFERENCE\n\
-Call memory_session(action=\"info\", mode=\"protocol\") for the full tool inventory.\n\
+Call memory_session(action=\"info\", info_mode=\"protocol\") for the full tool inventory.\n\
 \n\
 ## 999 — DIAGNOSTICS\n\
 If tool calls fail, ask the user to run: mag doctor\n\

--- a/src/memory_core/storage/sqlite/advanced.rs
+++ b/src/memory_core/storage/sqlite/advanced.rs
@@ -1543,18 +1543,19 @@ impl AdvancedSearcher for SqliteStorage {
                 // Each sub-query internally runs vector + FTS in try_join!,
                 // consuming 2 readers simultaneously, so effective parallelism
                 // is ~2 sub-queries at a time; additional queries queue on the
-                // reader mutexes without deadlock.  Results are merged with
-                // dedup after all tasks complete.
-                let mut join_set: tokio::task::JoinSet<Result<Vec<SemanticResult>>> =
+                // reader mutexes without deadlock.  Results are collected with
+                // their original index and sorted before merging to preserve
+                // deterministic dedup ordering.
+                let mut join_set: tokio::task::JoinSet<(usize, Result<Vec<SemanticResult>>)> =
                     tokio::task::JoinSet::new();
-                for sub_query in sub_queries.iter().skip(1) {
+                for (idx, sub_query) in sub_queries.iter().skip(1).enumerate() {
                     let pool = Arc::clone(&decomp_pool);
                     let embedder = Arc::clone(&decomp_embedder);
                     let sq = sub_query.clone();
                     let opts = decomp_opts.clone();
                     let sp = decomp_sp.clone();
                     join_set.spawn(async move {
-                        run_single_query_pipeline(
+                        let res = run_single_query_pipeline(
                             &pool,
                             &embedder,
                             &sq,
@@ -1565,11 +1566,20 @@ impl AdvancedSearcher for SqliteStorage {
                             include_superseded,
                             explain_enabled,
                         )
-                        .await
+                        .await;
+                        (idx, res)
                     });
                 }
+                // Collect all results, then sort by original sub-query index
+                // so merge order is deterministic (same as the old sequential loop).
+                let mut indexed_results: Vec<(usize, Vec<SemanticResult>)> = Vec::new();
                 while let Some(task_result) = join_set.join_next().await {
-                    let sub_results = task_result.context("sub-query task panicked")??;
+                    let (idx, sub_results) =
+                        task_result.context("sub-query task panicked")?;
+                    indexed_results.push((idx, sub_results?));
+                }
+                indexed_results.sort_by_key(|(idx, _)| *idx);
+                for (_idx, sub_results) in indexed_results {
                     for result in sub_results {
                         if seen_ids.insert(result.id.clone()) {
                             all_results.push(result);


### PR DESCRIPTION
## Summary
Follow-up fixes for review comments on merged Phase 1 PRs:

- **#291 (parallel sub-queries):** `JoinSet::join_next()` returns tasks in completion order, making dedup non-deterministic for equal-score ties. Fix: carry original sub-query index, sort by index before merging so behavior matches the old sequential loop.
- **#293 (MCP instructions):** `memory_session(action="info", mode="protocol")` used wrong parameter name. The `MemorySessionRequest` struct has `info_mode`, not `mode`. Fix: `mode` → `info_mode` in both instruction strings.

## Test plan
- [x] `cargo check` clean
- [x] Full test suite passes (all 1,086+ tests)
- [x] `prek run` clean

**Substrate Campaign: Phase 1 review cycle**

🤖 Generated with [Claude Code](https://claude.com/claude-code)