### PR TITLE
refactor(search): trim advanced.rs residual; extract dual-retrieval, decomp, keyword-only helpers

### DIFF
--- a/src/memory_core/storage/sqlite/advanced.rs
+++ b/src/memory_core/storage/sqlite/advanced.rs
@@ -80,7 +80,6 @@ impl AdvancedSearcher for SqliteStorage {
 
         let pool = Arc::clone(&self.pool);
         let embedder = Arc::clone(&self.embedder);
-        // Apply intent-based multipliers to scoring params.
         let mut scoring_params = self.scoring_params.clone();
         scoring_params.rrf_weight_vec *= intent_profile.vec_weight_mult;
         scoring_params.rrf_weight_fts *= intent_profile.fts_weight_mult;
@@ -101,18 +100,10 @@ impl AdvancedSearcher for SqliteStorage {
                 .is_some_and(|overlap| overlap >= scoring_params.abstention_min_text)
         });
 
-        // Capture filter dimensions for cache metadata before opts moves
-        // into closures further down. Both branches (keyword-only and full
-        // pipeline) share the cache-write tail at the bottom of the fn.
         let cache_event_type_filter = opts.event_type.as_ref().map(|et| et.to_string());
         let cache_project_filter = opts.project.clone();
         let cache_session_id_filter = opts.session_id.clone();
 
