### PR TITLE
feat: define RetrievalStrategy trait + FullPipelineStrategy (PR-4a-i)

### DIFF
--- a/src/memory_core/mod.rs
+++ b/src/memory_core/mod.rs
@@ -10,6 +10,7 @@ pub use traits::*;
 
 pub mod embedder;
 pub mod reranker;
+pub mod retrieval_strategy;
 pub mod scoring;
 pub mod scoring_strategy;
 pub mod storage;
@@ -21,6 +22,8 @@ pub use embedder::OnnxEmbedder;
 pub use embedder::{Embedder, PlaceholderEmbedder};
 #[allow(unused_imports)]
 pub use reranker::{NoOpReranker, Reranker};
+#[allow(unused_imports)]
+pub use retrieval_strategy::{CandidateSet, FullPipelineStrategy, QueryContext, RetrievalStrategy};
 #[allow(unused_imports)]
 pub use scoring::{
     ABSTENTION_MIN_TEXT, GRAPH_MIN_EDGE_WEIGHT, GRAPH_NEIGHBOR_FACTOR, RRF_WEIGHT_FTS,

--- a/src/memory_core/retrieval_strategy.rs
+++ b/src/memory_core/retrieval_strategy.rs
@@ -1,0 +1,244 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::memory_core::storage::sqlite::RankedSemanticCandidate;
+use crate::memory_core::{AdvancedSearcher, ScoringParams, SearchOptions, SemanticResult};
+
+// ── Supporting types ────────────────────────────────────────────────────
+
+/// An ordered set of candidates produced by a `RetrievalStrategy`.
+///
+/// Each entry is `(memory_id, raw_score, candidate)` where `raw_score` is
+/// signal-native (cosine similarity for vector, raw BM25 for FTS).
+///
+/// Aligned with `trait-surface.md` §3.2.
+#[allow(dead_code)]
+pub type CandidateSet = Vec<(String, f64, RankedSemanticCandidate)>;
+
+/// Read-path context passed through the retrieval pipeline.
+///
+/// Wraps the query string, limit, search options, scoring params, and
+/// pre-computed embedding needed by retrieval strategies.
+///
+/// Aligned with `trait-surface.md` §2.3.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct QueryContext {
+    /// Raw query string from the caller.
+    pub query: String,
+    /// Maximum number of results to return after the full pipeline.
+    pub limit: usize,
+    /// Filter and feature options (event_type, project, session, explain, etc.).
+    pub opts: SearchOptions,
+    /// Scoring knobs. Consumers should clone from a shared `Arc<ScoringParams>`.
+    pub scoring_params: ScoringParams,
+    /// Pre-computed query embedding. `None` until the embedding stage
+    /// populates it; strategies that do not need embeddings ignore it.
+    pub query_embedding: Option<Vec<f32>>,
+    /// Whether superseded memories should be included in candidate sets.
+    pub include_superseded: bool,
+}
+
+// ── Trait ────────────────────────────────────────────────────────────────
+
+/// Retrieves an unscored, unranked candidate set for a single retrieval signal.
+///
+/// Implementors MUST NOT apply multi-signal fusion -- that is `FusionStrategy`'s
+/// job (PR-4a-ii+). The returned `CandidateSet` is `(memory_id, raw_score,
+/// candidate)` where `raw_score` is signal-native (cosine similarity for vector;
+/// raw BM25 for FTS, where more-negative = better).
+///
+/// Aligned with `trait-surface.md` §3.2.
+#[async_trait]
+#[allow(dead_code)]
+pub trait RetrievalStrategy: Send + Sync {
+    /// Human-readable name used for logging and as the key in fusion dispatch.
+    fn name(&self) -> &str;
+
+    /// Collect candidates for the given query context.
+    ///
+    /// Implementors that perform blocking I/O (e.g. ONNX inference, SQLite reads)
+    /// MUST wrap the blocking work in `tokio::task::spawn_blocking`.
+    async fn collect(&self, ctx: &QueryContext) -> Result<CandidateSet>;
+}
+
+// ── FullPipelineStrategy ────────────────────────────────────────────────
+
+/// Reference implementation that wraps the existing 6-phase search pipeline.
+///
+/// Delegates to `AdvancedSearcher::advanced_search` on the underlying
+/// `SqliteStorage`, then converts the `Vec<SemanticResult>` output into a
+/// `CandidateSet`. This is a thin adapter -- no pipeline logic is duplicated.
+///
+/// Construction requires an `Arc<dyn AdvancedSearcher>` which in practice
+/// is the `SqliteStorage` instance.
+#[allow(dead_code)]
+pub struct FullPipelineStrategy {
+    searcher: Arc<dyn AdvancedSearcher>,
+}
+
+#[allow(dead_code)]
+impl FullPipelineStrategy {
+    /// Create a new `FullPipelineStrategy` wrapping the given searcher.
+    pub fn new(searcher: Arc<dyn AdvancedSearcher>) -> Self {
+        Self { searcher }
+    }
+}
+
+#[async_trait]
+impl RetrievalStrategy for FullPipelineStrategy {
+    fn name(&self) -> &str {
+        "full-pipeline"
+    }
+
+    async fn collect(&self, ctx: &QueryContext) -> Result<CandidateSet> {
+        let results: Vec<SemanticResult> = self
+            .searcher
+            .advanced_search(&ctx.query, ctx.limit, &ctx.opts)
+            .await?;
+
+        // Convert SemanticResult -> CandidateSet entries.
+        // The full pipeline already scores candidates internally, so we
+        // propagate the score as the raw_score signal and build a
+        // RankedSemanticCandidate shell around each result.
+        //
+        // NOTE: SemanticResult does not carry created_at, event_at,
+        // priority_value, or text_overlap. These fields are set to
+        // defaults here. Downstream consumers of FullPipelineStrategy
+        // output MUST NOT rely on these fields for fusion or ranking --
+        // the score field already incorporates them from the inner
+        // pipeline. PR-4a-ii will wire dispatch such that these
+        // placeholder values are never inspected.
+        let candidates: CandidateSet = results
+            .into_iter()
+            .map(|result| {
+                let id = result.id.clone();
+                let score = f64::from(result.score);
+                let candidate = RankedSemanticCandidate {
+                    created_at: String::new(),
+                    event_at: String::new(),
+                    score,
+                    priority_value: 1,
+                    vec_sim: None,
+                    text_overlap: 0.0,
+                    entity_id: result.entity_id.clone(),
+                    agent_type: result.agent_type.clone(),
+                    explain: None,
+                    result,
+                };
+                (id, score, candidate)
+            })
+            .collect();
+
+        Ok(candidates)
+    }
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::memory_core::SemanticResult;
+
+    /// Stub searcher that returns a fixed result set.
+    struct StubSearcher {
+        results: Vec<SemanticResult>,
+    }
+
+    #[async_trait]
+    impl AdvancedSearcher for StubSearcher {
+        async fn advanced_search(
+            &self,
+            _query: &str,
+            _limit: usize,
+            _opts: &SearchOptions,
+        ) -> Result<Vec<SemanticResult>> {
+            Ok(self.results.clone())
+        }
+    }
+
+    fn make_semantic_result(id: &str, score: f32) -> SemanticResult {
+        SemanticResult {
+            id: id.to_string(),
+            content: format!("content for {id}"),
+            tags: vec![],
+            importance: 0.5,
+            metadata: serde_json::json!({}),
+            event_type: None,
+            session_id: None,
+            project: None,
+            entity_id: None,
+            agent_type: None,
+            score,
+        }
+    }
+
+    fn make_query_context(query: &str) -> QueryContext {
+        QueryContext {
+            query: query.to_string(),
+            limit: 10,
+            opts: SearchOptions::default(),
+            scoring_params: ScoringParams::default(),
+            query_embedding: None,
+            include_superseded: false,
+        }
+    }
+
+    #[test]
+    fn full_pipeline_strategy_name() {
+        let searcher = Arc::new(StubSearcher { results: vec![] });
+        let strategy = FullPipelineStrategy::new(searcher);
+        assert_eq!(strategy.name(), "full-pipeline");
+    }
+
+    #[test]
+    fn full_pipeline_strategy_construction() {
+        let searcher = Arc::new(StubSearcher {
+            results: vec![make_semantic_result("a", 0.9)],
+        });
+        let strategy = FullPipelineStrategy::new(searcher);
+        // Verify the strategy implements the trait via dynamic dispatch.
+        let _boxed: Box<dyn RetrievalStrategy> = Box::new(strategy);
+    }
+
+    #[test]
+    fn retrieval_strategy_is_object_safe() {
+        // Verify the trait can be used as Arc<dyn RetrievalStrategy>.
+        let searcher = Arc::new(StubSearcher { results: vec![] });
+        let strategy = FullPipelineStrategy::new(searcher);
+        let _arc: Arc<dyn RetrievalStrategy> = Arc::new(strategy);
+    }
+
+    #[tokio::test]
+    async fn full_pipeline_collect_delegates_to_searcher() {
+        let searcher = Arc::new(StubSearcher {
+            results: vec![
+                make_semantic_result("mem-1", 0.85),
+                make_semantic_result("mem-2", 0.72),
+            ],
+        });
+        let strategy = FullPipelineStrategy::new(searcher);
+        let ctx = make_query_context("test query");
+
+        let candidates = strategy.collect(&ctx).await.unwrap();
+
+        assert_eq!(candidates.len(), 2);
+        assert_eq!(candidates[0].0, "mem-1");
+        assert!((candidates[0].1 - 0.85_f64).abs() < 0.01);
+        assert_eq!(candidates[1].0, "mem-2");
+        assert!((candidates[1].1 - 0.72_f64).abs() < 0.01);
+    }
+
+    #[tokio::test]
+    async fn full_pipeline_collect_empty_results() {
+        let searcher = Arc::new(StubSearcher { results: vec![] });
+        let strategy = FullPipelineStrategy::new(searcher);
+        let ctx = make_query_context("nothing here");
+
+        let candidates = strategy.collect(&ctx).await.unwrap();
+        assert!(candidates.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Phase 4a-i of the Substrate refactor campaign. Defines the `RetrievalStrategy` trait and `FullPipelineStrategy` reference implementation.

**New types:**
- `RetrievalStrategy` trait — `name()` + `async collect(&QueryContext) -> Result<CandidateSet>`
- `QueryContext` — wraps query string, limit, search options, scoring params
- `CandidateSet` — `Vec<(String, f64, RankedSemanticCandidate)>`
- `FullPipelineStrategy` — wraps `Arc<dyn AdvancedSearcher>`, delegates to existing 6-phase pipeline

**5 unit tests:** trait construction, name, object safety, delegation, empty results.

## Quality gates
- [x] `prek run` (fmt + clippy + tests) — PASS
- [x] Additive only — no existing code modified
- [x] 5 unit tests pass

## Campaign context
- **Depends on:** Phase 2 (ScoringStrategy pattern)
- **Unblocks:** PR-4a-ii (KeywordOnlyStrategy + dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>