### PR TITLE
feat: add strategy comparison benchmark harness (PR-3a)

### DIFF
--- a/benches/bench_utils/mod.rs
+++ b/benches/bench_utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod formatting;
 pub mod metrics;
 pub mod openai_types;
+pub mod stats;
 pub mod timing_embedder;

--- a/benches/bench_utils/stats.rs
+++ b/benches/bench_utils/stats.rs
@@ -1,0 +1,67 @@
+/// Compute the p-th percentile of a slice of millisecond measurements.
+/// `percentile` must be in [0.0, 100.0]. Returns 0.0 for empty slices.
+///
+/// Uses the nearest-rank method (sorted, index = ceil(p/100 * n) - 1).
+#[allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
+pub fn percentile_ms(samples: &[u128], percentile: f64) -> f64 {
+    if samples.is_empty() || !(0.0..=100.0).contains(&percentile) {
+        return 0.0;
+    }
+    let mut sorted: Vec<u128> = samples.to_vec();
+    sorted.sort_unstable();
+    let n = sorted.len();
+    // Nearest-rank: index = ceil(p/100 * n) - 1, clamped to valid range.
+    let rank = ((percentile / 100.0) * n as f64).ceil() as usize;
+    let idx = rank.saturating_sub(1).min(n - 1);
+    sorted[idx] as f64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_slice_returns_zero() {
+        assert_eq!(percentile_ms(&[], 95.0), 0.0);
+    }
+
+    #[test]
+    fn single_element() {
+        assert_eq!(percentile_ms(&[42], 95.0), 42.0);
+        assert_eq!(percentile_ms(&[42], 50.0), 42.0);
+        assert_eq!(percentile_ms(&[42], 0.0), 42.0);
+    }
+
+    #[test]
+    fn known_distribution() {
+        // 20 elements: 1..=20
+        let samples: Vec<u128> = (1..=20).collect();
+        // P95: ceil(0.95 * 20) - 1 = ceil(19) - 1 = 18 => value 19
+        assert_eq!(percentile_ms(&samples, 95.0), 19.0);
+        // P50: ceil(0.50 * 20) - 1 = ceil(10) - 1 = 9 => value 10
+        assert_eq!(percentile_ms(&samples, 50.0), 10.0);
+        // P100: ceil(1.0 * 20) - 1 = 19 => value 20
+        assert_eq!(percentile_ms(&samples, 100.0), 20.0);
+    }
+
+    #[test]
+    fn unsorted_input() {
+        let samples = vec![50, 10, 30, 20, 40];
+        // Sorted: [10, 20, 30, 40, 50]
+        // P95: ceil(0.95 * 5) - 1 = ceil(4.75) - 1 = 4 => value 50
+        assert_eq!(percentile_ms(&samples, 95.0), 50.0);
+        // P50: ceil(0.50 * 5) - 1 = ceil(2.5) - 1 = 2 => value 30
+        assert_eq!(percentile_ms(&samples, 50.0), 30.0);
+    }
+
+    #[test]
+    fn boundary_percentiles() {
+        let samples = vec![5, 10, 15];
+        assert_eq!(percentile_ms(&samples, 0.0), 5.0);
+        assert_eq!(percentile_ms(&samples, 100.0), 15.0);
+    }
+}

--- a/benches/locomo/main.rs
+++ b/benches/locomo/main.rs
@@ -48,6 +48,7 @@ mod llm;
 mod openai_embedder;
 mod scoring;
 mod seeding;
+mod strategies;
 mod types;
 mod voyage_embedder;
 
