### PR TITLE
docs: mark substrate campaign complete (all 15 roadmap PRs merged)

### DIFF
--- a/docs/specs/execution-roadmap.md
+++ b/docs/specs/execution-roadmap.md
@@ -289,7 +289,7 @@ PR-3b (depends on PR-2d) ──> PR-3c
 
 ---
 
-## Phase 4 — Exercise & Decompose (target: v0.2.2) -- IN PROGRESS
+## Phase 4 — Exercise & Decompose (target: v0.2.2) -- DONE
 
 Four PRs. PR-4a-i depends on PR-2a/PR-2d and can be opened after Phase 2 merges. PR-4b can be opened any time after Phase 1 — it has no dependency on Phases 2 or 3. PR-4a-ii depends on PR-4a-i. PR-4c depends on PR-4b.
 

--- a/docs/specs/execution-roadmap.md
+++ b/docs/specs/execution-roadmap.md
@@ -449,10 +449,10 @@ Phase 4
 ## Milestone Checkpoints
 
 ### v0.1.9 checkpoint
-- [ ] PR-1a merged: `--mcp-tools=minimal` filters the tool list at runtime
-- [ ] PR-1b merged: AGENTS.md tool count is accurate
-- [ ] PR-1c merged: sub-query parallelism active; `TODO(#121)` gone; no benchmark regression
-- [ ] PR-1d merged: `admin.rs` split into `admin/` subdirectory (4 files + mod.rs)
+- [x] PR-1a merged (#293): `--mcp-tools=minimal` filters the tool list at runtime
+- [x] PR-1b merged (#290): AGENTS.md tool count is accurate
+- [x] PR-1c merged (#291): sub-query parallelism active; `TODO(#121)` gone; no benchmark regression
+- [x] PR-1d merged (#292): `admin.rs` split into `admin/` subdirectory (4 files + mod.rs)
 
 ### v0.2.0 checkpoint
 - [x] PR-2a merged (#296): `ScoringStrategy` trait and `DefaultScoringStrategy` in place
@@ -469,10 +469,14 @@ Prerequisite: v0.2.0 checkpoint must be fully complete (all Phase 2 PRs merged) 
 - [x] PR-3c merged (#303): conformance suite passes for both backends
 
 ### v0.2.2 checkpoint
-- [ ] PR-4a-i merged: `RetrievalStrategy` trait defined (aligned with `trait-surface.md` §3.2); `FullPipelineStrategy` reference impl in place
-- [ ] PR-4a-ii merged: `KeywordOnlyStrategy` dispatched for keyword intent; 10-sample gate passed
-- [ ] PR-4b merged: `mcp_server.rs` split into `mcp/` module; MCP smoke tests pass
-- [ ] PR-4c merged: `advanced.rs` split into `pipeline/` subdirectory; benchmark gate passes
+- [x] PR-4a-i merged (#305): `RetrievalStrategy` trait defined (aligned with `trait-surface.md` §3.2); `FullPipelineStrategy` reference impl in place
+- [x] PR-4a-ii merged (#307): `KeywordOnlyStrategy` dispatched for keyword intent; 10-sample gate passed
+- [x] PR-4b merged (#306): `mcp_server.rs` split into `mcp/` module; MCP smoke tests pass
+- [x] PR-4c merged (#317): `advanced.rs` split into `pipeline/` subdirectory; benchmark gate passes
+
+**All 15 roadmap PRs merged.** Post-roadmap follow-up: #318 addressed eight deferred retrieval/lock bugs surfaced by Phase 4 review.
+
+**Post-roadmap residual**: `src/memory_core/storage/sqlite/advanced.rs` is 675 lines after PR-4c (vs. the ~350-line residual estimate in PR-4c §scope). The remainder is the `impl AdvancedSearcher` body — a dense orchestration that delegates to `pipeline::*` functions. Not flagged as blocking; track as a candidate for the v0.3.x substrate campaign if file-size policy is enforced strictly.
 
 ---
 

--- a/docs/strongholds/substrate-campaign.md
+++ b/docs/strongholds/substrate-campaign.md
@@ -45,11 +45,11 @@ MAG v0.2 is a Rust core exposing stable traits for Storage, Retrieval, Fusion, S
 | #301 | feat: strategy comparison benchmark harness (PR-3a) | 2026-04-14 | N/A |
 | #302 | feat: in-memory HashMap backend MemoryStorage (PR-3b) | 2026-04-14 | N/A |
 | #303 | test: shared backend conformance suite (PR-3c) | 2026-04-14 | N/A |
-| #305 | docs: add field-level doc comments to QueryContext / FullPipelineStrategy (PR-4a-i) | 2026-04-14 | N/A (additive) |
-| #306 | refactor: split mcp_server.rs into mcp/ module directory (PR-4b) | 2026-04-14 | N/A |
-| #307 | feat: add KeywordOnlyStrategy + intent-based dispatch (PR-4a-ii) | 2026-04-14 | 10-sample PASS |
-| #317 | refactor: split advanced.rs into pipeline/ subdirectory (PR-4c) | 2026-04-14 | PASS |
-| #318 | fix(search): address eight deferred retrieval/lock bugs (post-roadmap) | 2026-04-14 | N/A |
+| #305 | docs: add field-level doc comments to QueryContext / FullPipelineStrategy (PR-4a-i) | 2026-04-15 | N/A (additive) |
+| #306 | refactor: split mcp_server.rs into mcp/ module directory (PR-4b) | 2026-04-15 | N/A |
+| #307 | feat: add KeywordOnlyStrategy + intent-based dispatch (PR-4a-ii) | 2026-04-15 | 10-sample PASS |
+| #317 | refactor: split advanced.rs into pipeline/ subdirectory (PR-4c) | 2026-04-30 | PASS |
+| #318 | fix(search): address eight deferred retrieval/lock bugs (post-roadmap) | 2026-04-30 | N/A |
 
 ## Phase 4 Status
 
@@ -61,7 +61,7 @@ DONE. Both parallel chains landed:
 
 1. **sqlite/mod.rs trait impls already distributed** — The 19 trait implementations are already in submodules (crud.rs, search.rs, etc.). mod.rs problem is mixed concerns (struct, cache, relationships, I/O), not trait monolith.
 2. **Tool count is 19, not 16** — 15 legacy + 4 Wave 2 facades in TOOL_REGISTRY.
-3. **McpToolMode::Minimal is stubbed but not wired** — src/mcp_server.rs:54-56 explicitly says so.
+3. **McpToolMode::Minimal is stubbed but not wired** — was at src/mcp_server.rs:54-56 in v0.1.8; fixed in #293 and the file was later split into `src/mcp/` (#306).
 4. **Codebase is clean** — Zero dead code, zero unused deps, only 1 TODO (#121).
 5. **28 existing traits** — More mature trait surface than assumed. Refactor extends, not rewrites.
 

--- a/docs/strongholds/substrate-campaign.md
+++ b/docs/strongholds/substrate-campaign.md
@@ -1,8 +1,8 @@
 # MAG Experimentation Substrate Campaign
 
-**Status**: Phase 1 DONE, Phase 2 DONE, Phase 3 DONE, Phase 4 in progress
+**Status**: Phase 1 DONE, Phase 2 DONE, Phase 3 DONE, Phase 4 DONE — campaign complete (all 15 PRs merged)
 **Campaign Workspace**: `../mag-substrate` (jj workspace `substrate-campaign`)
-**Generated**: 2026-04-14
+**Generated**: 2026-04-14 | **Completed**: 2026-04-30
 
 ## Vision
 
@@ -45,12 +45,17 @@ MAG v0.2 is a Rust core exposing stable traits for Storage, Retrieval, Fusion, S
 | #301 | feat: strategy comparison benchmark harness (PR-3a) | 2026-04-14 | N/A |
 | #302 | feat: in-memory HashMap backend MemoryStorage (PR-3b) | 2026-04-14 | N/A |
 | #303 | test: shared backend conformance suite (PR-3c) | 2026-04-14 | N/A |
+| #305 | docs: add field-level doc comments to QueryContext / FullPipelineStrategy (PR-4a-i) | 2026-04-14 | N/A (additive) |
+| #306 | refactor: split mcp_server.rs into mcp/ module directory (PR-4b) | 2026-04-14 | N/A |
+| #307 | feat: add KeywordOnlyStrategy + intent-based dispatch (PR-4a-ii) | 2026-04-14 | 10-sample PASS |
+| #317 | refactor: split advanced.rs into pipeline/ subdirectory (PR-4c) | 2026-04-14 | PASS |
+| #318 | fix(search): address eight deferred retrieval/lock bugs (post-roadmap) | 2026-04-14 | N/A |
 
 ## Phase 4 Status
 
-Phase 4 in progress -- two parallel chains:
-- **4a-i + 4a-ii** (RetrievalStrategy trait + KeywordOnlyStrategy dispatch)
-- **4b + 4c** (split mcp_server.rs -> mcp/ module, then advanced.rs -> pipeline/)
+DONE. Both parallel chains landed:
+- **4a-i + 4a-ii** (RetrievalStrategy trait + KeywordOnlyStrategy dispatch) — `src/memory_core/retrieval_strategy.rs` exposes `RetrievalStrategy`, `FullPipelineStrategy`, and `KeywordOnlyStrategy`; `advanced_search` dispatches via intent.
+- **4b + 4c** (mcp_server.rs → `src/mcp/`, advanced.rs → `src/memory_core/storage/sqlite/pipeline/`) — `mcp_server.rs` is gone; `advanced.rs` residual is 675 lines (orchestration body) that delegates to eight `pipeline/` modules.
 
 ## Key Corrections from Source Inspection
 


### PR DESCRIPTION
## Summary

All 15 PRs in the v0.1.9 → v0.2.2 substrate refactor roadmap merged (#290, #291, #292, #293, #296, #297, #299, #300, #301, #302, #303, #305, #306, #307, #317), plus #318 follow-up addressing eight retrieval/lock bugs surfaced during Phase 4 review. The tracking docs were stale — this PR brings them in sync.

- `docs/specs/execution-roadmap.md` — flip v0.1.9 and v0.2.2 checkpoint boxes to `[x]` with the merged PR numbers.
- `docs/strongholds/substrate-campaign.md` — campaign status set to DONE; Phase 4 PRs (#305, #306, #307, #317) and post-roadmap follow-up (#318) added to the completed-PRs table; Phase 4 Status section rewritten with the actual landed module layout.

## Flagged residual (non-blocking)

`src/memory_core/storage/sqlite/advanced.rs` is **675 lines** after PR-4c — vs. the ~350-line residual estimate in the PR-4c §scope. The remainder is the `impl AdvancedSearcher` body, a dense orchestrator that delegates to `pipeline::*` helpers. Tracked in this commit as a candidate for follow-up; a decomposition PR is in flight in parallel.

## Test plan

- [x] `git diff` reviewed — docs-only, no code paths touched.
- [ ] No CI gates needed beyond the standard markdown checks.

https://claude.ai/code/session_01L1ddt9HaRiKwYhzunKkHNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1ddt9HaRiKwYhzunKkHNR)_