### PR TITLE
refactor: extract ScoringStrategy trait and DefaultScoringStrategy

### DIFF
--- a/src/memory_core/mod.rs
+++ b/src/memory_core/mod.rs
@@ -11,6 +11,7 @@ pub use traits::*;
 pub mod embedder;
 pub mod reranker;
 pub mod scoring;
+pub mod scoring_strategy;
 pub mod storage;
 
 #[cfg(feature = "real-embeddings")]
@@ -26,6 +27,8 @@ pub use scoring::{
 };
 #[allow(unused_imports)]
 pub(crate) use scoring::{is_stopword, simple_stem, token_set};
+#[allow(unused_imports)]
+pub use scoring_strategy::{DefaultScoringStrategy, ScoringStrategy};
 
 /// Orchestrates the memory pipeline by coordinating ingestors, processors, and storage.
 pub struct Pipeline {

--- a/src/memory_core/scoring_strategy.rs
+++ b/src/memory_core/scoring_strategy.rs
@@ -1,0 +1,115 @@
+use crate::memory_core::ScoringParams;
+use crate::memory_core::storage::sqlite::RankedSemanticCandidate;
+
+/// Extension point for scoring pipeline customization.
+///
+/// `ScoringStrategy` abstracts the score-refinement step of the search
+/// pipeline. `DefaultScoringStrategy` wraps the existing multi-factor
+/// scoring logic; future implementations (e.g., `KeywordOnlyStrategy`)
+/// can replace it without modifying storage.
+// The binary does not yet call this trait (PR-2d will wire it); suppress the
+// dead-code lint that fires when compiling the binary target.
+#[allow(dead_code)]
+pub trait ScoringStrategy: Send + Sync {
+    fn score(
+        &self,
+        candidate: &RankedSemanticCandidate,
+        query: &str,
+        params: &ScoringParams,
+    ) -> f64;
+}
+
+/// The default scoring strategy that delegates to the candidate's existing score.
+///
+/// This is a thin wrapper that preserves the pre-computed score from the
+/// multi-factor pipeline. The actual delegation into `fuse_refine_and_output`
+/// is wired in PR-2d.
+#[allow(dead_code)]
+pub struct DefaultScoringStrategy;
+
+#[allow(dead_code)]
+impl DefaultScoringStrategy {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for DefaultScoringStrategy {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ScoringStrategy for DefaultScoringStrategy {
+    fn score(
+        &self,
+        candidate: &RankedSemanticCandidate,
+        _query: &str,
+        _params: &ScoringParams,
+    ) -> f64 {
+        candidate.score
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory_core::SemanticResult;
+
+    fn make_candidate(score: f64) -> RankedSemanticCandidate {
+        #[allow(clippy::cast_possible_truncation)]
+        let score_f32 = score as f32;
+        RankedSemanticCandidate {
+            result: SemanticResult {
+                id: "test-id".to_string(),
+                content: "test content".to_string(),
+                tags: vec![],
+                importance: 0.5,
+                metadata: serde_json::json!({}),
+                event_type: None,
+                session_id: None,
+                project: None,
+                entity_id: None,
+                agent_type: None,
+                score: score_f32,
+            },
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+            event_at: "2024-01-01T00:00:00Z".to_string(),
+            score,
+            priority_value: 1,
+            vec_sim: None,
+            text_overlap: 0.0,
+            entity_id: None,
+            agent_type: None,
+            explain: None,
+        }
+    }
+
+    #[test]
+    fn default_strategy_returns_candidate_score() {
+        let strategy = DefaultScoringStrategy::new();
+        let candidate = make_candidate(0.75);
+        let params = ScoringParams::default();
+        let result = strategy.score(&candidate, "query text", &params);
+        assert!((result - 0.75).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn default_strategy_ignores_query_and_params() {
+        let strategy = DefaultScoringStrategy;
+        let candidate = make_candidate(0.42);
+        let params = ScoringParams::default();
+        // Different query strings should not affect the score.
+        assert!((strategy.score(&candidate, "foo", &params) - 0.42).abs() < f64::EPSILON);
+        assert!((strategy.score(&candidate, "bar", &params) - 0.42).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn scoring_strategy_is_object_safe() {
+        // Verify the trait can be used as a dynamic dispatch object.
+        let strategy: Box<dyn ScoringStrategy> = Box::new(DefaultScoringStrategy::new());
+        let candidate = make_candidate(1.0);
+        let params = ScoringParams::default();
+        assert!((strategy.score(&candidate, "q", &params) - 1.0).abs() < f64::EPSILON);
+    }
+}

--- a/src/memory_core/storage/sqlite/mod.rs
+++ b/src/memory_core/storage/sqlite/mod.rs
@@ -1223,23 +1223,23 @@ fn build_stats_paths_json(db_path: &Path) -> serde_json::Value {
 }
 
 #[derive(Debug, Clone)]
-struct RankedSemanticCandidate {
-    result: SemanticResult,
-    created_at: String,
+pub struct RankedSemanticCandidate {
+    pub result: SemanticResult,
+    pub created_at: String,
     /// The `event_at` timestamp for temporal filtering (may differ from `created_at`).
-    event_at: String,
-    score: f64,
+    pub event_at: String,
+    pub score: f64,
     /// Resolved priority (from stored value or event-type default), for explain mode.
-    priority_value: u8,
+    pub priority_value: u8,
     #[allow(dead_code)] // Stored for diagnostics; abstention uses collection-level text_overlap
-    vec_sim: Option<f64>,
-    text_overlap: f64,
+    pub vec_sim: Option<f64>,
+    pub text_overlap: f64,
     /// Stored for in-memory filtering and kept in sync with `SemanticResult`.
-    entity_id: Option<String>,
+    pub entity_id: Option<String>,
     /// Stored for in-memory filtering and kept in sync with `SemanticResult`.
-    agent_type: Option<String>,
+    pub agent_type: Option<String>,
     /// Component scores for explain mode; populated only when `SearchOptions.explain` is true.
-    explain: Option<serde_json::Value>,
+    pub explain: Option<serde_json::Value>,
 }
 
 mod admin;


### PR DESCRIPTION
## Summary
- Define `ScoringStrategy` trait as an extension point for scoring pipeline customization
- `DefaultScoringStrategy` preserves existing behavior (returns candidate score unchanged)
- Make `RankedSemanticCandidate` and its fields `pub` (required for trait signature visibility)
- 3 tests: score passthrough, query/params independence, object safety
- Additive only — no behavior changes, no benchmark gate required

PR-2d will wire the strategy into `SqliteStorage`.

## Test plan
- [x] `cargo check` clean
- [x] `cargo fmt` / `cargo clippy` clean
- [x] 3 new tests pass
- [x] CodeRabbit: no findings
- [x] No benchmark gate needed (additive only)

**Substrate Campaign: PR-2a (Phase 2 — Scoring Decoupling)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)