@@ -168,12 +169,29 @@ struct Args {
     /// Enable cross-encoder reranking in advanced search.
     #[arg(long)]
     cross_encoder: bool,
+    /// Retrieval strategy to use. Defaults to "sqlite-v1".
+    /// Use --list-strategies to see all available options.
+    #[arg(long, default_value = "sqlite-v1")]
+    strategy: String,
+    /// List all available strategies and exit.
+    #[arg(long)]
+    list_strategies: bool,
 }
 
 // ── Main ────────────────────────────────────────────────────────────────
 
 fn main() -> Result<()> {
     let args = Args::parse();
+    if args.list_strategies {
+        strategies::list_strategies();
+        return Ok(());
+    }
+    let strategy_cfg = strategies::find_strategy(&args.strategy).ok_or_else(|| {
+        anyhow::anyhow!(
+            "unknown strategy '{}'. Use --list-strategies to see available options.",
+            args.strategy
+        )
+    })?;
     if args.top_k == Some(0) {
         bail!("--top-k must be greater than 0");
     }
@@ -518,6 +536,7 @@ fn main() -> Result<()> {
     let mut total_queries = 0usize;
     let mut total_query_ms = 0u128;
     let mut total_seed_ms = 0u128;
+    let mut query_durations: Vec<u128> = Vec::new();
     let mut total_correct = 0usize;
     let mut total_f1_sum = 0.0f64;
     let mut total_evidence_recall_sum = 0.0f64;
@@ -557,24 +576,20 @@ fn main() -> Result<()> {
         }
 
         // Fresh database per sample -- isolates conversations.
-        let mut storage = SqliteStorage::new_in_memory_with_embedder(embedder.clone())?;
+        let mut storage =
+            strategies::build_storage(strategy_cfg, embedder.clone(), args.graph_factor)?;
 
-        // Attach reranker if --cross-encoder was passed.
+        // Attach reranker if --cross-encoder was passed and strategy allows it.
         #[cfg(feature = "real-embeddings")]
-        if let Some(ref r) = reranker {
+        if let Some(ref r) = reranker
+            && !strategy_cfg.no_rerank
+        {
             storage = storage.with_reranker(r.clone());
         }
 
-        // Apply CLI overrides to scoring params.
-        if let Some(gf) = args.graph_factor {
-            let mut params = storage.scoring_params().clone();
-            params.graph_neighbor_factor = gf;
-            storage.set_scoring_params(params);
-        }
-
         let seed_start = Instant::now();
-        let seeded =
-            runtime.block_on(seeding::seed_sample(&storage, sample, !args.no_entity_tags))?;
+        let use_entity_tags = !args.no_entity_tags && !strategy_cfg.no_entity_tags;
+        let seeded = runtime.block_on(seeding::seed_sample(&storage, sample, use_entity_tags))?;
         total_seed_ms += seed_start.elapsed().as_millis();
         total_memories += seeded;
         samples_evaluated += 1;
@@ -633,6 +648,7 @@ fn main() -> Result<()> {
             };
             let query_ms = query_start.elapsed().as_millis();
             total_query_ms += query_ms;
+            query_durations.push(query_ms);
             total_queries += 1;
             rss.sample();
 
@@ -859,15 +875,19 @@ fn main() -> Result<()> {
     #[allow(clippy::cast_possible_truncation)]
     let total_seed_ms_u64 = total_seed_ms as u64;
 
+    let p95_query_ms = bench_utils::stats::percentile_ms(&query_durations, 95.0);
+
     let summary = types::LoCoMoSummary {
         metadata,
         dataset: "LoCoMo10".to_string(),
         scoring_mode: scoring_label.to_string(),
+        strategy: args.strategy.clone(),
         samples_evaluated,
         questions_evaluated: total_queries,
         total_memories_ingested: total_memories,
         total_duration_seconds,
         avg_query_ms,
+        p95_query_ms,
         peak_rss_kb: rss.peak_kb,
         raw_correct: total_correct,
         raw_percentage: pct(total_correct, total_queries),

--- a/benches/locomo/strategies.rs
+++ b/benches/locomo/strategies.rs
@@ -1,0 +1,115 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use mag::memory_core::embedder::Embedder;
+use mag::memory_core::storage::sqlite::SqliteStorage;
+
+/// Stable identifier used on the CLI and in CSV/JSON outputs.
+/// kebab-case, e.g. "sqlite-v1", "sqlite-v1-no-graph".
+pub type StrategyId = &'static str;
+
+#[derive(Debug, Clone)]
+pub struct StrategyConfig {
+    pub id: StrategyId,
+    /// One-line human description printed in --list-strategies output.
+    pub description: &'static str,
+    /// Override graph_neighbor_factor. None = use storage default.
+    pub graph_neighbor_factor: Option<f64>,
+    /// Disable graph traversal entirely when true (metadata; actual disabling is
+    /// via `graph_neighbor_factor: Some(0.0)`).
+    #[allow(dead_code)]
+    pub no_graph: bool,
+    /// Disable cross-encoder reranking even when the binary supports it.
+    pub no_rerank: bool,
+    /// Disable entity-tag extraction during seeding.
+    pub no_entity_tags: bool,
+    /// Override RRF k constant. None = use storage default.
+    pub rrf_k: Option<f64>,
+}
+
+/// Ordered registry of all known strategies.
+pub const STRATEGIES: &[StrategyConfig] = &[
+    StrategyConfig {
+        id: "sqlite-v1",
+        description: "Reference strategy -- production defaults (graph + entity tags, no reranking)",
+        graph_neighbor_factor: None,
+        no_graph: false,
+        no_rerank: false,
+        no_entity_tags: false,
+        rrf_k: None,
+    },
+    StrategyConfig {
+        id: "sqlite-v1-no-graph",
+        description: "Ablation: disables graph traversal to measure its contribution",
+        graph_neighbor_factor: Some(0.0),
+        no_graph: true,
+        no_rerank: false,
+        no_entity_tags: false,
+        rrf_k: None,
+    },
+    StrategyConfig {
+        id: "sqlite-v1-no-rerank",
+        description: "Ablation: disables cross-encoder reranking (for when --cross-encoder is on)",
+        graph_neighbor_factor: None,
+        no_graph: false,
+        no_rerank: true,
+        no_entity_tags: false,
+        rrf_k: None,
+    },
+    StrategyConfig {
+        id: "sqlite-v1-rrf-tuned",
+        description: "Experimental: RRF k=30 (lower k up-weights top results)",
+        graph_neighbor_factor: None,
+        no_graph: false,
+        no_rerank: false,
+        no_entity_tags: false,
+        rrf_k: Some(30.0),
+    },
+];
+
+/// Look up a strategy by id. Returns None for unknown names.
+pub fn find_strategy(id: &str) -> Option<&'static StrategyConfig> {
+    STRATEGIES.iter().find(|s| s.id == id)
+}
+
+/// Print all strategies to stdout in human-readable form.
+pub fn list_strategies() {
+    println!("Available strategies:\n");
+    for s in STRATEGIES {
+        println!("  {:<26} {}", s.id, s.description);
+    }
+    println!();
+}
+
+/// Construct and configure a `SqliteStorage` instance from a `StrategyConfig`.
+///
+/// `graph_factor_override` comes from the `--graph-factor` CLI flag and wins
+/// over the strategy config value when present.
+pub fn build_storage(
+    cfg: &StrategyConfig,
+    embedder: Arc<dyn Embedder>,
+    graph_factor_override: Option<f64>,
+) -> Result<SqliteStorage> {
+    let mut storage = SqliteStorage::new_in_memory_with_embedder(embedder)?;
+
+    let mut params = storage.scoring_params().clone();
+
+    // Apply strategy-level graph_neighbor_factor (0.0 disables graph traversal).
+    if let Some(gf) = cfg.graph_neighbor_factor {
+        params.graph_neighbor_factor = gf;
+    }
+
+    // CLI --graph-factor wins over strategy config.
+    if let Some(gf) = graph_factor_override {
+        params.graph_neighbor_factor = gf;
+    }
+
+    // Apply RRF k override if the strategy specifies one.
+    if let Some(k) = cfg.rrf_k {
+        params.rrf_k = k;
+    }
+
+    storage.set_scoring_params(params);
+
+    Ok(storage)
+}

--- a/benches/locomo/types.rs
+++ b/benches/locomo/types.rs
@@ -145,11 +145,17 @@ pub(crate) struct LoCoMoSummary {
     pub metadata: mag::benchmarking::BenchmarkMetadata,
     pub dataset: String,
     pub scoring_mode: String,
+    /// Strategy identifier used for this run (e.g. "sqlite-v1").
+    #[serde(default)]
+    pub strategy: String,
     pub samples_evaluated: usize,
     pub questions_evaluated: usize,
     pub total_memories_ingested: usize,
     pub total_duration_seconds: f64,
     pub avg_query_ms: f64,
+    /// 95th-percentile per-question query latency in milliseconds.
+    #[serde(default)]
+    pub p95_query_ms: f64,
     pub peak_rss_kb: u64,
     pub raw_correct: usize,
     pub raw_percentage: f64,

--- a/docs/benchmarks/baselines.json
+++ b/docs/benchmarks/baselines.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": 1,
+  "sqlite-v1": {
+    "word-overlap": {
+      "samples": 10,
+      "overall": 90.1,
+      "single_hop": 86.9,
+      "temporal": 85.0,
+      "multi_hop": 56.2,
+      "open_domain": 95.7,
+      "adversarial": 92.6,
+      "evidence_recall": 92.0,
+      "avg_query_ms": 7.0,
+      "p95_query_ms": null,
+      "embedder": "bge-small-en-v1.5 (onnx, 384-dim)",
+      "commit": "83abccf",
+      "date": "2026-03-28",
+      "notes": "validated 10-sample; source: methodology.md"
+    },
+    "e2e-word-overlap": {
+      "samples": 2,
+      "overall": 91.2,
+      "single_hop": 87.1,
+      "temporal": 91.5,
+      "multi_hop": 75.6,
+      "open_domain": 94.3,
+      "adversarial": 91.3,
+      "evidence_recall": 90.9,
+      "avg_query_ms": null,
+      "p95_query_ms": null,
+      "embedder": "bge-small-en-v1.5 (onnx, 384-dim)",
+      "commit": "83abccf",
+      "date": "2026-03-28",
+      "notes": "gpt-5.4, 2-sample; source: methodology.md"
+    }
+  }
+}

--- a/scripts/bench.sh
+++ b/scripts/bench.sh
@@ -30,6 +30,10 @@ SAMPLES=2
 SCORING_MODE="word-overlap"
 NOTES=""
 GATE=false        # --gate: compare against 10-sample baseline, fail on regression
+STRATEGY="sqlite-v1"
+COMPARE_A=""
+COMPARE_B=""
+UPDATE_BASELINE=false
 
 # ── Parse flags ───────────────────────────────────────────────────────────────
 while [[ $# -gt 0 ]]; do
@@ -40,6 +44,9 @@ while [[ $# -gt 0 ]]; do
         --scoring-mode) SCORING_MODE="$2"; shift 2 ;;
         --notes)        NOTES="$2";        shift 2 ;;
         --gate)         GATE=true;         shift ;;
+        --strategy)     STRATEGY="$2";     shift 2 ;;
+        --compare)      COMPARE_A="$2"; COMPARE_B="$3"; shift 3 ;;
+        --update-baseline) UPDATE_BASELINE=true; shift ;;
         *) echo "Unknown flag: $1" >&2; exit 1 ;;
     esac
 done
@@ -48,63 +55,63 @@ done
 case "$MODEL" in
     bge-small)
         EMBEDDING_MODEL="onnx-bge-small"
