### PR TITLE
fix(search): address eight deferred retrieval/lock bugs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -122,7 +122,7 @@ Query → Intent classify (Keyword/Factual/Conceptual/General)
 - Schema migrations additive only — never drop/rename columns; `ALTER TABLE ADD COLUMN` with error ignoring
 - Trait-first design — add new trait + impl rather than modifying existing signatures
 - Struct-based API: `MemoryInput` (store), `MemoryUpdate` (update), `SearchOptions` (search/filter)
-- SQLite lock contention: `retry_on_lock()` with bounded backoff (5 attempts, 10-160ms + jitter)
+- SQLite lock contention: `retry_on_lock()` with bounded backoff (initial + 5 retries, 10-160ms + jitter)
 - Cache invalidation: selective for `store()`, full clear for bulk operations (import/sweep/compact)
 
 ## Quality Gates

--- a/src/memory_core/storage/sqlite/advanced.rs
+++ b/src/memory_core/storage/sqlite/advanced.rs
@@ -105,9 +105,10 @@ impl AdvancedSearcher for SqliteStorage {
         });
 
         // ── KeywordOnlyStrategy dispatch ────────────────────────────────
-        // For keyword-intent queries, skip embedding, vector search,
-        // RRF fusion, reranker, and graph enrichment. Use FTS5 BM25 only.
-        if intent == QueryIntent::Keyword {
+        // For keyword-intent queries (and empty queries, which can't produce a
+        // meaningful embedding), skip embedding, vector search, RRF fusion,
+        // reranker, and graph enrichment. Use FTS5 BM25 only.
+        if intent == QueryIntent::Keyword || query.is_empty() {
             tracing::debug!(query = %query, "dispatching to KeywordOnlyStrategy");
             let include_superseded = opts.include_superseded.unwrap_or(false);
             let explain_enabled = opts.explain.unwrap_or(false);
@@ -280,6 +281,7 @@ impl AdvancedSearcher for SqliteStorage {
         let scoring_strategy = Arc::clone(&self.scoring_strategy);
         let results = tokio::task::spawn_blocking({
             let pool = Arc::clone(&pool);
+            let sp = scoring_params.clone();
             move || {
                 // Optional cross-encoder reranking (sync, safe inside spawn_blocking)
                 let ce_scores = pipeline::compute_cross_encoder_scores(
@@ -287,7 +289,7 @@ impl AdvancedSearcher for SqliteStorage {
                     &query,
                     &vector_candidates,
                     &fts_candidates,
-                    &scoring_params,
+                    &sp,
                 );
 
                 let conn = pool.reader()?;
@@ -304,7 +306,7 @@ impl AdvancedSearcher for SqliteStorage {
                     limit,
                     include_superseded,
                     explain_enabled,
-                    &scoring_params,
+                    &sp,
                     ce_scores.as_ref(),
                     scoring_strategy.as_ref(),
                 )
@@ -326,7 +328,9 @@ impl AdvancedSearcher for SqliteStorage {
 
                 let decomp_pool = Arc::clone(&self.pool);
                 let decomp_embedder = Arc::clone(&self.embedder);
-                let decomp_sp = self.scoring_params.clone();
+                // Use the intent-adjusted scoring params so sub-queries inherit
+                // the same RRF / word-overlap weights as the main query.
+                let decomp_sp = scoring_params.clone();
                 let decomp_opts = opts_for_decomp.clone();
                 let decomp_strat = Arc::clone(&self.scoring_strategy);
                 // Parallel sub-query execution (resolves #121).

--- a/src/memory_core/storage/sqlite/advanced.rs
+++ b/src/memory_core/storage/sqlite/advanced.rs
@@ -637,10 +637,10 @@ mod tests {
 
     /// Empty and whitespace-only queries must take the FTS-only dispatch
     /// path; running vector search with an empty embedding produces no
-    /// useful signal. We assert via behavior: the call returns cleanly
-    /// (no panic from a zero-length embedding hitting downstream cosine
-    /// math) and respects `SearchOptions` filters supplied alongside the
-    /// blank query.
+    /// useful signal. The call must return cleanly (no panic from a
+    /// zero-length embedding hitting downstream cosine math) and yield
+    /// an empty result set, since FTS5 with a blank query matches
+    /// nothing.
     #[tokio::test]
     async fn blank_query_routes_to_fts_only() {
         use crate::memory_core::AdvancedSearcher;
@@ -653,7 +653,6 @@ mod tests {
             "alpha entry one",
             &MemoryInput {
                 content: "alpha entry one".to_string(),
-                project: Some("p1".to_string()),
                 ..Default::default()
             },
         )

--- a/src/memory_core/storage/sqlite/advanced.rs
+++ b/src/memory_core/storage/sqlite/advanced.rs
@@ -105,10 +105,11 @@ impl AdvancedSearcher for SqliteStorage {
         });
 
         // ── KeywordOnlyStrategy dispatch ────────────────────────────────
-        // For keyword-intent queries (and empty queries, which can't produce a
-        // meaningful embedding), skip embedding, vector search, RRF fusion,
-        // reranker, and graph enrichment. Use FTS5 BM25 only.
-        if intent == QueryIntent::Keyword || query.is_empty() {
+        // For keyword-intent queries (and empty / whitespace-only queries,
+        // which can't produce a meaningful embedding), skip embedding, vector
+        // search, RRF fusion, reranker, and graph enrichment. Use FTS5 BM25
+        // only.
+        if intent == QueryIntent::Keyword || query.trim().is_empty() {
             tracing::debug!(query = %query, "dispatching to KeywordOnlyStrategy");
             let include_superseded = opts.include_superseded.unwrap_or(false);
             let explain_enabled = opts.explain.unwrap_or(false);
@@ -632,5 +633,44 @@ mod tests {
 
         // Should still return results through the full pipeline.
         assert!(!results.is_empty(), "full pipeline should return results");
+    }
+
+    /// Empty and whitespace-only queries must take the FTS-only dispatch
+    /// path; running vector search with an empty embedding produces no
+    /// useful signal. We assert via behavior: the call returns cleanly
+    /// (no panic from a zero-length embedding hitting downstream cosine
+    /// math) and respects `SearchOptions` filters supplied alongside the
+    /// blank query.
+    #[tokio::test]
+    async fn blank_query_routes_to_fts_only() {
+        use crate::memory_core::AdvancedSearcher;
+
+        let storage = SqliteStorage::new_in_memory().unwrap();
+
+        <SqliteStorage as Storage>::store(
+            &storage,
+            "blank-1",
+            "alpha entry one",
+            &MemoryInput {
+                content: "alpha entry one".to_string(),
+                project: Some("p1".to_string()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        for query in ["", "   ", "\t\n  "] {
+            let results = storage
+                .advanced_search(query, 5, &SearchOptions::default())
+                .await
+                .expect("blank query must dispatch cleanly");
+            // FTS5 with an empty query matches nothing, so we expect an empty
+            // result set rather than a panic or an embedding-driven scan.
+            assert!(
+                results.is_empty(),
+                "blank query {query:?} should yield no FTS5 matches"
+            );
+        }
     }
 }

--- a/src/memory_core/storage/sqlite/conn_pool.rs
+++ b/src/memory_core/storage/sqlite/conn_pool.rs
@@ -19,8 +19,9 @@ pub(super) fn is_lock_error(err: &rusqlite::Error) -> bool {
     )
 }
 
-/// Maximum number of retry attempts for lock contention.
-const RETRY_MAX_ATTEMPTS: u32 = 5;
+/// Maximum number of retries after the initial call (so total calls is
+/// `RETRY_MAX_RETRIES + 1`).
+const RETRY_MAX_RETRIES: u32 = 5;
 
 /// Base delay between retries (doubled each attempt).
 const RETRY_BASE_DELAY_MS: u64 = 10;
@@ -30,33 +31,34 @@ const RETRY_BASE_DELAY_MS: u64 = 10;
 /// This is a **synchronous** function intended to run inside `spawn_blocking`.
 /// Uses `std::thread::sleep` (not tokio) for delays.
 ///
-/// - Max attempts: 5
-/// - Backoff: 10ms, 20ms, 40ms, 80ms (+ random 0-50% jitter)
+/// - Max retries: 5 (so up to 6 calls including the initial attempt)
+/// - Backoff: 10ms, 20ms, 40ms, 80ms, 160ms (+ random 0-50% jitter)
 /// - Non-lock errors are returned immediately without retry.
 pub(super) fn retry_on_lock<T, F>(mut f: F) -> std::result::Result<T, rusqlite::Error>
 where
     F: FnMut() -> std::result::Result<T, rusqlite::Error>,
 {
-    let mut attempt = 0_u32;
+    let mut retries = 0_u32;
     loop {
         match f() {
             Ok(val) => return Ok(val),
-            Err(err) if is_lock_error(&err) && attempt + 1 < RETRY_MAX_ATTEMPTS => {
-                attempt += 1;
-                let base_ms = RETRY_BASE_DELAY_MS * 2_u64.pow(attempt - 1);
-                // Simple jitter: add 0-50% of base_ms using a cheap hash of the attempt
-                // counter and a timestamp nanos component to avoid pulling in a rand dependency.
+            Err(err) if is_lock_error(&err) && retries < RETRY_MAX_RETRIES => {
+                let base_ms = RETRY_BASE_DELAY_MS * 2_u64.pow(retries);
+                // Simple jitter: add 0-50% of base_ms using a cheap hash of the
+                // retry counter and a timestamp nanos component to avoid pulling
+                // in a rand dependency.
                 let jitter_ms = {
                     let nanos = std::time::SystemTime::now()
                         .duration_since(std::time::UNIX_EPOCH)
                         .map(|d| d.subsec_nanos() as u64)
                         .unwrap_or(0);
-                    let seed = nanos.wrapping_mul(u64::from(attempt).wrapping_add(7));
+                    let seed = nanos.wrapping_mul(u64::from(retries).wrapping_add(7));
                     seed % (base_ms / 2 + 1)
                 };
                 let delay = Duration::from_millis(base_ms + jitter_ms);
+                retries += 1;
                 tracing::debug!(
-                    attempt,
+                    retry = retries,
                     delay_ms = delay.as_millis(),
                     "sqlite lock contention, retrying"
                 );
@@ -65,7 +67,7 @@ where
             Err(err) => {
                 if is_lock_error(&err) {
                     tracing::warn!(
-                        attempts = RETRY_MAX_ATTEMPTS,
+                        retries = RETRY_MAX_RETRIES,
                         "sqlite lock contention persisted after all retries"
                     );
                 }
@@ -329,8 +331,9 @@ mod tests {
         });
         assert!(result.is_err());
         assert_eq!(
-            attempts, 5,
-            "should attempt exactly RETRY_MAX_ATTEMPTS times"
+            attempts,
+            RETRY_MAX_RETRIES + 1,
+            "should attempt initial + RETRY_MAX_RETRIES times"
         );
     }
 }

--- a/src/memory_core/storage/sqlite/pipeline/abstention.rs
+++ b/src/memory_core/storage/sqlite/pipeline/abstention.rs
@@ -32,17 +32,27 @@ pub(crate) fn abstain_and_dedup(
     query: &str,
 ) -> Result<Vec<SemanticResult>> {
     // ── Phase 6: Collection-level abstention + dedup ─────────────
-    let mut deduped = Vec::new();
-    let mut seen = HashSet::new();
+    // Dedup by content fingerprint, keeping the highest-scoring candidate per
+    // fingerprint. HashMap iteration order is nondeterministic, so a
+    // first-wins policy would surface arbitrary duplicates.
+    let mut by_fingerprint: HashMap<String, RankedSemanticCandidate> = HashMap::new();
     for candidate in ranked.into_values() {
         if !matches_search_options(&candidate, opts) {
             continue;
         }
         let fingerprint = normalize_for_dedup(&candidate.result.content);
-        if seen.insert(fingerprint) {
-            deduped.push(candidate);
+        match by_fingerprint.entry(fingerprint) {
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                if candidate.score > entry.get().score {
+                    *entry.get_mut() = candidate;
+                }
+            }
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(candidate);
+            }
         }
     }
+    let mut deduped: Vec<RankedSemanticCandidate> = by_fingerprint.into_values().collect();
 
     // Apply abstention gate on the filtered (in-scope) candidates.
     if !query_tokens.is_empty() {
@@ -114,8 +124,13 @@ pub(crate) fn merge_hot_cache_results(
         .collect();
 
     for hot_result in hot_results {
-        if let Some(existing) = merged.get_mut(&hot_result.id) {
-            merge_semantic_result(existing, hot_result);
+        match merged.entry(hot_result.id.clone()) {
+            std::collections::hash_map::Entry::Occupied(mut entry) => {
+                merge_semantic_result(entry.get_mut(), hot_result);
+            }
+            std::collections::hash_map::Entry::Vacant(entry) => {
+                entry.insert(hot_result);
+            }
         }
     }
 

--- a/src/memory_core/storage/sqlite/pipeline/decomp.rs
+++ b/src/memory_core/storage/sqlite/pipeline/decomp.rs
@@ -32,10 +32,10 @@ pub(crate) async fn run_single_query_pipeline(
     scoring_strategy: &Arc<dyn ScoringStrategy>,
 ) -> Result<Vec<SemanticResult>> {
     let intent = classify_query_intent(query);
-    // Route empty queries through FTS-only — vector search with an empty
-    // embedding can't produce meaningful similarities, and `build_fts5_query`
-    // already short-circuits empty input safely.
-    let fts_only = intent == QueryIntent::Keyword || query.is_empty();
+    // Route empty / whitespace-only queries through FTS-only — vector search
+    // with an empty embedding can't produce meaningful similarities, and
+    // `build_fts5_query` already short-circuits empty input safely.
+    let fts_only = intent == QueryIntent::Keyword || query.trim().is_empty();
 
     let query_embedding = if fts_only {
         Vec::new()

--- a/src/memory_core/storage/sqlite/pipeline/decomp.rs
+++ b/src/memory_core/storage/sqlite/pipeline/decomp.rs
@@ -32,9 +32,12 @@ pub(crate) async fn run_single_query_pipeline(
     scoring_strategy: &Arc<dyn ScoringStrategy>,
 ) -> Result<Vec<SemanticResult>> {
     let intent = classify_query_intent(query);
-    let keyword_only = intent == QueryIntent::Keyword;
+    // Route empty queries through FTS-only — vector search with an empty
+    // embedding can't produce meaningful similarities, and `build_fts5_query`
+    // already short-circuits empty input safely.
+    let fts_only = intent == QueryIntent::Keyword || query.is_empty();
 
-    let query_embedding = if keyword_only || query.is_empty() {
+    let query_embedding = if fts_only {
         Vec::new()
     } else {
         let embedder = Arc::clone(embedder);
@@ -44,7 +47,7 @@ pub(crate) async fn run_single_query_pipeline(
             .context("spawn_blocking join error")??
     };
 
-    let (vector_candidates, fts_candidates) = if keyword_only {
+    let (vector_candidates, fts_candidates) = if fts_only {
         let pool = Arc::clone(pool);
         let q = query.to_string();
         let o = opts.clone();

--- a/src/memory_core/storage/sqlite/pipeline/enrichment.rs
+++ b/src/memory_core/storage/sqlite/pipeline/enrichment.rs
@@ -156,6 +156,12 @@ pub(crate) fn enrich_graph_neighbors(
                     let neighbor_et = event_type_from_sql(event_type);
                     let neighbor_et_ref = neighbor_et.as_ref().unwrap_or(&EventType::Memory);
                     let neighbor_pv = resolve_priority(neighbor_et.as_ref(), priority);
+                    // Apply type weight + priority factor so graph-injected
+                    // candidates are normalized against direct-retrieval ones
+                    // (which apply these in `collect_vector_candidates` /
+                    // `collect_fts_candidates`).
+                    neighbor_score *= type_weight_et(neighbor_et_ref)
+                        * priority_factor(neighbor_pv, scoring_params);
                     neighbor_score *= time_decay_et(&created_at, neighbor_et_ref, scoring_params);
                     neighbor_score *= scoring_params.neighbor_importance_floor
                         + importance * scoring_params.neighbor_importance_scale;
@@ -281,7 +287,6 @@ pub(crate) fn expand_entity_tags(
 
     let expansion_limit = 25usize;
     let mut expanded_count = 0usize;
-    let existing_ids: HashSet<String> = ranked.keys().cloned().collect();
 
     let tag_sql = if include_superseded {
         "SELECT id, content, tags, importance, metadata, event_type, session_id, \
@@ -355,7 +360,11 @@ pub(crate) fn expand_entity_tags(
                         event_at,
                     ) = row;
 
-                    if existing_ids.contains(&id) {
+                    // Live check against `ranked` so candidates inserted earlier
+                    // in this expansion loop are also deduped (a snapshot taken
+                    // before the loop would let the same memory be added twice
+                    // when it matches multiple entity tags).
+                    if ranked.contains_key(&id) {
                         continue;
                     }
 

--- a/src/memory_core/storage/sqlite/pipeline/retrieval.rs
+++ b/src/memory_core/storage/sqlite/pipeline/retrieval.rs
@@ -23,9 +23,9 @@ use crate::memory_core::{
 pub(crate) fn collect_vector_candidates(
     conn: &Connection,
     query_embedding: &[f32],
-    #[cfg_attr(not(feature = "sqlite-vec"), allow(unused))] limit: usize,
+    limit: usize,
     include_superseded: bool,
-    #[cfg_attr(not(feature = "sqlite-vec"), allow(unused))] opts: &SearchOptions,
+    opts: &SearchOptions,
     scoring_params: &ScoringParams,
 ) -> Result<Vec<(String, f64, RankedSemanticCandidate)>> {
     let mut vector_candidates: Vec<(String, f64, RankedSemanticCandidate)> = Vec::new();
@@ -88,18 +88,43 @@ pub(crate) fn collect_vector_candidates(
 
     #[cfg(not(feature = "sqlite-vec"))]
     {
-        let vector_sql = if include_superseded {
-            "SELECT id, content, embedding, tags, importance, metadata, event_type, session_id, project, priority, created_at, entity_id, agent_type, event_at
-             FROM memories WHERE embedding IS NOT NULL"
-        } else {
-            "SELECT id, content, embedding, tags, importance, metadata, event_type, session_id, project, priority, created_at, entity_id, agent_type, event_at
-             FROM memories WHERE embedding IS NOT NULL AND superseded_by_id IS NULL"
-        };
+        use rusqlite::types::Value as SqlValue;
+
+        // Apply SearchOptions filters (project, session_id, event_type,
+        // dates, etc.) at the SQL layer so the brute-force scan is bounded
+        // to the candidate set the user actually asked for. Mirrors the
+        // pre-filter semantics of the sqlite-vec branch.
+        let mut vector_sql = String::from(
+            "SELECT id, content, embedding, tags, importance, metadata, event_type, session_id, project, priority, created_at, entity_id, agent_type, event_at \
+             FROM memories WHERE embedding IS NOT NULL",
+        );
+        if !include_superseded {
+            vector_sql.push_str(" AND superseded_by_id IS NULL");
+        }
+        let mut vector_params: Vec<SqlValue> = Vec::new();
+        let mut param_idx = 1;
+        append_search_filters(
+            &mut vector_sql,
+            &mut vector_params,
+            &mut param_idx,
+            opts,
+            "",
+        );
+        // Cap the brute-force scan to keep latency bounded on large tables.
+        // Mirrors the sqlite-vec KNN candidate cap (limit*10, clamped to
+        // [200, 10_000]). Most-recent rows win when the cap bites.
+        let scan_limit = limit.saturating_mul(10).clamp(200, 10_000);
+        let scan_limit_sql = i64::try_from(scan_limit).unwrap_or(i64::MAX);
+        vector_sql.push_str(" ORDER BY created_at DESC LIMIT ?");
+        vector_sql.push_str(&param_idx.to_string());
+        vector_params.push(SqlValue::Integer(scan_limit_sql));
+
         let mut vector_stmt = conn
-            .prepare(vector_sql)
+            .prepare(&vector_sql)
             .context("failed to prepare advanced vector query")?;
+        let param_refs = to_param_refs(&vector_params);
         let vector_rows = vector_stmt
-            .query_map([], |row| {
+            .query_map(param_refs.as_slice(), |row| {
                 Ok((
                     row.get::<_, String>(0)?,
                     row.get::<_, String>(1)?,


### PR DESCRIPTION
## Summary

Bug-fix PR collecting eight previously-deferred correctness issues across the SQLite retrieval pipeline and connection pool. Each fix is small and isolated; together they should move LoCoMo by ~1–3 pp.

### Fixes

1. **Max-score dedup** (`pipeline/abstention.rs`): `abstain_and_dedup` deduped by content fingerprint via `HashSet::insert`, so whichever HashMap iteration surfaced first won — meaning the *worse* duplicate could evict the better one. Now keeps the max-score candidate per fingerprint.
2. **Hot-cache cache-only insert** (`pipeline/abstention.rs`): `merge_hot_cache_results` only updated existing IDs, silently dropping confident hot-tier hits that the live pipeline didn't retrieve. Now inserts missing hot results.
3. **Graph-neighbor type/priority weights** (`pipeline/enrichment.rs`): `enrich_graph_neighbors` was missing the `type_weight_et * priority_factor` multipliers that direct retrieval applies, so injected neighbors were systematically under-scored relative to direct hits.
4. **Live `existing_ids`** (`pipeline/enrichment.rs`): entity-tag expansion snapshotted `existing_ids` once, so a memory inserted from one tag iteration could be re-inserted by another. Now checks `ranked.contains_key` live.
5. **Intent-adjusted `decomp_sp`** (`advanced.rs`): sub-queries cloned the raw `self.scoring_params`, ignoring the intent-profile multipliers (`vec_weight_mult`, `fts_weight_mult`, `word_overlap_mult`) that the main query applied. Now clones the intent-adjusted params.
6. **`retry_on_lock` bounds** (`conn_pool.rs`): docs claimed 10–160ms backoff but the loop only reached 80ms (4 retries). Bumped to 5 retries so backoff hits the documented 10/20/40/80/160ms slots; constant renamed to `RETRY_MAX_RETRIES` for clarity, exhaustion test and AGENTS.md updated.
7. **Empty-query FTS routing** (`advanced.rs`, `pipeline/decomp.rs`): empty queries fell through to the vector pipeline with an empty embedding (cosine sim against zero vector → 0). Now routed through the FTS-only path in both `advanced_search` and `run_single_query_pipeline`.
8. **Bounded non-sqlite-vec retrieval** (`pipeline/retrieval.rs`): the non-sqlite-vec vector scan ignored `SearchOptions` and had no `LIMIT`, scanning every embedded row. Now applies `append_search_filters` and an `ORDER BY created_at DESC LIMIT limit*10 (clamp 200..=10_000)` cap, mirroring the sqlite-vec branch.

## Test plan

- [x] `cargo check --lib` (default features) — clean
- [x] `cargo check --lib --features sqlite-vec` — clean
- [x] `cargo clippy --lib -- -D warnings` (default + sqlite-vec) — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] CI to run full `cargo test --all-features` (this env can't link `ort-sys` due to a 403 from `cdn.pyke.io`)
- [ ] `./scripts/bench.sh --gate` (LoCoMo 2-sample) — please run pre-merge given the scoring/retrieval changes
- [ ] `./scripts/bench.sh --samples 10` if the gate warns

https://claude.ai/code/session_01UZqRscFGHbWVsqwQ859W7D

---
_Generated by [Claude Code](https://claude.ai/code/session_01UZqRscFGHbWVsqwQ859W7D)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Retain the highest-scoring result per content fingerprint for better deduplication
  * Standardized scoring across candidate sources for more consistent rankings

* **Improvements**
  * Empty/whitespace queries follow an FTS-only path and safely return no results
  * Refined database retry semantics and backoff schedule to improve reliability under contention

* **Documentation**
  * Clarified the bounded retry/backoff behavior for lock contention handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->