-        // ── KeywordOnlyStrategy dispatch ────────────────────────────────
-        // For keyword-intent queries (and empty / whitespace-only queries,
-        // which can't produce a meaningful embedding), skip embedding, vector
-        // search, RRF fusion, reranker, and graph enrichment. Use FTS5 BM25
-        // only.
         let results = if intent == QueryIntent::Keyword || query.trim().is_empty() {
             tracing::debug!(query = %query, "dispatching to KeywordOnlyStrategy");
             pipeline::run_keyword_only_search(
@@ -160,11 +151,6 @@ impl AdvancedSearcher for SqliteStorage {
             let candidate_limit =
                 ((limit as f64 * intent_profile.top_k_mult * dynamic_mult).ceil() as usize).max(1);
 
-            // Phases 1+2: Vector search and FTS5 search (non-keyword queries).
-            // Keyword queries were dispatched via KeywordOnlyStrategy above.
-            // When the pool has dedicated readers, run them on separate
-            // connections in parallel. In-memory mode (no readers) falls
-            // back to sequential execution on the single writer connection.
             let (vector_candidates, fts_candidates) = pipeline::collect_dual_candidates(
                 &pool,
                 &query,
@@ -176,7 +162,6 @@ impl AdvancedSearcher for SqliteStorage {
             )
             .await?;
 
-            // Clone opts before it moves into the fuse closure so sub-queries can reuse it.
             let opts_for_decomp = opts.clone();
 
             // Phases 3-6: RRF fusion, score refinement, graph enrichment,
@@ -186,8 +171,6 @@ impl AdvancedSearcher for SqliteStorage {
             let results = tokio::task::spawn_blocking({
                 let pool = Arc::clone(&pool);
                 let sp = scoring_params.clone();
-                let query = query.clone();
-                let query_embedding = query_embedding.clone();
                 let opts = opts_for_decomp.clone();
                 move || {
                     // Optional cross-encoder reranking (sync, safe inside spawn_blocking)

--- a/src/memory_core/storage/sqlite/advanced.rs
+++ b/src/memory_core/storage/sqlite/advanced.rs
@@ -197,77 +197,16 @@ impl AdvancedSearcher for SqliteStorage {
         // When the pool has dedicated readers, run them on separate
         // connections in parallel. In-memory mode (no readers) falls
         // back to sequential execution on the single writer connection.
-        let (vector_candidates, fts_candidates) = if pool.has_readers() {
-            let (vec_result, fts_result) = tokio::try_join!(
-                tokio::task::spawn_blocking({
-                    let pool = Arc::clone(&pool);
-                    let emb = query_embedding.clone();
-                    let o = opts.clone();
-                    let sp = scoring_params.clone();
-                    move || {
-                        let conn = pool.reader()?;
-                        pipeline::collect_vector_candidates(
-                            &conn,
-                            &emb,
-                            candidate_limit,
-                            include_superseded,
-                            &o,
-                            &sp,
-                        )
-                    }
-                }),
-                tokio::task::spawn_blocking({
-                    let pool = Arc::clone(&pool);
-                    let q = query.clone();
-                    let o = opts.clone();
-                    let sp = scoring_params.clone();
-                    move || {
-                        let conn = pool.reader()?;
-                        pipeline::collect_fts_candidates(
-                            &conn,
-                            &q,
-                            candidate_limit,
-                            &o,
-                            include_superseded,
-                            &sp,
-                        )
-                    }
-                }),
-            )
-            .context("parallel search join error")?;
-            (vec_result?, fts_result?)
-        } else {
-            // Sequential: single connection (in-memory / test mode).
-            tokio::task::spawn_blocking({
-                let pool = Arc::clone(&pool);
-                let emb = query_embedding.clone();
-                let q = query.clone();
-                let o = opts.clone();
-                let sp = scoring_params.clone();
-                move || {
-                    let conn = pool.reader()?;
-                    let vec_c = pipeline::collect_vector_candidates(
-                        &conn,
-                        &emb,
-                        candidate_limit,
-                        include_superseded,
-                        &o,
-                        &sp,
-                    )?;
-                    let fts_c = pipeline::collect_fts_candidates(
-                        &conn,
-                        &q,
-                        candidate_limit,
-                        &o,
-                        include_superseded,
-                        &sp,
-                    )?;
-                    Ok::<_, anyhow::Error>((vec_c, fts_c))
-                }
-            })
-            .await
-            .context("spawn_blocking join error")??
-        };
+        let (vector_candidates, fts_candidates) = pipeline::collect_dual_candidates(
+            &pool,
+            &query,
+            &query_embedding,
+            candidate_limit,
+            include_superseded,
+            &opts,
+            &scoring_params,
+        )
+        .await?;
 
         // Capture filter dimensions for cache metadata before opts moves into closure.
         let cache_event_type_filter = opts.event_type.as_ref().map(|et| et.to_string());

--- a/src/memory_core/storage/sqlite/advanced.rs
+++ b/src/memory_core/storage/sqlite/advanced.rs
@@ -1,6 +1,3 @@
-use super::nlp::{
-    content_fingerprint, extract_query_entities, extract_topic_keywords, generate_sub_queries,
-};
 use super::pipeline;
 use super::query_classifier::{
     IntentProfile, QueryIntent, classify_query_intent, detect_dynamic_limit_mult,
@@ -256,95 +253,22 @@ impl AdvancedSearcher for SqliteStorage {
         .context("spawn_blocking join error")??;
 
         // ── Query decomposition: enrich results for multi-entity queries ──
-        let decomp_entities = extract_query_entities(&query_for_decomp);
-        let results = if decomp_entities.len() >= 2 {
-            let topics = extract_topic_keywords(&query_for_decomp, &decomp_entities);
-            let sub_queries = generate_sub_queries(&query_for_decomp, &decomp_entities, &topics);
-
-            if !topics.is_empty() && sub_queries.len() > 1 {
-                let mut all_results = results;
-                let mut seen_ids: HashSet<String> =
-                    all_results.iter().map(|r| r.id.clone()).collect();
-
-                let decomp_pool = Arc::clone(&self.pool);
-                let decomp_embedder = Arc::clone(&self.embedder);
-                // Use the intent-adjusted scoring params so sub-queries inherit
-                // the same RRF / word-overlap weights as the main query.
-                let decomp_sp = scoring_params.clone();
-                let decomp_opts = opts_for_decomp.clone();
-                let decomp_strat = Arc::clone(&self.scoring_strategy);
-                // Parallel sub-query execution (resolves #121).
-                // ConnPool has 4 dedicated reader connections in WAL mode.
-                // Each sub-query internally runs vector + FTS in try_join!,
-                // consuming 2 readers simultaneously, so effective parallelism
-                // is ~2 sub-queries at a time; additional queries queue on the
-                // reader mutexes without deadlock.  Results are collected with
-                // their original index and sorted before merging to preserve
-                // deterministic dedup ordering.
-                let mut join_set: tokio::task::JoinSet<(usize, Result<Vec<SemanticResult>>)> =
-                    tokio::task::JoinSet::new();
-                for (idx, sub_query) in sub_queries.iter().skip(1).enumerate() {
-                    let pool = Arc::clone(&decomp_pool);
-                    let embedder = Arc::clone(&decomp_embedder);
-                    let sq = sub_query.clone();
-                    let opts = decomp_opts.clone();
-                    let sp = decomp_sp.clone();
-                    let strat = Arc::clone(&decomp_strat);
-                    join_set.spawn(async move {
-                        let res = pipeline::run_single_query_pipeline(
-                            &pool,
-                            &embedder,
-                            &sq,
-                            candidate_limit,
-                            limit,
-                            &opts,
-                            &sp,
-                            include_superseded,
-                            explain_enabled,
-                            &strat,
-                        )
-                        .await;
-                        (idx, res)
-                    });
-                }
-                // Collect all results, then sort by original sub-query index
-                // so merge order is deterministic (same as the old sequential loop).
-                let mut indexed_results: Vec<(usize, Vec<SemanticResult>)> = Vec::new();
-                while let Some(task_result) = join_set.join_next().await {
-                    let (idx, sub_results) = task_result.context("sub-query task panicked")?;
-                    indexed_results.push((idx, sub_results?));
-                }
-                indexed_results.sort_by_key(|(idx, _)| *idx);
-                for (_idx, sub_results) in indexed_results {
-                    for result in sub_results {
-                        if seen_ids.insert(result.id.clone()) {
-                            all_results.push(result);
-                        } else if let Some(existing) =
-                            all_results.iter_mut().find(|r| r.id == result.id)
-                            && result.score > existing.score
-                        {
-                            existing.score = result.score;
-                        }
-                    }
-                }
-
-                let mut deduped: Vec<SemanticResult> = Vec::new();
-                let mut fingerprints: HashSet<String> = HashSet::new();
-                all_results.sort_by(|a, b| b.score.total_cmp(&a.score));
-                for result in all_results {
-                    let fp = content_fingerprint(&result.content);
-                    if fingerprints.insert(fp) {
-                        deduped.push(result);
-                    }
-                }
-                deduped.truncate(limit);
-                deduped
-            } else {
-                results
-            }
-        } else {
-            results
-        };
+        // Use the intent-adjusted scoring params so sub-queries inherit
+        // the same RRF / word-overlap weights as the main query.
+        let results = pipeline::enrich_with_decomposition(
+            &self.pool,
+            &self.embedder,
+            &self.scoring_strategy,
+            results,
+            &query_for_decomp,
+            candidate_limit,
+            limit,
+            &opts_for_decomp,
+            &scoring_params,
+            include_superseded,
+            explain_enabled,
+        )
+        .await?;
 
         let results = if hot_has_confident_match {
             pipeline::merge_hot_cache_results(hot_results, results, limit)

--- a/src/memory_core/storage/sqlite/advanced.rs
+++ b/src/memory_core/storage/sqlite/advanced.rs
@@ -105,15 +105,15 @@ impl AdvancedSearcher for SqliteStorage {
         let cache_session_id_filter = opts.session_id.clone();
 
         let results = if intent == QueryIntent::Keyword || query.trim().is_empty() {
-            tracing::debug!(query = %query, "dispatching to KeywordOnlyStrategy");
+            tracing::debug!(query = %query, strategy = "keyword-only", "dispatching retrieval strategy");
+            let hot_match = hot_has_confident_match.then_some(hot_results);
             pipeline::run_keyword_only_search(
                 self,
                 &query,
                 limit,
                 &opts,
                 &scoring_params,
-                hot_results,
-                hot_has_confident_match,
+                hot_match,
             )
             .await?
         } else {
@@ -266,7 +266,7 @@ mod tests {
     async fn bounded_fts_candidates_preserve_created_at_filters() {
         let storage = SqliteStorage::new_in_memory().unwrap();
 
-        for idx in 0..120 {
+        for idx in 0..(super::pipeline::ADVANCED_FTS_CANDIDATE_MIN + 20) {
             let id = format!("old-{idx}");
             <SqliteStorage as Storage>::store(
                 &storage,
@@ -326,7 +326,7 @@ mod tests {
     async fn bounded_fts_candidates_preserve_event_at_filters() {
         let storage = SqliteStorage::new_in_memory().unwrap();
 
-        for idx in 0..120 {
+        for idx in 0..(super::pipeline::ADVANCED_FTS_CANDIDATE_MIN + 20) {
             let id = format!("old-event-{idx}");
             <SqliteStorage as Storage>::store(
                 &storage,

--- a/src/memory_core/storage/sqlite/advanced.rs
+++ b/src/memory_core/storage/sqlite/advanced.rs
@@ -101,179 +101,150 @@ impl AdvancedSearcher for SqliteStorage {
                 .is_some_and(|overlap| overlap >= scoring_params.abstention_min_text)
         });
 
+        // Capture filter dimensions for cache metadata before opts moves
+        // into closures further down. Both branches (keyword-only and full
+        // pipeline) share the cache-write tail at the bottom of the fn.
+        let cache_event_type_filter = opts.event_type.as_ref().map(|et| et.to_string());
+        let cache_project_filter = opts.project.clone();
+        let cache_session_id_filter = opts.session_id.clone();
+
         // ── KeywordOnlyStrategy dispatch ────────────────────────────────
         // For keyword-intent queries (and empty / whitespace-only queries,
         // which can't produce a meaningful embedding), skip embedding, vector
         // search, RRF fusion, reranker, and graph enrichment. Use FTS5 BM25
         // only.
-        if intent == QueryIntent::Keyword || query.trim().is_empty() {
+        let results = if intent == QueryIntent::Keyword || query.trim().is_empty() {
             tracing::debug!(query = %query, "dispatching to KeywordOnlyStrategy");
-            let include_superseded = opts.include_superseded.unwrap_or(false);
-            let explain_enabled = opts.explain.unwrap_or(false);
-            let candidates: CandidateSet = self
-                .fts_search(&query, limit, &opts, include_superseded, &scoring_params)
-                .await?;
-
-            let scoring_strategy = Arc::clone(&self.scoring_strategy);
-            let query_owned = query.clone();
-            let sp = scoring_params.clone();
-            let results = tokio::task::spawn_blocking(move || {
-                pipeline::keyword_candidates_to_results(
-                    candidates,
-                    &query_owned,
-                    limit,
-                    &sp,
-                    scoring_strategy.as_ref(),
-                    explain_enabled,
-                )
+            pipeline::run_keyword_only_search(
+                self,
+                &query,
+                limit,
+                &opts,
+                &scoring_params,
+                hot_results,
+                hot_has_confident_match,
+            )
+            .await?
+        } else {
+            // Phase 0: Embedding computation (blocking).
+            // Keyword queries have already been handled above via
+            // KeywordOnlyStrategy, so all remaining queries require an
+            // embedding.
+            let query_embedding = tokio::task::spawn_blocking({
+                let embedder = Arc::clone(&embedder);
+                let query = query.clone();
+                move || {
+                    let emb = if query.is_empty() {
+                        Vec::new()
+                    } else {
+                        embedder
+                            .embed(&query)
+                            .context("failed to compute query embedding")?
+                    };
+                    Ok::<_, anyhow::Error>(emb)
+                }
             })
             .await
-            .context("spawn_blocking join error")?;
+            .context("spawn_blocking join error")??;
 
-            let results = if hot_has_confident_match {
+            let include_superseded = opts.include_superseded.unwrap_or(false);
+            let explain_enabled = opts.explain.unwrap_or(false);
+
+            // Apply top_k_mult: scale candidate oversampling while keeping final limit intact.
+            let dynamic_mult = detect_dynamic_limit_mult(&query);
+            #[allow(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                clippy::cast_precision_loss
+            )]
+            let candidate_limit =
+                ((limit as f64 * intent_profile.top_k_mult * dynamic_mult).ceil() as usize).max(1);
+
+            // Phases 1+2: Vector search and FTS5 search (non-keyword queries).
+            // Keyword queries were dispatched via KeywordOnlyStrategy above.
+            // When the pool has dedicated readers, run them on separate
+            // connections in parallel. In-memory mode (no readers) falls
+            // back to sequential execution on the single writer connection.
+            let (vector_candidates, fts_candidates) = pipeline::collect_dual_candidates(
+                &pool,
+                &query,
+                &query_embedding,
+                candidate_limit,
+                include_superseded,
+                &opts,
+                &scoring_params,
+            )
+            .await?;
+
+            // Clone opts before it moves into the fuse closure so sub-queries can reuse it.
+            let opts_for_decomp = opts.clone();
+
+            // Phases 3-6: RRF fusion, score refinement, graph enrichment,
+            // abstention + dedup. Needs one reader for graph queries.
+            let reranker = self.reranker.clone();
+            let scoring_strategy = Arc::clone(&self.scoring_strategy);
+            let results = tokio::task::spawn_blocking({
+                let pool = Arc::clone(&pool);
+                let sp = scoring_params.clone();
+                let query = query.clone();
+                let query_embedding = query_embedding.clone();
+                let opts = opts_for_decomp.clone();
+                move || {
+                    // Optional cross-encoder reranking (sync, safe inside spawn_blocking)
+                    let ce_scores = pipeline::compute_cross_encoder_scores(
+                        reranker.as_ref(),
+                        &query,
+                        &vector_candidates,
+                        &fts_candidates,
+                        &sp,
+                    );
+
+                    let conn = pool.reader()?;
+                    // `fuse_and_score` orchestrates phases 3-6 internally
+                    // (RRF fusion -> refine -> graph enrichment -> entity expansion
+                    // -> abstention/dedup via `abstain_and_dedup`).
+                    pipeline::fuse_and_score(
+                        &conn,
+                        vector_candidates,
+                        fts_candidates,
+                        &query,
+                        &query_embedding,
+                        &opts,
+                        limit,
+                        include_superseded,
+                        explain_enabled,
+                        &sp,
+                        ce_scores.as_ref(),
+                        scoring_strategy.as_ref(),
+                    )
+                }
+            })
+            .await
+            .context("spawn_blocking join error")??;
+
+            // ── Query decomposition: enrich results for multi-entity queries ──
+            // Use the intent-adjusted scoring params so sub-queries inherit
+            // the same RRF / word-overlap weights as the main query.
+            let results = pipeline::enrich_with_decomposition(
+                &self.pool,
+                &self.embedder,
+                &self.scoring_strategy,
+                results,
+                &query_for_decomp,
+                candidate_limit,
+                limit,
+                &opts_for_decomp,
+                &scoring_params,
+                include_superseded,
+                explain_enabled,
+            )
+            .await?;
+
+            if hot_has_confident_match {
                 pipeline::merge_hot_cache_results(hot_results, results, limit)
             } else {
                 results
-            };
-
-            // ── Cache store ──────────────────────────────────────────────
-            let cache_event_type_filter = opts.event_type.as_ref().map(|et| et.to_string());
-            let cache_project_filter = opts.project.clone();
-            let cache_session_id_filter = opts.session_id.clone();
-            if let Ok(mut cache) = self.query_cache.lock() {
-                cache.put(
-                    cache_key,
-                    super::CachedQuery {
-                        inserted_at: std::time::Instant::now(),
-                        results: results.clone(),
-                        event_type_filter: cache_event_type_filter,
-                        project_filter: cache_project_filter,
-                        session_id_filter: cache_session_id_filter,
-                    },
-                );
             }
-
-            return Ok(results);
-        }
-
-        // Phase 0: Embedding computation (blocking).
-        // Keyword queries have already returned above via KeywordOnlyStrategy,
-        // so all remaining queries require an embedding.
-        let query_embedding = tokio::task::spawn_blocking({
-            let embedder = Arc::clone(&embedder);
-            let query = query.clone();
-            move || {
-                let emb = if query.is_empty() {
-                    Vec::new()
-                } else {
-                    embedder
-                        .embed(&query)
-                        .context("failed to compute query embedding")?
-                };
-                Ok::<_, anyhow::Error>(emb)
-            }
-        })
-        .await
-        .context("spawn_blocking join error")??;
-
-        let include_superseded = opts.include_superseded.unwrap_or(false);
-        let explain_enabled = opts.explain.unwrap_or(false);
-
-        // Apply top_k_mult: scale candidate oversampling while keeping final limit intact.
-        let dynamic_mult = detect_dynamic_limit_mult(&query);
-        #[allow(
-            clippy::cast_possible_truncation,
-            clippy::cast_sign_loss,
-            clippy::cast_precision_loss
-        )]
-        let candidate_limit =
-            ((limit as f64 * intent_profile.top_k_mult * dynamic_mult).ceil() as usize).max(1);
-
-        // Phases 1+2: Vector search and FTS5 search (non-keyword queries).
-        // Keyword queries were dispatched via KeywordOnlyStrategy above.
-        // When the pool has dedicated readers, run them on separate
-        // connections in parallel. In-memory mode (no readers) falls
-        // back to sequential execution on the single writer connection.
-        let (vector_candidates, fts_candidates) = pipeline::collect_dual_candidates(
-            &pool,
-            &query,
-            &query_embedding,
-            candidate_limit,
-            include_superseded,
-            &opts,
-            &scoring_params,
-        )
-        .await?;
-
-        // Capture filter dimensions for cache metadata before opts moves into closure.
-        let cache_event_type_filter = opts.event_type.as_ref().map(|et| et.to_string());
-        let cache_project_filter = opts.project.clone();
-        let cache_session_id_filter = opts.session_id.clone();
-        // Clone opts before it moves into the fuse closure so sub-queries can reuse it.
-        let opts_for_decomp = opts.clone();
-
-        // Phases 3-6: RRF fusion, score refinement, graph enrichment,
-        // abstention + dedup. Needs one reader for graph queries.
-        let reranker = self.reranker.clone();
-        let scoring_strategy = Arc::clone(&self.scoring_strategy);
-        let results = tokio::task::spawn_blocking({
-            let pool = Arc::clone(&pool);
-            let sp = scoring_params.clone();
-            move || {
-                // Optional cross-encoder reranking (sync, safe inside spawn_blocking)
-                let ce_scores = pipeline::compute_cross_encoder_scores(
-                    reranker.as_ref(),
-                    &query,
-                    &vector_candidates,
-                    &fts_candidates,
-                    &sp,
-                );
-
-                let conn = pool.reader()?;
-                // `fuse_and_score` orchestrates phases 3-6 internally
-                // (RRF fusion -> refine -> graph enrichment -> entity expansion
-                // -> abstention/dedup via `abstain_and_dedup`).
-                pipeline::fuse_and_score(
-                    &conn,
-                    vector_candidates,
-                    fts_candidates,
-                    &query,
-                    &query_embedding,
-                    &opts,
-                    limit,
-                    include_superseded,
-                    explain_enabled,
-                    &sp,
-                    ce_scores.as_ref(),
-                    scoring_strategy.as_ref(),
-                )
-            }
-        })
-        .await
-        .context("spawn_blocking join error")??;
-
-        // ── Query decomposition: enrich results for multi-entity queries ──
-        // Use the intent-adjusted scoring params so sub-queries inherit
-        // the same RRF / word-overlap weights as the main query.
-        let results = pipeline::enrich_with_decomposition(
-            &self.pool,
-            &self.embedder,
-            &self.scoring_strategy,
-            results,
-            &query_for_decomp,
-            candidate_limit,
-            limit,
-            &opts_for_decomp,
-            &scoring_params,
-            include_superseded,
-            explain_enabled,
-        )
-        .await?;
-
-        let results = if hot_has_confident_match {
-            pipeline::merge_hot_cache_results(hot_results, results, limit)
-        } else {
-            results
         };
 
         // ── Cache store ──────────────────────────────────────────────────

--- a/src/memory_core/storage/sqlite/pipeline/decomp.rs
+++ b/src/memory_core/storage/sqlite/pipeline/decomp.rs
@@ -110,8 +110,10 @@ pub(crate) async fn run_single_query_pipeline(
 /// For multi-entity queries we extract entities/topics, generate sub-queries,
 /// then fan out the remaining sub-queries (skipping the first, which is the
 /// original query already represented by `base_results`). Sub-results are
-/// merged: new ids appended, duplicates score-maxed, and the final list
-/// fingerprint-deduped on content before truncating to `limit`.
+/// merged: new ids appended; on duplicate id, the higher score wins (first
+/// occurrence wins on ties for stable ordering across parallel completion);
+/// then the final list is fingerprint-deduped on content before truncating
+/// to `limit`.
 ///
 /// If decomposition does not apply (fewer than two entities, no topics, or
 /// only one sub-query) the base results are returned unchanged.

--- a/src/memory_core/storage/sqlite/pipeline/decomp.rs
+++ b/src/memory_core/storage/sqlite/pipeline/decomp.rs
@@ -2,12 +2,15 @@
 //! `advanced_search`. Each sub-query (one per detected entity) is fed
 //! through this function in parallel.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
 
 use super::super::conn_pool::ConnPool;
+use super::super::nlp::{
+    content_fingerprint, extract_query_entities, extract_topic_keywords, generate_sub_queries,
+};
 use super::super::query_classifier::{QueryIntent, classify_query_intent};
 use super::fusion::fuse_and_score;
 use super::retrieval::{collect_dual_candidates, collect_fts_candidates};
@@ -99,4 +102,109 @@ pub(crate) async fn run_single_query_pipeline(
     })
     .await
     .context("spawn_blocking join error")?
+}
+
+/// Enrich a base result set by running each detected sub-query through the
+/// single-query pipeline in parallel and merging the results.
+///
+/// For multi-entity queries we extract entities/topics, generate sub-queries,
+/// then fan out the remaining sub-queries (skipping the first, which is the
+/// original query already represented by `base_results`). Sub-results are
+/// merged: new ids appended, duplicates score-maxed, and the final list
+/// fingerprint-deduped on content before truncating to `limit`.
+///
+/// If decomposition does not apply (fewer than two entities, no topics, or
+/// only one sub-query) the base results are returned unchanged.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn enrich_with_decomposition(
+    pool: &Arc<ConnPool>,
+    embedder: &Arc<dyn Embedder>,
+    scoring_strategy: &Arc<dyn ScoringStrategy>,
+    base_results: Vec<SemanticResult>,
+    query_for_decomp: &str,
+    candidate_limit: usize,
+    limit: usize,
+    opts: &SearchOptions,
+    scoring_params: &ScoringParams,
+    include_superseded: bool,
+    explain_enabled: bool,
+) -> Result<Vec<SemanticResult>> {
+    let decomp_entities = extract_query_entities(query_for_decomp);
+    if decomp_entities.len() < 2 {
+        return Ok(base_results);
+    }
+    let topics = extract_topic_keywords(query_for_decomp, &decomp_entities);
+    let sub_queries = generate_sub_queries(query_for_decomp, &decomp_entities, &topics);
+    if topics.is_empty() || sub_queries.len() <= 1 {
+        return Ok(base_results);
+    }
+
+    let mut all_results = base_results;
+    let mut seen_ids: HashSet<String> = all_results.iter().map(|r| r.id.clone()).collect();
+
+    // Parallel sub-query execution (resolves #121).
+    // ConnPool has 4 dedicated reader connections in WAL mode.
+    // Each sub-query internally runs vector + FTS in try_join!,
+    // consuming 2 readers simultaneously, so effective parallelism
+    // is ~2 sub-queries at a time; additional queries queue on the
+    // reader mutexes without deadlock.  Results are collected with
+    // their original index and sorted before merging to preserve
+    // deterministic dedup ordering.
+    let mut join_set: tokio::task::JoinSet<(usize, Result<Vec<SemanticResult>>)> =
+        tokio::task::JoinSet::new();
+    for (idx, sub_query) in sub_queries.iter().skip(1).enumerate() {
+        let pool = Arc::clone(pool);
+        let embedder = Arc::clone(embedder);
+        let sq = sub_query.clone();
+        let opts = opts.clone();
+        let sp = scoring_params.clone();
+        let strat = Arc::clone(scoring_strategy);
+        join_set.spawn(async move {
+            let res = run_single_query_pipeline(
+                &pool,
+                &embedder,
+                &sq,
+                candidate_limit,
+                limit,
+                &opts,
+                &sp,
+                include_superseded,
+                explain_enabled,
+                &strat,
+            )
+            .await;
+            (idx, res)
+        });
+    }
+    // Collect all results, then sort by original sub-query index
+    // so merge order is deterministic (same as the old sequential loop).
+    let mut indexed_results: Vec<(usize, Vec<SemanticResult>)> = Vec::new();
+    while let Some(task_result) = join_set.join_next().await {
+        let (idx, sub_results) = task_result.context("sub-query task panicked")?;
+        indexed_results.push((idx, sub_results?));
+    }
+    indexed_results.sort_by_key(|(idx, _)| *idx);
+    for (_idx, sub_results) in indexed_results {
+        for result in sub_results {
+            if seen_ids.insert(result.id.clone()) {
+                all_results.push(result);
+            } else if let Some(existing) = all_results.iter_mut().find(|r| r.id == result.id)
+                && result.score > existing.score
+            {
+                existing.score = result.score;
+            }
+        }
+    }
+
+    let mut deduped: Vec<SemanticResult> = Vec::new();
+    let mut fingerprints: HashSet<String> = HashSet::new();
+    all_results.sort_by(|a, b| b.score.total_cmp(&a.score));
+    for result in all_results {
+        let fp = content_fingerprint(&result.content);
+        if fingerprints.insert(fp) {
+            deduped.push(result);
+        }
+    }
+    deduped.truncate(limit);
+    Ok(deduped)
 }

--- a/src/memory_core/storage/sqlite/pipeline/decomp.rs
+++ b/src/memory_core/storage/sqlite/pipeline/decomp.rs
@@ -10,7 +10,7 @@ use anyhow::{Context, Result};
 use super::super::conn_pool::ConnPool;
 use super::super::query_classifier::{QueryIntent, classify_query_intent};
 use super::fusion::fuse_and_score;
-use super::retrieval::{collect_fts_candidates, collect_vector_candidates};
+use super::retrieval::{collect_dual_candidates, collect_fts_candidates};
 use crate::memory_core::embedder::Embedder;
 use crate::memory_core::scoring_strategy::ScoringStrategy;
 use crate::memory_core::{ScoringParams, SearchOptions, SemanticResult};
@@ -48,71 +48,28 @@ pub(crate) async fn run_single_query_pipeline(
     };
 
     let (vector_candidates, fts_candidates) = if fts_only {
-        let pool = Arc::clone(pool);
+        let pool_arc = Arc::clone(pool);
         let q = query.to_string();
         let o = opts.clone();
         let sp = scoring_params.clone();
         let fts_result = tokio::task::spawn_blocking(move || {
-            let conn = pool.reader()?;
+            let conn = pool_arc.reader()?;
             collect_fts_candidates(&conn, &q, candidate_limit, &o, include_superseded, &sp)
         })
         .await
         .context("spawn_blocking join error")??;
         (Vec::new(), fts_result)
-    } else if pool.has_readers() {
-        let (vec_result, fts_result) = tokio::try_join!(
-            tokio::task::spawn_blocking({
-                let pool = Arc::clone(pool);
-                let emb = query_embedding.clone();
-                let o = opts.clone();
-                let sp = scoring_params.clone();
-                move || {
-                    let conn = pool.reader()?;
-                    collect_vector_candidates(
-                        &conn,
-                        &emb,
-                        candidate_limit,
-                        include_superseded,
-                        &o,
-                        &sp,
-                    )
-                }
-            }),
-            tokio::task::spawn_blocking({
-                let pool = Arc::clone(pool);
-                let q = query.to_string();
-                let o = opts.clone();
-                let sp = scoring_params.clone();
-                move || {
-                    let conn = pool.reader()?;
-                    collect_fts_candidates(&conn, &q, candidate_limit, &o, include_superseded, &sp)
-                }
-            }),
-        )
-        .context("parallel search join error")?;
-        (vec_result?, fts_result?)
     } else {
-        let pool = Arc::clone(pool);
-        let emb = query_embedding.clone();
-        let q = query.to_string();
-        let o = opts.clone();
-        let sp = scoring_params.clone();
-        tokio::task::spawn_blocking(move || {
-            let conn = pool.reader()?;
-            let vec_c = collect_vector_candidates(
-                &conn,
-                &emb,
-                candidate_limit,
-                include_superseded,
-                &o,
-                &sp,
-            )?;
-            let fts_c =
-                collect_fts_candidates(&conn, &q, candidate_limit, &o, include_superseded, &sp)?;
-            Ok::<_, anyhow::Error>((vec_c, fts_c))
-        })
-        .await
-        .context("spawn_blocking join error")??
+        collect_dual_candidates(
+            pool,
+            query,
+            &query_embedding,
+            candidate_limit,
+            include_superseded,
+            opts,
+            scoring_params,
+        )
+        .await?
     };
 
     let ce_scores: Option<HashMap<String, f32>> = None;

--- a/src/memory_core/storage/sqlite/pipeline/mod.rs
+++ b/src/memory_core/storage/sqlite/pipeline/mod.rs
@@ -46,4 +46,4 @@ pub(super) use decomp::enrich_with_decomposition;
 pub(super) use fusion::fuse_and_score;
 pub(super) use rerank::compute_cross_encoder_scores;
 pub(super) use retrieval::{collect_dual_candidates, collect_fts_candidates};
-pub(super) use scoring::keyword_candidates_to_results;
+pub(super) use scoring::run_keyword_only_search;

--- a/src/memory_core/storage/sqlite/pipeline/mod.rs
+++ b/src/memory_core/storage/sqlite/pipeline/mod.rs
@@ -45,5 +45,5 @@ pub(super) use abstention::merge_hot_cache_results;
 pub(super) use decomp::run_single_query_pipeline;
 pub(super) use fusion::fuse_and_score;
 pub(super) use rerank::compute_cross_encoder_scores;
-pub(super) use retrieval::{collect_fts_candidates, collect_vector_candidates};
+pub(super) use retrieval::{collect_dual_candidates, collect_fts_candidates};
 pub(super) use scoring::keyword_candidates_to_results;

--- a/src/memory_core/storage/sqlite/pipeline/mod.rs
+++ b/src/memory_core/storage/sqlite/pipeline/mod.rs
@@ -39,7 +39,7 @@ pub(super) fn advanced_fts_candidate_limit(limit: usize) -> usize {
 // Phase functions are declared `pub(super)` inside their respective
 // sub-modules (visible only within `pipeline/`). Re-exporting them here as
 // `pub(super) use` makes them visible to the parent `sqlite/` module so
-// `advanced.rs` can call them as `pipeline::collect_vector_candidates`, etc.
+// `advanced.rs` can call them as e.g. `pipeline::collect_dual_candidates`.
 
 pub(super) use abstention::merge_hot_cache_results;
 pub(super) use decomp::enrich_with_decomposition;

--- a/src/memory_core/storage/sqlite/pipeline/mod.rs
+++ b/src/memory_core/storage/sqlite/pipeline/mod.rs
@@ -42,7 +42,7 @@ pub(super) fn advanced_fts_candidate_limit(limit: usize) -> usize {
 // `advanced.rs` can call them as `pipeline::collect_vector_candidates`, etc.
 
 pub(super) use abstention::merge_hot_cache_results;
-pub(super) use decomp::run_single_query_pipeline;
+pub(super) use decomp::enrich_with_decomposition;
 pub(super) use fusion::fuse_and_score;
 pub(super) use rerank::compute_cross_encoder_scores;
 pub(super) use retrieval::{collect_dual_candidates, collect_fts_candidates};

--- a/src/memory_core/storage/sqlite/pipeline/retrieval.rs
+++ b/src/memory_core/storage/sqlite/pipeline/retrieval.rs
@@ -404,8 +404,14 @@ pub(crate) async fn collect_dual_candidates(
                     &o,
                     &sp,
                 )?;
-                let fts_c =
-                    collect_fts_candidates(&conn, &q, candidate_limit, &o, include_superseded, &sp)?;
+                let fts_c = collect_fts_candidates(
+                    &conn,
+                    &q,
+                    candidate_limit,
+                    &o,
+                    include_superseded,
+                    &sp,
+                )?;
                 Ok::<_, anyhow::Error>((vec_c, fts_c))
             }
         })

--- a/src/memory_core/storage/sqlite/pipeline/retrieval.rs
+++ b/src/memory_core/storage/sqlite/pipeline/retrieval.rs
@@ -1,8 +1,11 @@
 //! Phase 1 (vector candidates) and Phase 2 (FTS candidates) retrieval.
 
+use std::sync::Arc;
+
 use anyhow::{Context, Result};
 use rusqlite::Connection;
 
+use super::super::conn_pool::ConnPool;
 #[cfg(not(feature = "sqlite-vec"))]
 use super::super::dot_product;
 #[cfg(not(feature = "sqlite-vec"))]
@@ -15,6 +18,7 @@ use super::super::helpers::{
 use super::super::helpers::{hydrate_memories_by_ids, vec_distance_to_similarity, vec_knn_search};
 use super::super::storage::RankedSemanticCandidate;
 use super::advanced_fts_candidate_limit;
+use crate::memory_core::retrieval_strategy::CandidateSet;
 use crate::memory_core::{
     EventType, ScoringParams, SearchOptions, SemanticResult, priority_factor, type_weight_et,
 };
@@ -332,4 +336,80 @@ pub(crate) fn collect_fts_candidates(
     // so sort ascending (most negative first = best rank for RRF)
     fts_candidates.sort_by(|a, b| a.1.total_cmp(&b.1));
     Ok(fts_candidates)
+}
+
+/// Run Phase 1 (vector) and Phase 2 (FTS) candidate retrieval, in parallel
+/// when the connection pool has dedicated readers and sequentially otherwise.
+///
+/// In WAL-pooled mode the two scans run on independent reader connections
+/// via `try_join!`. In single-connection (in-memory / test) mode they share
+/// the writer connection, so we run them sequentially inside one
+/// `spawn_blocking` to keep the SQLite connection on a single thread.
+pub(crate) async fn collect_dual_candidates(
+    pool: &Arc<ConnPool>,
+    query: &str,
+    query_embedding: &[f32],
+    candidate_limit: usize,
+    include_superseded: bool,
+    opts: &SearchOptions,
+    scoring_params: &ScoringParams,
+) -> Result<(CandidateSet, CandidateSet)> {
+    if pool.has_readers() {
+        let (vec_result, fts_result) = tokio::try_join!(
+            tokio::task::spawn_blocking({
+                let pool = Arc::clone(pool);
+                let emb = query_embedding.to_vec();
+                let o = opts.clone();
+                let sp = scoring_params.clone();
+                move || {
+                    let conn = pool.reader()?;
+                    collect_vector_candidates(
+                        &conn,
+                        &emb,
+                        candidate_limit,
+                        include_superseded,
+                        &o,
+                        &sp,
+                    )
+                }
+            }),
+            tokio::task::spawn_blocking({
+                let pool = Arc::clone(pool);
+                let q = query.to_string();
+                let o = opts.clone();
+                let sp = scoring_params.clone();
+                move || {
+                    let conn = pool.reader()?;
+                    collect_fts_candidates(&conn, &q, candidate_limit, &o, include_superseded, &sp)
+                }
+            }),
+        )
+        .context("parallel search join error")?;
+        Ok((vec_result?, fts_result?))
+    } else {
+        // Sequential: single connection (in-memory / test mode).
+        tokio::task::spawn_blocking({
+            let pool = Arc::clone(pool);
+            let emb = query_embedding.to_vec();
+            let q = query.to_string();
+            let o = opts.clone();
+            let sp = scoring_params.clone();
+            move || {
+                let conn = pool.reader()?;
+                let vec_c = collect_vector_candidates(
+                    &conn,
+                    &emb,
+                    candidate_limit,
+                    include_superseded,
+                    &o,
+                    &sp,
+                )?;
+                let fts_c =
+                    collect_fts_candidates(&conn, &q, candidate_limit, &o, include_superseded, &sp)?;
+                Ok::<_, anyhow::Error>((vec_c, fts_c))
+            }
+        })
+        .await
+        .context("spawn_blocking join error")?
+    }
 }

--- a/src/memory_core/storage/sqlite/pipeline/scoring.rs
+++ b/src/memory_core/storage/sqlite/pipeline/scoring.rs
@@ -207,11 +207,7 @@ pub(crate) fn keyword_candidates_to_results(
 /// For keyword-intent queries (and empty / whitespace-only queries, which
 /// can't produce a meaningful embedding), this skips embedding, vector
 /// search, RRF fusion, reranker, and graph enrichment, using FTS5 BM25
-/// only. Runs `keyword_candidates_to_results` inside `spawn_blocking` and
-/// merges hot-cache hits when the cache had a confident text match.
-///
-/// Cache writes are intentionally left to the caller so both keyword and
-/// full-pipeline branches share a single cache-write tail.
+/// only. Merges hot-cache hits when the cache had a confident text match.
 pub(crate) async fn run_keyword_only_search(
     storage: &SqliteStorage,
     query: &str,

--- a/src/memory_core/storage/sqlite/pipeline/scoring.rs
+++ b/src/memory_core/storage/sqlite/pipeline/scoring.rs
@@ -5,9 +5,13 @@
 //! `KeywordOnlyStrategy` dispatch in `advanced_search`.
 
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
-use super::super::storage::RankedSemanticCandidate;
-use crate::memory_core::retrieval_strategy::CandidateSet;
+use anyhow::{Context, Result};
+
+use super::super::storage::{RankedSemanticCandidate, SqliteStorage};
+use super::abstention::merge_hot_cache_results;
+use crate::memory_core::retrieval_strategy::{CandidateSet, FtsSearcher};
 use crate::memory_core::scoring::query_coverage_boost;
 use crate::memory_core::scoring_strategy::ScoringStrategy;
 use crate::memory_core::{
@@ -196,4 +200,54 @@ pub(crate) fn keyword_candidates_to_results(
             candidate.result
         })
         .collect()
+}
+
+/// `KeywordOnlyStrategy` dispatch path for `advanced_search`.
+///
+/// For keyword-intent queries (and empty / whitespace-only queries, which
+/// can't produce a meaningful embedding), this skips embedding, vector
+/// search, RRF fusion, reranker, and graph enrichment, using FTS5 BM25
+/// only. Runs `keyword_candidates_to_results` inside `spawn_blocking` and
+/// merges hot-cache hits when the cache had a confident text match.
+///
+/// Cache writes are intentionally left to the caller so both keyword and
+/// full-pipeline branches share a single cache-write tail.
+pub(crate) async fn run_keyword_only_search(
+    storage: &SqliteStorage,
+    query: &str,
+    limit: usize,
+    opts: &SearchOptions,
+    scoring_params: &ScoringParams,
+    hot_results: Vec<SemanticResult>,
+    hot_has_confident_match: bool,
+) -> Result<Vec<SemanticResult>> {
+    let include_superseded = opts.include_superseded.unwrap_or(false);
+    let explain_enabled = opts.explain.unwrap_or(false);
+    let candidates: CandidateSet = storage
+        .fts_search(query, limit, opts, include_superseded, scoring_params)
+        .await?;
+
+    let scoring_strategy = Arc::clone(&storage.scoring_strategy);
+    let query_owned = query.to_string();
+    let sp = scoring_params.clone();
+    let results = tokio::task::spawn_blocking(move || {
+        keyword_candidates_to_results(
+            candidates,
+            &query_owned,
+            limit,
+            &sp,
+            scoring_strategy.as_ref(),
+            explain_enabled,
+        )
+    })
+    .await
+    .context("spawn_blocking join error")?;
+
+    let results = if hot_has_confident_match {
+        merge_hot_cache_results(hot_results, results, limit)
+    } else {
+        results
+    };
+
+    Ok(results)
 }

--- a/src/memory_core/storage/sqlite/pipeline/scoring.rs
+++ b/src/memory_core/storage/sqlite/pipeline/scoring.rs
@@ -207,15 +207,15 @@ pub(crate) fn keyword_candidates_to_results(
 /// For keyword-intent queries (and empty / whitespace-only queries, which
 /// can't produce a meaningful embedding), this skips embedding, vector
 /// search, RRF fusion, reranker, and graph enrichment, using FTS5 BM25
-/// only. Merges hot-cache hits when the cache had a confident text match.
+/// only. Pass `Some(hot_results)` when the hot cache had a confident text
+/// match to merge them with the FTS results; pass `None` to skip the merge.
 pub(crate) async fn run_keyword_only_search(
     storage: &SqliteStorage,
     query: &str,
     limit: usize,
     opts: &SearchOptions,
     scoring_params: &ScoringParams,
-    hot_results: Vec<SemanticResult>,
-    hot_has_confident_match: bool,
+    hot_match: Option<Vec<SemanticResult>>,
 ) -> Result<Vec<SemanticResult>> {
     let include_superseded = opts.include_superseded.unwrap_or(false);
     let explain_enabled = opts.explain.unwrap_or(false);
@@ -239,11 +239,8 @@ pub(crate) async fn run_keyword_only_search(
     .await
     .context("spawn_blocking join error")?;
 
-    let results = if hot_has_confident_match {
-        merge_hot_cache_results(hot_results, results, limit)
-    } else {
-        results
-    };
-
-    Ok(results)
+    Ok(match hot_match {
+        Some(hot_results) => merge_hot_cache_results(hot_results, results, limit),
+        None => results,
+    })
 }


### PR DESCRIPTION
## Summary

Post-PR-4c (#317) follow-up. The PR-4c spec called for `advanced.rs` to land at ~350 lines after the `pipeline/` split but it stayed at 675 because the `impl AdvancedSearcher::advanced_search` body was still a 380-line orchestration.

This PR extracts three logical sections into pipeline helpers and converges the dual cache-write into one shared tail.

| File | Before | After |
|---|---|---|
| `src/memory_core/storage/sqlite/advanced.rs` | 675 | **492** (250 non-test, ~242 tests) |
| `src/memory_core/storage/sqlite/pipeline/retrieval.rs` | 335 | 421 |
| `src/memory_core/storage/sqlite/pipeline/decomp.rs` | 145 | 210 |
| `src/memory_core/storage/sqlite/pipeline/scoring.rs` | 199 | 249 |

Net: `advanced.rs` non-test residual is **250 lines**, well under the 500-line soft limit and within range of the spec's 350-line target.

## Changes

1. **`pipeline::collect_dual_candidates`** (commit `886d087`) — wraps the parallel/sequential vector+FTS retrieval block. Both `advanced_search` and `decomp.rs::run_single_query_pipeline` now call this single helper, eliminating one duplicated `try_join!`/sequential branch.

2. **`pipeline::enrich_with_decomposition`** (commit `f9524d9`) — wraps the multi-entity sub-query JoinSet fan-out (entity/topic extraction, parallel execution, indexed sort, score-max merge, fingerprint dedup, truncate). `run_single_query_pipeline` is now an internal helper of `decomp.rs`.

3. **`pipeline::run_keyword_only_search` + cache-write convergence** (commit `69518dc`) — hoists the FTS-only dispatch path. Both branches of the `if intent == Keyword || query.trim().is_empty()` ladder now produce a final results vec that flows into one shared cache-write tail. The duplicate cache-store block from the parent commit is gone.

4. **`refactor(search): drop redundant clones and stale comments`** (commit `23fd95c`) — addresses simplify-skill review findings: drop two unused `String` / `Vec<f32>` clones in the fuse closure (pure efficiency regression vs. parent — neither value was used after the closure), and delete six stale/duplicated comments that narrate WHAT or describe the refactor itself.

## Behavior

Pure structural/efficiency refactor — no behavior change. Verified by:

- 611 lib tests pass (one pre-existing CLI smoke-test failure on parent `84c6981` confirmed unrelated).
- `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings` clean.
- `./scripts/bench.sh --gate --notes "advanced.rs decomposition (post PR-4c residual)"` PASS.
- Adversarial parity review (8 focus areas: keyword cache-write, decomposition seen_ids ordering, callsite param parity, scoring_params clones, opts lifetime, empty-query routing, run_single_query_pipeline dedup, test coverage) — clean, no regressions.
- Code-reuse review — no missed reuse, no `Arc::clone` chain shortcuts.

## Out of scope

Filed as **#320** for a follow-up: adopt the existing `QueryContext` struct (PR-4a-i) across all five pipeline helpers (`collect_dual_candidates`, `run_single_query_pipeline`, `enrich_with_decomposition`, `run_keyword_only_search`, `fuse_and_score`) to remove four `#[allow(clippy::too_many_arguments)]` suppressions and replace `run_keyword_only_search`'s `&SqliteStorage` param with `&dyn FtsSearcher` + `&Arc<dyn ScoringStrategy>`. Deferred because it touches helpers with broader contracts than this PR's three new extractions.

## Test plan

- [x] `cargo build --all-features`
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all-features --lib` — 611 pass
- [x] `./scripts/bench.sh --gate` — no regression
- [x] Adversarial parity review (clean)
- [x] simplify skill (3 IMPORTANTs filed as #320; 1 efficiency-IMPORTANT + 5 comment-NITs fixed inline)
- [ ] CI green

https://claude.ai/code/session_01L1ddt9HaRiKwYhzunKkHNR

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1ddt9HaRiKwYhzunKkHNR)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization of search pipeline infrastructure to improve maintainability and performance.
  * Consolidated candidate collection and scoring logic for better resource efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->