-        CARGO_FLAGS=(--release --bin locomo_bench -- --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
+        CARGO_FLAGS=(--release --bin locomo_bench -- --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}" --strategy "${STRATEGY}")
         ;;
     voyage-nano-int8)
         EMBEDDING_MODEL="voyage-nano-int8"
         DIM_ARG="${DIM:-1024}"
-        CARGO_FLAGS=(--release --bin locomo_bench -- --voyage-onnx --voyage-quant int8 --embedder-dim "${DIM_ARG}" --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
+        CARGO_FLAGS=(--release --bin locomo_bench -- --voyage-onnx --voyage-quant int8 --embedder-dim "${DIM_ARG}" --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}" --strategy "${STRATEGY}")
         ;;
     voyage-nano-fp16)
         EMBEDDING_MODEL="voyage-nano-fp16"
         DIM_ARG="${DIM:-1024}"
-        CARGO_FLAGS=(--release --bin locomo_bench -- --voyage-onnx --voyage-quant fp16 --embedder-dim "${DIM_ARG}" --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
+        CARGO_FLAGS=(--release --bin locomo_bench -- --voyage-onnx --voyage-quant fp16 --embedder-dim "${DIM_ARG}" --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}" --strategy "${STRATEGY}")
         ;;
     voyage-nano-fp32)
         EMBEDDING_MODEL="voyage-nano-fp32"
         DIM_ARG="${DIM:-1024}"
