### PR TITLE
refactor: extract Reranker trait boundary (#119)

### DIFF
--- a/src/memory_core/mod.rs
+++ b/src/memory_core/mod.rs
@@ -20,6 +20,8 @@ pub use embedder::OnnxEmbedder;
 #[allow(unused_imports)]
 pub use embedder::{Embedder, PlaceholderEmbedder};
 #[allow(unused_imports)]
+pub use reranker::{NoOpReranker, Reranker};
+#[allow(unused_imports)]
 pub use scoring::{
     ABSTENTION_MIN_TEXT, GRAPH_MIN_EDGE_WEIGHT, GRAPH_NEIGHBOR_FACTOR, RRF_WEIGHT_FTS,
     RRF_WEIGHT_VEC, ScoringParams, feedback_factor, jaccard_pre, jaccard_similarity,

--- a/src/memory_core/reranker.rs
+++ b/src/memory_core/reranker.rs
@@ -1,8 +1,36 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow};
 
 use crate::app_paths;
+
+/// Abstraction over relevance re-ranking strategies.
+///
+/// Implementors receive a query and a slice of (id, passage) pairs and return
+/// a map of memory-id → relevance score.  The trait is object-safe so
+/// `SqliteStorage` can hold `Arc<dyn Reranker>` and callers can swap in
+/// `NoOpReranker` for tests without pulling in ONNX dependencies.
+///
+/// The trait is intentionally **synchronous** — `CrossEncoderReranker::rerank`
+/// runs ONNX inference (CPU-bound) and is always called from inside a
+/// `tokio::task::spawn_blocking` closure in `advanced.rs`.
+pub trait Reranker: Send + Sync {
+    /// Re-rank `candidates` (each a `(memory_id, passage_text)` pair) against
+    /// `query`.  Returns a map from memory-id to a relevance score in [0, 1].
+    fn rerank(&self, query: &str, candidates: &[(&str, &str)]) -> Result<HashMap<String, f32>>;
+}
+
+/// A no-op reranker that returns an empty score map, leaving the existing
+/// fusion order unchanged.  Used in tests and feature-gated build targets.
+#[allow(dead_code)]
+pub struct NoOpReranker;
+
+impl Reranker for NoOpReranker {
+    fn rerank(&self, _query: &str, _candidates: &[(&str, &str)]) -> Result<HashMap<String, f32>> {
+        Ok(HashMap::new())
+    }
+}
 
 #[cfg(feature = "real-embeddings")]
 const CROSS_ENCODER_MODEL_NAME: &str = "ms-marco-MiniLM-L-6-v2";
@@ -254,6 +282,22 @@ impl CrossEncoderReranker {
 
         self.touch_last_used();
         Ok(scores)
+    }
+}
+
+#[cfg(feature = "real-embeddings")]
+impl Reranker for CrossEncoderReranker {
+    fn rerank(&self, query: &str, candidates: &[(&str, &str)]) -> Result<HashMap<String, f32>> {
+        if candidates.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let passages: Vec<&str> = candidates.iter().map(|(_, p)| *p).collect();
+        let scores = self.score_batch(query, &passages)?;
+        let mut map = HashMap::with_capacity(scores.len());
+        for (i, &(id, _)) in candidates.iter().enumerate() {
+            map.insert(id.to_owned(), scores[i]);
+        }
+        Ok(map)
     }
 }
 

--- a/src/memory_core/storage/sqlite/advanced.rs
+++ b/src/memory_core/storage/sqlite/advanced.rs
@@ -313,9 +313,12 @@ fn collect_fts_candidates(
 }
 
 /// Compute cross-encoder scores for the top candidates if a reranker is available.
