### PR TITLE
refactor: inject ScoringStrategy into SqliteStorage (PR-2d)

### DIFF
--- a/src/memory_core/scoring_strategy.rs
+++ b/src/memory_core/scoring_strategy.rs
@@ -7,9 +7,6 @@ use crate::memory_core::storage::sqlite::RankedSemanticCandidate;
 /// pipeline. `DefaultScoringStrategy` wraps the existing multi-factor
 /// scoring logic; future implementations (e.g., `KeywordOnlyStrategy`)
 /// can replace it without modifying storage.
-// The binary does not yet call this trait (PR-2d will wire it); suppress the
-// dead-code lint that fires when compiling the binary target.
-#[allow(dead_code)]
 pub trait ScoringStrategy: Send + Sync {
     fn score(
         &self,
@@ -24,10 +21,8 @@ pub trait ScoringStrategy: Send + Sync {
 /// This is a thin wrapper that preserves the pre-computed score from the
 /// multi-factor pipeline. The actual delegation into `fuse_refine_and_output`
 /// is wired in PR-2d.
-#[allow(dead_code)]
 pub struct DefaultScoringStrategy;
 
-#[allow(dead_code)]
 impl DefaultScoringStrategy {
     pub fn new() -> Self {
         Self

--- a/src/memory_core/storage/sqlite/advanced.rs
+++ b/src/memory_core/storage/sqlite/advanced.rs
@@ -10,6 +10,7 @@ use crate::memory_core::domain::{
     REL_PARALLEL_CONTEXT, REL_PRECEDED_BY, REL_RELATES_TO, REL_SHARES_THEME, REL_SIMILAR_TO,
 };
 use crate::memory_core::scoring::query_coverage_boost;
+use crate::memory_core::scoring_strategy::ScoringStrategy;
 
 const ADVANCED_FTS_CANDIDATE_MULTIPLIER: usize = 20;
 const ADVANCED_FTS_CANDIDATE_MIN: usize = 100;
@@ -881,6 +882,7 @@ fn fuse_refine_and_output(
     explain_enabled: bool,
     scoring_params: &ScoringParams,
     cross_encoder_scores: Option<&HashMap<String, f32>>,
+    scoring_strategy: &dyn ScoringStrategy,
 ) -> Result<Vec<SemanticResult>> {
     // Phase 3: Weighted RRF fusion -- vector similarity weighted higher
     // for semantic discrimination (Oracle recommendation)
@@ -1060,6 +1062,11 @@ fn fuse_refine_and_output(
         return Ok(Vec::new());
     }
 
+    // Apply the pluggable scoring strategy as a final pass.
+    for candidate in &mut deduped {
+        candidate.score = scoring_strategy.score(candidate, query, scoring_params);
+    }
+
     deduped.sort_by(|a, b| b.score.total_cmp(&a.score));
     let max_score = deduped.first().map(|c| c.score).unwrap_or(0.0);
     let mut out = Vec::new();
@@ -1185,6 +1192,7 @@ async fn run_single_query_pipeline(
     scoring_params: &ScoringParams,
     include_superseded: bool,
     explain_enabled: bool,
+    scoring_strategy: &Arc<dyn ScoringStrategy>,
 ) -> Result<Vec<SemanticResult>> {
     let intent = classify_query_intent(query);
     let keyword_only = intent == QueryIntent::Keyword;
@@ -1274,6 +1282,7 @@ async fn run_single_query_pipeline(
     let emb = query_embedding;
     let o = opts.clone();
     let sp = scoring_params.clone();
+    let strat = Arc::clone(scoring_strategy);
     tokio::task::spawn_blocking(move || {
         let conn = pool_for_fuse.reader()?;
         fuse_refine_and_output(
@@ -1288,6 +1297,7 @@ async fn run_single_query_pipeline(
             explain_enabled,
             &sp,
             ce_scores.as_ref(),
+            strat.as_ref(),
         )
     })
     .await
@@ -1490,6 +1500,7 @@ impl AdvancedSearcher for SqliteStorage {
         // Phases 3-6: RRF fusion, score refinement, graph enrichment,
         // abstention + dedup. Needs one reader for graph queries.
         let reranker = self.reranker.clone();
+        let scoring_strategy = Arc::clone(&self.scoring_strategy);
         let results = tokio::task::spawn_blocking({
             let pool = Arc::clone(&pool);
             move || {
@@ -1515,6 +1526,7 @@ impl AdvancedSearcher for SqliteStorage {
                     explain_enabled,
                     &scoring_params,
                     ce_scores.as_ref(),
+                    scoring_strategy.as_ref(),
                 )
             }
         })
@@ -1536,6 +1548,7 @@ impl AdvancedSearcher for SqliteStorage {
                 let decomp_embedder = Arc::clone(&self.embedder);
                 let decomp_sp = self.scoring_params.clone();
                 let decomp_opts = opts_for_decomp.clone();
+                let decomp_strat = Arc::clone(&self.scoring_strategy);
                 // Parallel sub-query execution (resolves #121).
                 // ConnPool has 4 dedicated reader connections in WAL mode.
                 // Each sub-query internally runs vector + FTS in try_join!,
@@ -1552,6 +1565,7 @@ impl AdvancedSearcher for SqliteStorage {
                     let sq = sub_query.clone();
                     let opts = decomp_opts.clone();
                     let sp = decomp_sp.clone();
+                    let strat = Arc::clone(&decomp_strat);
                     join_set.spawn(async move {
                         let res = run_single_query_pipeline(
                             &pool,
@@ -1563,6 +1577,7 @@ impl AdvancedSearcher for SqliteStorage {
                             &sp,
                             include_superseded,
                             explain_enabled,
+                            &strat,
                         )
                         .await;
                         (idx, res)

--- a/src/memory_core/storage/sqlite/storage.rs
+++ b/src/memory_core/storage/sqlite/storage.rs
@@ -8,8 +8,10 @@ use anyhow::{Context, Result};
 use rusqlite::{Connection, OptionalExtension};
 
 use crate::memory_core::{
-    MemoryInput, MemoryUpdate, ScoringParams, SemanticResult, Storage, Updater, embedder::Embedder,
+    MemoryInput, MemoryUpdate, ScoringParams, SemanticResult, Storage, Updater,
+    embedder::Embedder,
     reranker::Reranker,
+    scoring_strategy::{DefaultScoringStrategy, ScoringStrategy},
 };
 
 use super::cache::{QueryCache, new_query_cache};
@@ -46,6 +48,7 @@ pub struct SqliteStorage {
     pub(super) hot_cache_refresh_guard: Arc<()>,
     pub(super) hot_cache_refresh_started: Arc<AtomicBool>,
     pub(super) reranker: Option<Arc<dyn Reranker>>,
+    pub(super) scoring_strategy: Arc<dyn ScoringStrategy>,
 }
 
 #[cfg(feature = "sqlite-vec")]
@@ -108,6 +111,7 @@ impl SqliteStorage {
             hot_cache_refresh_guard: Arc::new(()),
             hot_cache_refresh_started: Arc::new(AtomicBool::new(false)),
             reranker: None,
+            scoring_strategy: Arc::new(DefaultScoringStrategy::new()),
         })
     }
 
@@ -121,6 +125,13 @@ impl SqliteStorage {
     #[allow(dead_code)]
     pub fn reranker(&self) -> Option<&Arc<dyn Reranker>> {
         self.reranker.as_ref()
+    }
+
+    /// Sets the scoring strategy for this storage instance.
+    #[allow(dead_code)]
+    pub fn with_scoring_strategy(mut self, strategy: Arc<dyn ScoringStrategy>) -> Self {
+        self.scoring_strategy = strategy;
+        self
     }
 
     /// Runs `PRAGMA optimize` to update SQLite query planner statistics.
@@ -197,6 +208,7 @@ impl SqliteStorage {
             hot_cache_refresh_guard: Arc::new(()),
             hot_cache_refresh_started: Arc::new(AtomicBool::new(false)),
             reranker: None,
+            scoring_strategy: Arc::new(DefaultScoringStrategy::new()),
         })
     }
 


### PR DESCRIPTION
## Summary

Phase 2d (final) of the Substrate refactor campaign. Injects the `ScoringStrategy` trait into `SqliteStorage`, decoupling scoring logic from the storage struct.

**Changes (28 insertions, 6 deletions):**
- `storage.rs` — Added `scoring_strategy: Arc<dyn ScoringStrategy>` field, default `DefaultScoringStrategy`, builder method
- `advanced.rs` — Threaded strategy through `fuse_refine_and_output` pipeline and all 3 call sites
- `scoring_strategy.rs` — Removed dead-code suppressions (trait now wired)

**Impact:** Enables Phase 3's `MemoryStorage` backend to use alternative scoring strategies without code duplication.

## Quality gates
- [x] `prek run` (fmt + clippy + tests) — PASS
- [ ] 10-sample benchmark gate — PENDING (mandatory: algorithmic path change)
- [x] No public API surface changes
- [x] No test file modifications

## Campaign context
- **Depends on:** PR-2a (#296), PR-2b (#297), PR-2c (#299) — all merged
- **Completes:** Phase 2
- **Unblocks:** Phase 3 (PR-3a strategy comparison, PR-3b MemoryStorage backend)

## Test plan
- [x] `cargo test --all-features` — all tests pass
- [x] `cargo clippy --all-features -- -D warnings` — clean
- [ ] 10-sample benchmark structural sanity gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to configure custom scoring strategies for search operations.

* **Refactor**
  * Integrated configurable scoring into the search pipeline so results are rescored before final sorting and normalization.
  * Added a builder-style option to set a custom scoring strategy on storage instances.
  * Removed internal lint suppressions to improve code clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->