-        CARGO_FLAGS=(--release --bin locomo_bench -- --voyage-onnx --voyage-quant fp32 --embedder-dim "${DIM_ARG}" --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
+        CARGO_FLAGS=(--release --bin locomo_bench -- --voyage-onnx --voyage-quant fp32 --embedder-dim "${DIM_ARG}" --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}" --strategy "${STRATEGY}")
         ;;
     voyage-nano-q4)
         EMBEDDING_MODEL="voyage-nano-q4"
         DIM_ARG="${DIM:-1024}"
-        CARGO_FLAGS=(--release --bin locomo_bench -- --voyage-onnx --voyage-quant q4 --embedder-dim "${DIM_ARG}" --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
+        CARGO_FLAGS=(--release --bin locomo_bench -- --voyage-onnx --voyage-quant q4 --embedder-dim "${DIM_ARG}" --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}" --strategy "${STRATEGY}")
         ;;
     granite)
         EMBEDDING_MODEL="granite-embedding-30m-english"
-        CARGO_FLAGS=(--release --bin locomo_bench -- --granite --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
+        CARGO_FLAGS=(--release --bin locomo_bench -- --granite --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}" --strategy "${STRATEGY}")
         ;;
     minilm-l6)
         EMBEDDING_MODEL="all-MiniLM-L6-v2-int8"
-        CARGO_FLAGS=(--release --bin locomo_bench -- --minilm-l6 --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
+        CARGO_FLAGS=(--release --bin locomo_bench -- --minilm-l6 --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}" --strategy "${STRATEGY}")
         ;;
     minilm-l12)
         EMBEDDING_MODEL="all-MiniLM-L12-v2-int8"
-        CARGO_FLAGS=(--release --bin locomo_bench -- --minilm-l12 --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
+        CARGO_FLAGS=(--release --bin locomo_bench -- --minilm-l12 --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}" --strategy "${STRATEGY}")
         ;;
     e5-small)
         EMBEDDING_MODEL="e5-small-v2-int8"
-        CARGO_FLAGS=(--release --bin locomo_bench -- --e5-small --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
+        CARGO_FLAGS=(--release --bin locomo_bench -- --e5-small --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}" --strategy "${STRATEGY}")
         ;;
     bge-base)
         EMBEDDING_MODEL="bge-base-en-v1.5-int8"
-        CARGO_FLAGS=(--release --bin locomo_bench -- --bge-base --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
+        CARGO_FLAGS=(--release --bin locomo_bench -- --bge-base --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}" --strategy "${STRATEGY}")
         ;;
     nomic)
         EMBEDDING_MODEL="nomic-embed-text-v1.5-int8"
-        CARGO_FLAGS=(--release --bin locomo_bench -- --nomic --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
+        CARGO_FLAGS=(--release --bin locomo_bench -- --nomic --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}" --strategy "${STRATEGY}")
         ;;
     arctic-xs)
         EMBEDDING_MODEL="snowflake-arctic-embed-xs-int8"
-        CARGO_FLAGS=(--release --bin locomo_bench -- --arctic-xs --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
+        CARGO_FLAGS=(--release --bin locomo_bench -- --arctic-xs --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}" --strategy "${STRATEGY}")
         ;;
     arctic-s)
         EMBEDDING_MODEL="snowflake-arctic-embed-s-int8"
-        CARGO_FLAGS=(--release --bin locomo_bench -- --arctic-s --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
+        CARGO_FLAGS=(--release --bin locomo_bench -- --arctic-s --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}" --strategy "${STRATEGY}")
         ;;
     gte-small)
         EMBEDDING_MODEL="gte-small-int8"
-        CARGO_FLAGS=(--release --bin locomo_bench -- --gte-small --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}")
+        CARGO_FLAGS=(--release --bin locomo_bench -- --gte-small --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}" --strategy "${STRATEGY}")
         ;;
     *)
         echo "Unknown model: ${MODEL}" >&2
@@ -173,7 +180,8 @@ COMMIT="$(git -C "${REPO_DIR}" rev-parse --short HEAD 2>/dev/null || echo '')"
 BRANCH="$(git -C "${REPO_DIR}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo '')"
 
 # ── Append CSV row ────────────────────────────────────────────────────────────