-#[cfg(feature = "real-embeddings")]
+///
+/// Returns `None` when no reranker is configured or the candidate list is empty.
+/// Must be called from inside a `spawn_blocking` closure — `rerank` is synchronous
+/// and may block on ONNX inference.
 fn compute_cross_encoder_scores(
-    reranker: Option<&std::sync::Arc<crate::memory_core::reranker::CrossEncoderReranker>>,
+    reranker: Option<&std::sync::Arc<dyn crate::memory_core::reranker::Reranker>>,
     query: &str,
     vector_candidates: &[(String, f64, RankedSemanticCandidate)],
     fts_candidates: &[(String, f64, RankedSemanticCandidate)],
@@ -349,14 +352,13 @@ fn compute_cross_encoder_scores(
     if candidates_for_rerank.is_empty() {
         return None;
     }
-    let passages: Vec<&str> = candidates_for_rerank.iter().map(|(_, c)| *c).collect();
-    match reranker.score_batch(query, &passages) {
-        Ok(scores) => {
-            let mut map = HashMap::with_capacity(scores.len());
-            for (i, &(id, _)) in candidates_for_rerank.iter().enumerate() {
-                map.insert(id.to_owned(), scores[i]);
+    match reranker.rerank(query, &candidates_for_rerank) {
+        Ok(map) => {
+            if map.is_empty() {
+                None
+            } else {
+                Some(map)
             }
-            Some(map)
         }
         Err(e) => {
             tracing::warn!("cross-encoder reranking failed, skipping: {e}");
@@ -1487,13 +1489,11 @@ impl AdvancedSearcher for SqliteStorage {
 
         // Phases 3-6: RRF fusion, score refinement, graph enrichment,
         // abstention + dedup. Needs one reader for graph queries.
-        #[cfg(feature = "real-embeddings")]
         let reranker = self.reranker.clone();
         let results = tokio::task::spawn_blocking({
             let pool = Arc::clone(&pool);
             move || {
-                // Optional cross-encoder reranking
-                #[cfg(feature = "real-embeddings")]
+                // Optional cross-encoder reranking (sync, safe inside spawn_blocking)
                 let ce_scores = compute_cross_encoder_scores(
                     reranker.as_ref(),
                     &query,
@@ -1501,8 +1501,6 @@ impl AdvancedSearcher for SqliteStorage {
                     &fts_candidates,
                     &scoring_params,
                 );
-                #[cfg(not(feature = "real-embeddings"))]
-                let ce_scores: Option<HashMap<String, f32>> = None;
 
                 let conn = pool.reader()?;
                 fuse_refine_and_output(

--- a/src/memory_core/storage/sqlite/mod.rs
+++ b/src/memory_core/storage/sqlite/mod.rs
@@ -77,8 +77,7 @@ pub enum InitMode {
 /// Uses a connection pool with one writer and N readers (WAL mode) for
 /// concurrent read access. The pool is behind `Arc` so the struct can
 /// be cloned into both the `Storage` and `Retriever` roles of a [`Pipeline`].
-#[cfg(feature = "real-embeddings")]
-use crate::memory_core::reranker::CrossEncoderReranker;
+use crate::memory_core::reranker::Reranker;
 
 #[derive(Clone)]
 pub struct SqliteStorage {
@@ -90,8 +89,7 @@ pub struct SqliteStorage {
     hot_cache: Option<HotTierCache>,
     hot_cache_refresh_guard: Arc<()>,
     hot_cache_refresh_started: Arc<AtomicBool>,
-    #[cfg(feature = "real-embeddings")]
-    reranker: Option<Arc<CrossEncoderReranker>>,
+    reranker: Option<Arc<dyn Reranker>>,
 }
 
 #[cfg(feature = "sqlite-vec")]
@@ -159,22 +157,19 @@ impl SqliteStorage {
             )),
             hot_cache_refresh_guard: Arc::new(()),
             hot_cache_refresh_started: Arc::new(AtomicBool::new(false)),
-            #[cfg(feature = "real-embeddings")]
             reranker: None,
         })
     }
 
-    /// Sets the cross-encoder reranker for this storage instance.
-    #[cfg(feature = "real-embeddings")]
-    pub fn with_reranker(mut self, reranker: Arc<CrossEncoderReranker>) -> Self {
+    /// Sets the reranker for this storage instance.
+    pub fn with_reranker(mut self, reranker: Arc<dyn Reranker>) -> Self {
         self.reranker = Some(reranker);
         self
     }
 
     /// Returns a reference to the reranker, if configured.
-    #[cfg(feature = "real-embeddings")]
     #[allow(dead_code)]
-    pub fn reranker(&self) -> Option<&Arc<CrossEncoderReranker>> {
+    pub fn reranker(&self) -> Option<&Arc<dyn Reranker>> {
         self.reranker.as_ref()
     }
 
@@ -843,7 +838,6 @@ impl SqliteStorage {
             )),
             hot_cache_refresh_guard: Arc::new(()),
             hot_cache_refresh_started: Arc::new(AtomicBool::new(false)),
-            #[cfg(feature = "real-embeddings")]
             reranker: None,
         })
     }


### PR DESCRIPTION
## Summary
- Add sync `Reranker` trait so `SqliteStorage` holds `Arc<dyn Reranker>` instead of concrete `CrossEncoderReranker`
- Trait is intentionally **sync** (not async) because it runs inside `spawn_blocking` in the search pipeline — preserves the existing CPU-bound safety model
- `NoOpReranker` returns empty HashMap — usable in tests and non-ONNX builds
- Remove `#[cfg(feature = "real-embeddings")]` guards from storage field/accessors — the trait abstraction handles both cases
- `CrossEncoderReranker` is no longer directly referenced in `SqliteStorage`

Resolves #119.

## Watcher review (2 findings — both fixed)
- **CRITICAL (fixed):** Made trait sync instead of async to keep ONNX inference inside `spawn_blocking`
- **MAJOR (fixed):** Removed stale `#[cfg]` from `new_in_memory_with_embedder` constructor

## Test plan
- [x] `cargo check` / `cargo fmt` / `cargo clippy` clean
- [x] All tests pass
- [ ] Benchmark gate (CI 2-sample)

**Substrate Campaign: PR-2b (Phase 2 — Scoring Decoupling)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)