-CSV_ROW="${DATE_STR},${COMMIT},${BRANCH},,${SCORING_MODE},${SAMPLES},${EMBEDDING_MODEL},${overall_score},${single_hop},${temporal},${multi_hop},${open_domain},${adversarial},${evidence_recall},${avg_embed_ms},${NOTES}"
+FULL_NOTES="${NOTES:+${NOTES} }strategy=${STRATEGY}"
+CSV_ROW="${DATE_STR},${COMMIT},${BRANCH},,${SCORING_MODE},${SAMPLES},${EMBEDDING_MODEL},${overall_score},${single_hop},${temporal},${multi_hop},${open_domain},${adversarial},${evidence_recall},${avg_embed_ms},${FULL_NOTES}"
 echo "${CSV_ROW}" >> "${RESULTS_CSV}"
 echo "Appended result to ${RESULTS_CSV}"
 
@@ -207,6 +215,66 @@ mkdir -p "$(dirname "${LATEST_MD}")"
 } > "${LATEST_MD}"
 echo "Updated ${LATEST_MD}"
 
+# ── Compare mode: run two strategies head-to-head ────────────────────────────
+if [[ -n "${COMPARE_A}" && -n "${COMPARE_B}" ]]; then
+    echo ""
+    echo "=== Strategy Comparison: ${COMPARE_A} vs ${COMPARE_B} ==="
+    echo ""
+
+    COMPARE_TMP_DIR="$(mktemp -d)"
+    trap "rm -rf '${COMPARE_TMP_DIR}'" EXIT
+
+    # Run strategy A
+    # Note: compare mode uses default (bge-small) model flags; --model flags are not forwarded.
+    echo "Running strategy A: ${COMPARE_A}..."
+    A_FLAGS=(--release --bin locomo_bench -- --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}" --strategy "${COMPARE_A}" --json)
+    cargo run "${A_FLAGS[@]}" 2>/dev/null > "${COMPARE_TMP_DIR}/a.json"
+    echo "Strategy A complete."
+
+    # Run strategy B
+    echo "Running strategy B: ${COMPARE_B}..."
+    B_FLAGS=(--release --bin locomo_bench -- --scoring-mode "${SCORING_MODE}" --samples "${SAMPLES}" --strategy "${COMPARE_B}" --json)
+    cargo run "${B_FLAGS[@]}" 2>/dev/null > "${COMPARE_TMP_DIR}/b.json"
+    echo "Strategy B complete."
+
+    # Generate comparison report
+    COMPARE_SCRIPT="${REPO_DIR}/scripts/compare_strategies.py"
+    BASELINES_JSON="${REPO_DIR}/docs/benchmarks/baselines.json"
+    COMPARE_OUTPUT_DIR="${REPO_DIR}/docs/benchmarks/comparisons"
+
+    COMPARE_CMD=(python3 "${COMPARE_SCRIPT}"
+        --a-json "${COMPARE_TMP_DIR}/a.json"
+        --b-json "${COMPARE_TMP_DIR}/b.json"
+        --output-dir "${COMPARE_OUTPUT_DIR}")
+
+    if [[ -f "${BASELINES_JSON}" ]]; then
+        COMPARE_CMD+=(--baselines "${BASELINES_JSON}")
+    fi
+
+    if [[ "${UPDATE_BASELINE}" == true ]]; then
+        COMPARE_CMD+=(--update-baseline)
+    fi
+
+    "${COMPARE_CMD[@]}"
+
+    # Append CSV rows for both strategies
+    for STRAT_FILE in a b; do
+        STRAT_JSON="${COMPARE_TMP_DIR}/${STRAT_FILE}.json"
+        STRAT_ID=$(python3 -c "import json; print(json.load(open('${STRAT_JSON}')).get('strategy', 'unknown'))")
+        STRAT_OVERALL=$(python3 -c "import json; d=json.load(open('${STRAT_JSON}')); print(f'{d.get(\"mean_f1\", 0)*100:.1f}')")
+        OTHER_STRAT="${COMPARE_B}"
+        if [[ "${STRAT_FILE}" == "b" ]]; then OTHER_STRAT="${COMPARE_A}"; fi
+        STRAT_NOTES="strategy=${STRAT_ID} compare_with=${OTHER_STRAT}"
+        STRAT_ROW="${DATE_STR},${COMMIT},${BRANCH},,${SCORING_MODE},${SAMPLES},${EMBEDDING_MODEL},${STRAT_OVERALL},,,,,,,,${STRAT_NOTES}"
+        echo "${STRAT_ROW}" >> "${RESULTS_CSV}"
+    done
+    echo "Appended comparison CSV rows to ${RESULTS_CSV}"
+
+    echo ""
+    echo "=== Comparison complete ==="
+    exit 0
+fi
+
 # ── Gate mode: compare against 10-sample baseline ────────────────────────────
 if [[ "${GATE}" == true ]]; then
     echo ""
@@ -215,7 +283,25 @@ if [[ "${GATE}" == true ]]; then
     WARN_THRESHOLD=2.0   # suggest 10-sample confirmation
     FAIL_THRESHOLD=5.0   # hard fail — too large for variance
 
-    BASELINE=$(grep ",10," "${RESULTS_CSV}" | grep "bge-small" | tail -1 | cut -d',' -f8)
+    BASELINES_JSON="${REPO_DIR}/docs/benchmarks/baselines.json"
+    BASELINE=""
+    if [[ -f "${BASELINES_JSON}" ]]; then
+        BASELINE=$(python3 -c "
+import json, sys
+with open('${BASELINES_JSON}') as f:
+    db = json.load(f)
+strategy = '${STRATEGY}'
+mode = '${SCORING_MODE}'
+try:
+    print(db[strategy][mode]['overall'])
+except KeyError:
+    print('')
+" 2>/dev/null || echo "")
+    fi
+    # Fallback to CSV grep if baselines.json lookup failed.
+    if [ -z "$BASELINE" ]; then
+        BASELINE=$(grep ",10," "${RESULTS_CSV}" | grep "bge-small" | tail -1 | cut -d',' -f8)
+    fi
     if [ -z "$BASELINE" ]; then
         echo "WARNING: No 10-sample baseline found — skipping gate"
     else

--- a/scripts/compare_strategies.py
+++ b/scripts/compare_strategies.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+"""Strategy comparison report generator for LoCoMo benchmarks.
+
+Reads two JSON benchmark outputs and produces a comparison report
+in both JSON and Markdown formats.
+
+Python 3 stdlib only -- zero pip dependencies.
+"""
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+# ── Verdict thresholds (tune without touching algorithm) ────────────────
+BETTER_OVERALL_THRESHOLD = 0.5     # B must be >= +0.5pp overall to be BETTER
+BETTER_CATEGORY_MAX_REGRESSION = 2.0  # No category may regress > 2pp for BETTER
+EQUIVALENT_THRESHOLD = 0.5        # Abs delta < 0.5pp in all categories = EQUIVALENT
+REGRESSION_THRESHOLD = -2.0       # B overall delta <= -2pp = REGRESSION
+
+# ── Category keys (order for table display) ─────────────────────────────
+CATEGORY_KEYS = [
+    ("single_hop", "Single-Hop QA"),
+    ("temporal", "Temporal"),
+    ("multi_hop", "Multi-Hop QA"),
+    ("open_domain", "Open-Domain"),
+    ("adversarial", "Adversarial"),
+]
+
+
+def extract_scores(data):
+    """Extract score dict from a benchmark JSON output."""
+    categories = data.get("categories", {})
+
+    def cat_f1(key):
+        """Mean F1 for a category, as a percentage."""
+        cat = categories.get(key, {})
+        total = cat.get("total", 0)
+        f1_sum = cat.get("f1_sum", 0.0)
+        if total == 0:
+            return 0.0
+        return (f1_sum / total) * 100.0
+
+    return {
+        "overall": data.get("mean_f1", 0.0) * 100.0,
+        "single_hop": cat_f1("single-hop"),
+        "temporal": cat_f1("temporal"),
+        "multi_hop": cat_f1("multi-hop"),
+        "open_domain": cat_f1("open-domain"),
+        "adversarial": cat_f1("adversarial"),
+        "evidence_recall": data.get("mean_evidence_recall", 0.0) * 100.0,
+        "avg_query_ms": data.get("avg_query_ms", 0.0),
+        "p95_query_ms": data.get("p95_query_ms", 0.0),
+    }
+
+
+def compute_deltas(scores_a, scores_b):
+    """Compute B minus A deltas for all metrics."""
+    deltas = {}
+    for key in scores_a:
+        deltas[key] = round(scores_b[key] - scores_a[key], 4)
+    return deltas
+
+
+def determine_verdict(deltas):
+    """Determine comparison verdict based on delta thresholds."""
+    overall_delta = deltas["overall"]
+    category_deltas = [
+        deltas[k] for k, _ in CATEGORY_KEYS
+    ]
+
+    max_cat_regression = min(category_deltas) if category_deltas else 0.0
+
+    if overall_delta >= BETTER_OVERALL_THRESHOLD and max_cat_regression > -BETTER_CATEGORY_MAX_REGRESSION:
+        return "BETTER", (
+            f"B is +{overall_delta:.1f}pp overall with no category regressing "
+            f"more than {BETTER_CATEGORY_MAX_REGRESSION}pp"
+        )
+
+    all_within_equiv = all(abs(d) < EQUIVALENT_THRESHOLD for d in category_deltas)
+    if all_within_equiv and abs(overall_delta) < EQUIVALENT_THRESHOLD:
+        return "EQUIVALENT", (
+            f"All category deltas within {EQUIVALENT_THRESHOLD}pp noise floor"
+        )
+
+    if overall_delta <= REGRESSION_THRESHOLD:
+        return "REGRESSION", (
+            f"B is {overall_delta:.1f}pp overall -- exceeds "
+            f"{abs(REGRESSION_THRESHOLD)}pp hard regression threshold"
+        )
+
+    return "INCONCLUSIVE", (
+        f"Mixed category results; overall delta {overall_delta:+.1f}pp "
+        f"within noise floor"
+    )
+
+
+def build_comparison_report(data_a, data_b, baselines_data=None):
+    """Build the full comparison report dict."""
+    strategy_a = data_a.get("strategy", "sqlite-v1")
+    strategy_b = data_b.get("strategy", "sqlite-v1")
+    scoring_mode = data_a.get("scoring_mode", "unknown")
+    samples = data_a.get("samples_evaluated", 0)
+    embedder = data_a.get("embedder_name", "unknown")
+
+    scores_a = extract_scores(data_a)
+    scores_b = extract_scores(data_b)
+    deltas = compute_deltas(scores_a, scores_b)
+    verdict, verdict_reason = determine_verdict(deltas)
+
+    # Look up baseline for strategy_a
+    baseline_used = None
+    if baselines_data and strategy_a in baselines_data:
+        mode_baseline = baselines_data[strategy_a].get(scoring_mode)
+        if mode_baseline:
+            baseline_used = {
+                "overall": mode_baseline.get("overall"),
+                "samples": mode_baseline.get("samples"),
+            }
+
+    return {
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "strategy_a": strategy_a,
+        "strategy_b": strategy_b,
+        "scoring_mode": scoring_mode,
+        "samples": samples,
+        "embedder": embedder,
+        "verdict": verdict,
+        "verdict_reason": verdict_reason,
+        "baseline_used": baseline_used,
+        "results": {
+            "strategy_a": scores_a,
+            "strategy_b": scores_b,
+        },
+        "deltas": deltas,
+    }
+
+
+def format_delta(val):
+    """Format a delta value with sign."""
+    if val > 0:
+        return f"+{val:.1f}"
+    return f"{val:.1f}"
+
+
+def generate_markdown(report):
+    """Generate a Markdown comparison report."""
+    a_name = report["strategy_a"]
+    b_name = report["strategy_b"]
+    scores_a = report["results"]["strategy_a"]
+    scores_b = report["results"]["strategy_b"]
+    deltas = report["deltas"]
+
+    lines = [
+        f"# Strategy Comparison: {a_name} vs {b_name}",
+        "",
+        f"- Date: {report['generated_at'][:10]}",
+        f"- Scoring mode: {report['scoring_mode']}",
+        f"- Samples: {report['samples']}",
+        f"- Embedder: {report['embedder']}",
+        f"- Verdict: **{report['verdict']}** -- {report['verdict_reason']}",
+        "",
+        "## Score Comparison",
+        "",
+        f"| Category      | {a_name} | {b_name} | Delta |",
+        f"|---------------|{'---:' + ' ' * (len(a_name) - 3)}|{'---:' + ' ' * (len(b_name) - 3)}|------:|",
+    ]
+
+    for key, label in CATEGORY_KEYS:
+        lines.append(
+            f"| {label:<13} | {scores_a[key]:>{len(a_name)}.1f}% "
+            f"| {scores_b[key]:>{len(b_name)}.1f}% "
+            f"| {format_delta(deltas[key]):>5} |"
+        )
+
+    # Overall (bold)
+    lines.append(
+        f"| **Overall**   | **{scores_a['overall']:.1f}%** "
+        f"| **{scores_b['overall']:.1f}%** "
+        f"| **{format_delta(deltas['overall'])}** |"
+    )
+
+    # Evidence recall
+    lines.append(
+        f"| Evidence Rec  | {scores_a['evidence_recall']:>{len(a_name)}.1f}% "
+        f"| {scores_b['evidence_recall']:>{len(b_name)}.1f}% "
+        f"| {format_delta(deltas['evidence_recall']):>5} |"
+    )
+
+    lines.extend([
+        "",
+        "## Latency",
+        "",
+        f"| Metric        | {a_name} | {b_name} | Delta |",
+        f"|---------------|{'---:' + ' ' * (len(a_name) - 3)}|{'---:' + ' ' * (len(b_name) - 3)}|------:|",
+        f"| Avg query ms  | {scores_a['avg_query_ms']:>{len(a_name)}.1f} "
+        f"| {scores_b['avg_query_ms']:>{len(b_name)}.1f} "
+        f"| {format_delta(deltas['avg_query_ms']):>5} |",
+        f"| P95 query ms  | {scores_a['p95_query_ms']:>{len(a_name)}.1f} "
+        f"| {scores_b['p95_query_ms']:>{len(b_name)}.1f} "
+        f"| {format_delta(deltas['p95_query_ms']):>5} |",
+    ])
+
+    # Baseline comparison
+    baseline = report.get("baseline_used")
+    if baseline and baseline.get("overall") is not None:
+        bl_overall = baseline["overall"]
+        bl_samples = baseline.get("samples", "?")
+        delta_from_bl = scores_a["overall"] - bl_overall
+        gate = "PASS" if abs(delta_from_bl) <= 2.0 else "WARN"
+        lines.extend([
+            "",
+            f"## Baseline comparison ({a_name} reference)",
+            "",
+            f"Baseline: {bl_overall}% ({bl_samples}-sample)",
+            f"Current A: {scores_a['overall']:.1f}% -- "
+            f"within {abs(delta_from_bl):.1f}pp of baseline. Gate: {gate}",
+        ])
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _git_short_hash() -> str:
+    """Return the current git short commit hash, or 'unknown' if unavailable."""
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare two LoCoMo benchmark strategy results"
+    )
+    parser.add_argument(
+        "--a-json", required=True,
+        help="Path to strategy A JSON result"
+    )
+    parser.add_argument(
+        "--b-json", required=True,
+        help="Path to strategy B JSON result"
+    )
+    parser.add_argument(
+        "--baselines", default=None,
+        help="Path to baselines.json"
+    )
+    parser.add_argument(
+        "--output-dir", default=None,
+        help="Directory to write comparison reports"
+    )
+    parser.add_argument(
+        "--update-baseline", action="store_true",
+        help="Update baselines.json with strategy B result"
+    )
+
+    args = parser.parse_args()
+
+    # Load inputs
+    try:
+        with open(args.a_json) as f:
+            data_a = json.load(f)
+        with open(args.b_json) as f:
+            data_b = json.load(f)
+    except (ValueError, json.JSONDecodeError) as e:
+        print(f"error: failed to parse benchmark JSON: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    baselines_data = None
+    if args.baselines and os.path.exists(args.baselines):
+        try:
+            with open(args.baselines) as f:
+                baselines_data = json.load(f)
+        except (ValueError, json.JSONDecodeError) as e:
+            print(f"error: failed to parse baselines JSON: {e}", file=sys.stderr)
+            sys.exit(1)
+
+    # Build report
+    report = build_comparison_report(data_a, data_b, baselines_data)
+
+    # Generate markdown
+    markdown = generate_markdown(report)
+
+    # Output
+    if args.output_dir:
+        strategy_a = report["strategy_a"]
+        strategy_b = report["strategy_b"]
+        date_str = datetime.now().strftime("%Y-%m-%d")
+        dirname = f"{date_str}_{strategy_a}_vs_{strategy_b}"
+        out_path = os.path.join(args.output_dir, dirname)
+        os.makedirs(out_path, exist_ok=True)
+
+        json_path = os.path.join(out_path, "comparison_report.json")
+        md_path = os.path.join(out_path, "comparison_report.md")
+
+        with open(json_path, "w") as f:
+            json.dump(report, f, indent=2)
+            f.write("\n")
+        with open(md_path, "w") as f:
+            f.write(markdown)
+
+        print(f"Reports written to {out_path}/", file=sys.stderr)
+
+    # Always print markdown to stdout
+    print(markdown)
+
+    # Update baseline if requested
+    if args.update_baseline and args.baselines:
+        strategy_b_id = report["strategy_b"]
+        scoring_mode = report["scoring_mode"]
+        scores_b = report["results"]["strategy_b"]
+
+        if baselines_data is None:
+            baselines_data = {"schema_version": 1}
+
+        if strategy_b_id not in baselines_data:
+            baselines_data[strategy_b_id] = {}
+
+        # Preserve old entry under a superseded key
+        if scoring_mode in baselines_data[strategy_b_id]:
+            date_str = datetime.now().strftime("%Y-%m-%d")
+            old_key = f"_superseded_{date_str}_{scoring_mode}"
+            baselines_data[strategy_b_id][old_key] = baselines_data[strategy_b_id][scoring_mode]
+
+        baselines_data[strategy_b_id][scoring_mode] = {
+            "samples": report["samples"],
+            "overall": round(scores_b["overall"], 1),
+            "single_hop": round(scores_b["single_hop"], 1),
+            "temporal": round(scores_b["temporal"], 1),
+            "multi_hop": round(scores_b["multi_hop"], 1),
+            "open_domain": round(scores_b["open_domain"], 1),
+            "adversarial": round(scores_b["adversarial"], 1),
+            "evidence_recall": round(scores_b["evidence_recall"], 1),
+            "avg_query_ms": round(scores_b["avg_query_ms"], 1),
+            "p95_query_ms": round(scores_b["p95_query_ms"], 1),
+            "embedder": report["embedder"],
+            "commit": _git_short_hash(),
+            "date": datetime.now().strftime("%Y-%m-%d"),
+            "notes": f"auto-updated via compare_strategies.py",
+        }
+
+        with open(args.baselines, "w") as f:
+            json.dump(baselines_data, f, indent=2)
+            f.write("\n")
+        print(f"Updated baseline for {strategy_b_id}/{scoring_mode}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Phase 3a of the Substrate refactor campaign. Adds a `--strategy <name>` flag to `locomo_bench` for head-to-head comparison of retrieval pipeline variants.

**4 strategy variants:**
| Strategy | Description |
|----------|-------------|
| `sqlite-v1` | Reference (current default pipeline) |
| `sqlite-v1-no-graph` | Graph enrichment disabled (ablation) |
| `sqlite-v1-no-rerank` | Reranker disabled (ablation) |
| `sqlite-v1-rrf-tuned` | Experimental RRF weight tuning |

**New files:**
- `strategies.rs` — Strategy registry + `build_storage()` factory
- `stats.rs` — P95 latency percentile helper
- `compare_strategies.py` — JSON + Markdown comparison reports
- `baselines.json` — Baseline thresholds per strategy

**Infrastructure:**
- `bench.sh --compare A B --samples N` for head-to-head runs
- `bench.sh --strategy <name>` for single-strategy runs
- `baselines.json` replaces CSV-grep for gate lookups

## Quality gates
- [x] `prek run` (fmt + clippy + tests) — PASS
- [x] 68 bench tests pass (5 new stats tests)
- [x] Backward compatible — `bench.sh --gate` still works

## Campaign context
- **Depends on:** Phase 2 complete (all merged)
- **Independent of:** PR-3b (MemoryStorage)
- **Unblocks:** Strategy comparison experiments

## Test plan
- [x] `locomo_bench --list-strategies` shows 4 variants
- [x] `locomo_bench --strategy sqlite-v1` produces reference scores
- [x] Stats unit tests pass (empty, single, known distribution, boundary)
- [x] `compare_strategies.py` generates valid JSON + Markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable benchmark strategies with CLI to select or list strategies and apply tuned profiles.
  * 95th-percentile query latency tracked and included in benchmark summaries.
  * New benchmark comparison tool to compare strategies, produce reports, and optionally update baselines.
  * Added a percentile utility for computing latency percentiles (with unit tests).

* **Documentation**
  * Added baseline benchmark results data.

* **Chores**
  * Benchmark runner script now forwards strategy info and records strategy in logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->