### PR TITLE
refactor(search): adopt QueryContext in pipeline helpers (#320)

### DIFF
--- a/src/memory_core/retrieval_strategy.rs
+++ b/src/memory_core/retrieval_strategy.rs
@@ -18,27 +18,45 @@ pub type CandidateSet = Vec<(String, f64, RankedSemanticCandidate)>;
 
 /// Read-path context passed through the retrieval pipeline.
 ///
-/// Wraps the query string, limit, search options, scoring params, and
-/// pre-computed embedding needed by retrieval strategies.
+/// Bundles the per-query state threaded through `RetrievalStrategy` impls
+/// and the lower-level pipeline helpers (`fuse_and_score`,
+/// `run_single_query_pipeline`, `enrich_with_decomposition`,
+/// `collect_dual_candidates`, `run_keyword_only_search`). Centralising these
+/// fields avoids the long parameter lists that previously required
+/// `#[allow(clippy::too_many_arguments)]` on those helpers.
 ///
 /// Aligned with `trait-surface.md` §2.3.
 #[derive(Debug, Clone)]
-#[allow(dead_code)] // Consumed by RetrievalStrategy impls in v0.3.x pipeline composition
 pub struct QueryContext {
     /// Raw query string from the caller.
     pub query: String,
     /// Maximum number of results to return after the full pipeline.
     pub limit: usize,
+    /// Oversampled retrieval candidate limit (applies `top_k_mult` and the
+    /// dynamic limit multiplier). Equal to `limit` for single-strategy paths
+    /// that don't oversample.
+    pub candidate_limit: usize,
     /// Filter and feature options (event_type, project, session, explain, etc.).
     pub opts: SearchOptions,
     /// Scoring knobs. Consumers should clone from a shared `Arc<ScoringParams>`.
     pub scoring_params: ScoringParams,
-    /// Pre-computed query embedding. `None` until the embedding stage
-    /// populates it; strategies that do not need embeddings ignore it.
-    #[allow(dead_code)] // Consumed by vector strategy in v0.3.x pipeline composition
+    /// Pre-computed query embedding. `None` (or an empty vector) when the
+    /// strategy doesn't need embeddings (e.g. keyword-only path) or when
+    /// the embedding stage hasn't run yet.
     pub query_embedding: Option<Vec<f32>>,
     /// Whether superseded memories should be included in candidate sets.
     pub include_superseded: bool,
+    /// Whether per-candidate explain payloads should be populated.
+    pub explain_enabled: bool,
+}
+
+impl QueryContext {
+    /// View the query embedding as a slice, returning an empty slice when
+    /// no embedding is set. Convenience for helpers that take `&[f32]`.
+    #[must_use]
+    pub fn embedding_slice(&self) -> &[f32] {
+        self.query_embedding.as_deref().unwrap_or(&[])
+    }
 }
 
 // ── Trait ────────────────────────────────────────────────────────────────
@@ -253,10 +271,12 @@ mod tests {
         QueryContext {
             query: query.to_string(),
             limit: 10,
+            candidate_limit: 10,
             opts: SearchOptions::default(),
             scoring_params: ScoringParams::default(),
             query_embedding: None,
             include_superseded: false,
+            explain_enabled: false,
         }
     }
 
@@ -455,10 +475,12 @@ mod tests {
         let ctx = QueryContext {
             query: "my_func".to_string(),
             limit: 5,
+            candidate_limit: 5,
             opts: SearchOptions::default(),
             scoring_params: ScoringParams::default(),
             query_embedding: None,
             include_superseded: false,
+            explain_enabled: false,
         };
 
         let _ = strategy.collect(&ctx).await.unwrap();

--- a/src/memory_core/storage/sqlite/advanced.rs
+++ b/src/memory_core/storage/sqlite/advanced.rs
@@ -3,7 +3,7 @@ use super::query_classifier::{
     IntentProfile, QueryIntent, classify_query_intent, detect_dynamic_limit_mult,
 };
 use super::*;
-use crate::memory_core::retrieval_strategy::{CandidateSet, FtsSearcher};
+use crate::memory_core::retrieval_strategy::{CandidateSet, FtsSearcher, QueryContext};
 
 #[async_trait]
 impl FtsSearcher for SqliteStorage {
@@ -104,18 +104,34 @@ impl AdvancedSearcher for SqliteStorage {
         let cache_project_filter = opts.project.clone();
         let cache_session_id_filter = opts.session_id.clone();
 
-        let results = if intent == QueryIntent::Keyword || query.trim().is_empty() {
-            tracing::debug!(query = %query, strategy = "keyword-only", "dispatching retrieval strategy");
+        let include_superseded = opts.include_superseded.unwrap_or(false);
+        let explain_enabled = opts.explain.unwrap_or(false);
+
+        // Apply top_k_mult: scale candidate oversampling while keeping final limit intact.
+        let dynamic_mult = detect_dynamic_limit_mult(&query);
+        #[allow(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            clippy::cast_precision_loss
+        )]
+        let candidate_limit =
+            ((limit as f64 * intent_profile.top_k_mult * dynamic_mult).ceil() as usize).max(1);
+
+        let mut ctx = QueryContext {
+            query,
+            limit,
+            candidate_limit,
+            opts,
+            scoring_params,
+            query_embedding: None,
+            include_superseded,
+            explain_enabled,
+        };
+
+        let results = if intent == QueryIntent::Keyword || ctx.query.trim().is_empty() {
+            tracing::debug!(query = %ctx.query, strategy = "keyword-only", "dispatching retrieval strategy");
             let hot_match = hot_has_confident_match.then_some(hot_results);
-            pipeline::run_keyword_only_search(
-                self,
-                &query,
-                limit,
-                &opts,
-                &scoring_params,
-                hot_match,
-            )
-            .await?
+            pipeline::run_keyword_only_search(self, &self.scoring_strategy, &ctx, hot_match).await?
         } else {
             // Phase 0: Embedding computation (blocking).
             // Keyword queries have already been handled above via
@@ -123,7 +139,7 @@ impl AdvancedSearcher for SqliteStorage {
             // embedding.
             let query_embedding = tokio::task::spawn_blocking({
                 let embedder = Arc::clone(&embedder);
-                let query = query.clone();
+                let query = ctx.query.clone();
                 move || {
                     let emb = if query.is_empty() {
                         Vec::new()
@@ -138,31 +154,26 @@ impl AdvancedSearcher for SqliteStorage {
             .await
             .context("spawn_blocking join error")??;
 
-            let include_superseded = opts.include_superseded.unwrap_or(false);
-            let explain_enabled = opts.explain.unwrap_or(false);
+            ctx.query_embedding = Some(query_embedding);
 
-            // Apply top_k_mult: scale candidate oversampling while keeping final limit intact.
-            let dynamic_mult = detect_dynamic_limit_mult(&query);
-            #[allow(
-                clippy::cast_possible_truncation,
-                clippy::cast_sign_loss,
-                clippy::cast_precision_loss
-            )]
-            let candidate_limit =
-                ((limit as f64 * intent_profile.top_k_mult * dynamic_mult).ceil() as usize).max(1);
+            let (vector_candidates, fts_candidates) =
+                pipeline::collect_dual_candidates(&pool, &ctx).await?;
 
-            let (vector_candidates, fts_candidates) = pipeline::collect_dual_candidates(
-                &pool,
-                &query,
-                &query_embedding,
-                candidate_limit,
-                include_superseded,
-                &opts,
-                &scoring_params,
-            )
-            .await?;
-
-            let opts_for_decomp = opts.clone();
+            // Build the sub-query decomposition context now, before `ctx`
+            // is moved into the fusion `spawn_blocking`. Sub-queries inherit
+            // intent-adjusted scoring params and the candidate / final limits
+            // but recompute their own embeddings, so we explicitly omit the
+            // parent's embedding (would otherwise be a wasted Vec<f32> clone).
+            let decomp_ctx = QueryContext {
+                query: query_for_decomp,
+                limit: ctx.limit,
+                candidate_limit: ctx.candidate_limit,
+                opts: ctx.opts.clone(),
+                scoring_params: ctx.scoring_params.clone(),
+                query_embedding: None,
+                include_superseded: ctx.include_superseded,
+                explain_enabled: ctx.explain_enabled,
+            };
 
             // Phases 3-6: RRF fusion, score refinement, graph enrichment,
             // abstention + dedup. Needs one reader for graph queries.
@@ -170,16 +181,18 @@ impl AdvancedSearcher for SqliteStorage {
             let scoring_strategy = Arc::clone(&self.scoring_strategy);
             let results = tokio::task::spawn_blocking({
                 let pool = Arc::clone(&pool);
-                let sp = scoring_params.clone();
-                let opts = opts_for_decomp.clone();
+                // Move `ctx` into the closure to hand the embedding off
+                // without an extra clone; `decomp_ctx` already holds the
+                // copies it needs for the post-fuse decomposition step.
+                let ctx_for_fuse = ctx;
                 move || {
                     // Optional cross-encoder reranking (sync, safe inside spawn_blocking)
                     let ce_scores = pipeline::compute_cross_encoder_scores(
                         reranker.as_ref(),
-                        &query,
+                        &ctx_for_fuse.query,
                         &vector_candidates,
                         &fts_candidates,
-                        &sp,
+                        &ctx_for_fuse.scoring_params,
                     );
 
                     let conn = pool.reader()?;
@@ -190,13 +203,7 @@ impl AdvancedSearcher for SqliteStorage {
                         &conn,
                         vector_candidates,
                         fts_candidates,
-                        &query,
-                        &query_embedding,
-                        &opts,
-                        limit,
-                        include_superseded,
-                        explain_enabled,
-                        &sp,
+                        &ctx_for_fuse,
                         ce_scores.as_ref(),
                         scoring_strategy.as_ref(),
                     )
@@ -205,21 +212,12 @@ impl AdvancedSearcher for SqliteStorage {
             .await
             .context("spawn_blocking join error")??;
 
-            // ── Query decomposition: enrich results for multi-entity queries ──
-            // Use the intent-adjusted scoring params so sub-queries inherit
-            // the same RRF / word-overlap weights as the main query.
             let results = pipeline::enrich_with_decomposition(
                 &self.pool,
                 &self.embedder,
                 &self.scoring_strategy,
+                &decomp_ctx,
                 results,
-                &query_for_decomp,
-                candidate_limit,
-                limit,
-                &opts_for_decomp,
-                &scoring_params,
-                include_superseded,
-                explain_enabled,
             )
             .await?;
 

--- a/src/memory_core/storage/sqlite/pipeline/decomp.rs
+++ b/src/memory_core/storage/sqlite/pipeline/decomp.rs
@@ -14,47 +14,48 @@ use super::super::nlp::{
 use super::super::query_classifier::{QueryIntent, classify_query_intent};
 use super::fusion::fuse_and_score;
 use super::retrieval::{collect_dual_candidates, collect_fts_candidates};
+use crate::memory_core::SemanticResult;
 use crate::memory_core::embedder::Embedder;
+use crate::memory_core::retrieval_strategy::QueryContext;
 use crate::memory_core::scoring_strategy::ScoringStrategy;
-use crate::memory_core::{ScoringParams, SearchOptions, SemanticResult};
 
 /// Run the core search pipeline for a single query: embed -> vector+FTS -> fuse -> refine.
 ///
 /// Used by query decomposition to run each sub-query through the full pipeline.
-#[allow(clippy::too_many_arguments)]
+/// The embedding is recomputed for `ctx.query` inside this function; any
+/// embedding already on `ctx` is ignored.
 pub(crate) async fn run_single_query_pipeline(
     pool: &Arc<ConnPool>,
     embedder: &Arc<dyn Embedder>,
-    query: &str,
-    candidate_limit: usize,
-    limit: usize,
-    opts: &SearchOptions,
-    scoring_params: &ScoringParams,
-    include_superseded: bool,
-    explain_enabled: bool,
+    ctx: &QueryContext,
     scoring_strategy: &Arc<dyn ScoringStrategy>,
 ) -> Result<Vec<SemanticResult>> {
-    let intent = classify_query_intent(query);
+    let intent = classify_query_intent(&ctx.query);
     // Route empty / whitespace-only queries through FTS-only — vector search
     // with an empty embedding can't produce meaningful similarities, and
     // `build_fts5_query` already short-circuits empty input safely.
-    let fts_only = intent == QueryIntent::Keyword || query.trim().is_empty();
+    let fts_only = intent == QueryIntent::Keyword || ctx.query.trim().is_empty();
 
     let query_embedding = if fts_only {
         Vec::new()
     } else {
         let embedder = Arc::clone(embedder);
-        let q = query.to_string();
+        let q = ctx.query.clone();
         tokio::task::spawn_blocking(move || embedder.embed(&q))
             .await
             .context("spawn_blocking join error")??
     };
 
+    let mut local_ctx = ctx.clone();
+    local_ctx.query_embedding = Some(query_embedding);
+
     let (vector_candidates, fts_candidates) = if fts_only {
         let pool_arc = Arc::clone(pool);
-        let q = query.to_string();
-        let o = opts.clone();
-        let sp = scoring_params.clone();
+        let q = local_ctx.query.clone();
+        let o = local_ctx.opts.clone();
+        let sp = local_ctx.scoring_params.clone();
+        let candidate_limit = local_ctx.candidate_limit;
+        let include_superseded = local_ctx.include_superseded;
         let fts_result = tokio::task::spawn_blocking(move || {
             let conn = pool_arc.reader()?;
             collect_fts_candidates(&conn, &q, candidate_limit, &o, include_superseded, &sp)
@@ -63,25 +64,12 @@ pub(crate) async fn run_single_query_pipeline(
         .context("spawn_blocking join error")??;
         (Vec::new(), fts_result)
     } else {
-        collect_dual_candidates(
-            pool,
-            query,
-            &query_embedding,
-            candidate_limit,
-            include_superseded,
-            opts,
-            scoring_params,
-        )
-        .await?
+        collect_dual_candidates(pool, &local_ctx).await?
     };
 
     let ce_scores: Option<HashMap<String, f32>> = None;
 
     let pool_for_fuse = Arc::clone(pool);
-    let q = query.to_string();
-    let emb = query_embedding;
-    let o = opts.clone();
-    let sp = scoring_params.clone();
     let strat = Arc::clone(scoring_strategy);
     tokio::task::spawn_blocking(move || {
         let conn = pool_for_fuse.reader()?;
@@ -89,13 +77,7 @@ pub(crate) async fn run_single_query_pipeline(
             &conn,
             vector_candidates,
             fts_candidates,
-            &q,
-            &emb,
-            &o,
-            limit,
-            include_superseded,
-            explain_enabled,
-            &sp,
+            &local_ctx,
             ce_scores.as_ref(),
             strat.as_ref(),
         )
@@ -107,36 +89,33 @@ pub(crate) async fn run_single_query_pipeline(
 /// Enrich a base result set by running each detected sub-query through the
 /// single-query pipeline in parallel and merging the results.
 ///
+/// `ctx.query` is treated as the source query for decomposition (entity /
+/// topic extraction). Each sub-query is then executed by cloning `ctx`
+/// and overriding `query` with the sub-query string.
+///
 /// For multi-entity queries we extract entities/topics, generate sub-queries,
 /// then fan out the remaining sub-queries (skipping the first, which is the
 /// original query already represented by `base_results`). Sub-results are
 /// merged: new ids appended; on duplicate id, the higher score wins (first
 /// occurrence wins on ties for stable ordering across parallel completion);
 /// then the final list is fingerprint-deduped on content before truncating
-/// to `limit`.
+/// to `ctx.limit`.
 ///
 /// If decomposition does not apply (fewer than two entities, no topics, or
 /// only one sub-query) the base results are returned unchanged.
-#[allow(clippy::too_many_arguments)]
 pub(crate) async fn enrich_with_decomposition(
     pool: &Arc<ConnPool>,
     embedder: &Arc<dyn Embedder>,
     scoring_strategy: &Arc<dyn ScoringStrategy>,
+    ctx: &QueryContext,
     base_results: Vec<SemanticResult>,
-    query_for_decomp: &str,
-    candidate_limit: usize,
-    limit: usize,
-    opts: &SearchOptions,
-    scoring_params: &ScoringParams,
-    include_superseded: bool,
-    explain_enabled: bool,
 ) -> Result<Vec<SemanticResult>> {
-    let decomp_entities = extract_query_entities(query_for_decomp);
+    let decomp_entities = extract_query_entities(&ctx.query);
     if decomp_entities.len() < 2 {
         return Ok(base_results);
     }
-    let topics = extract_topic_keywords(query_for_decomp, &decomp_entities);
-    let sub_queries = generate_sub_queries(query_for_decomp, &decomp_entities, &topics);
+    let topics = extract_topic_keywords(&ctx.query, &decomp_entities);
+    let sub_queries = generate_sub_queries(&ctx.query, &decomp_entities, &topics);
     if topics.is_empty() || sub_queries.len() <= 1 {
         return Ok(base_results);
     }
@@ -157,24 +136,15 @@ pub(crate) async fn enrich_with_decomposition(
     for (idx, sub_query) in sub_queries.iter().skip(1).enumerate() {
         let pool = Arc::clone(pool);
         let embedder = Arc::clone(embedder);
-        let sq = sub_query.clone();
-        let opts = opts.clone();
-        let sp = scoring_params.clone();
         let strat = Arc::clone(scoring_strategy);
+        let mut sub_ctx = ctx.clone();
+        sub_ctx.query = sub_query.clone();
+        // Embedding is recomputed inside `run_single_query_pipeline` for
+        // the sub-query; clear the parent embedding to avoid carrying
+        // stale state across the spawn boundary.
+        sub_ctx.query_embedding = None;
         join_set.spawn(async move {
-            let res = run_single_query_pipeline(
-                &pool,
-                &embedder,
-                &sq,
-                candidate_limit,
-                limit,
-                &opts,
-                &sp,
-                include_superseded,
-                explain_enabled,
-                &strat,
-            )
-            .await;
+            let res = run_single_query_pipeline(&pool, &embedder, &sub_ctx, &strat).await;
             (idx, res)
         });
     }
@@ -207,6 +177,6 @@ pub(crate) async fn enrich_with_decomposition(
             deduped.push(result);
         }
     }
-    deduped.truncate(limit);
+    deduped.truncate(ctx.limit);
     Ok(deduped)
 }

--- a/src/memory_core/storage/sqlite/pipeline/fusion.rs
+++ b/src/memory_core/storage/sqlite/pipeline/fusion.rs
@@ -21,11 +21,9 @@ use super::super::storage::RankedSemanticCandidate;
 use super::abstention::abstain_and_dedup;
 use super::enrichment::{enrich_graph_neighbors, expand_entity_tags};
 use super::scoring::refine_scores;
+use crate::memory_core::retrieval_strategy::QueryContext;
 use crate::memory_core::scoring_strategy::ScoringStrategy;
-use crate::memory_core::{
-    EventType, ScoringParams, SearchOptions, SemanticResult, priority_factor, token_set,
-    type_weight_et,
-};
+use crate::memory_core::{EventType, SemanticResult, priority_factor, token_set, type_weight_et};
 
 /// Phases 3-6: RRF fusion, score refinement, graph enrichment, abstention.
 ///
@@ -33,21 +31,17 @@ use crate::memory_core::{
 /// internally invokes [`enrich_graph_neighbors`], [`expand_entity_tags`],
 /// [`refine_scores`], and finally [`abstain_and_dedup`] for the Phase 6
 /// dedup/abstention/output stage.
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn fuse_and_score(
     conn: &Connection,
     vector_candidates: Vec<(String, f64, RankedSemanticCandidate)>,
     fts_candidates: Vec<(String, f64, RankedSemanticCandidate)>,
-    query: &str,
-    query_embedding: &[f32],
-    opts: &SearchOptions,
-    limit: usize,
-    include_superseded: bool,
-    explain_enabled: bool,
-    scoring_params: &ScoringParams,
+    ctx: &QueryContext,
     cross_encoder_scores: Option<&HashMap<String, f32>>,
     scoring_strategy: &dyn ScoringStrategy,
 ) -> Result<Vec<SemanticResult>> {
+    let scoring_params = &ctx.scoring_params;
+    let opts = &ctx.opts;
+    let explain_enabled = ctx.explain_enabled;
     // Phase 3: Weighted RRF fusion -- vector similarity weighted higher
     // for semantic discrimination (Oracle recommendation)
     let mut ranked: HashMap<String, RankedSemanticCandidate> = HashMap::new();
@@ -166,7 +160,7 @@ pub(crate) fn fuse_and_score(
         }
     }
 
-    let query_tokens = token_set(query, 3);
+    let query_tokens = token_set(&ctx.query, 3);
     refine_scores(
         &mut ranked,
         &query_tokens,
@@ -180,9 +174,9 @@ pub(crate) fn fuse_and_score(
         conn,
         &mut ranked,
         &query_tokens,
-        query_embedding,
-        limit,
-        include_superseded,
+        ctx.embedding_slice(),
+        ctx.limit,
+        ctx.include_superseded,
         explain_enabled,
         scoring_params,
     );
@@ -192,8 +186,8 @@ pub(crate) fn fuse_and_score(
         conn,
         &mut ranked,
         &query_tokens,
-        limit,
-        include_superseded,
+        ctx.limit,
+        ctx.include_superseded,
         explain_enabled,
         scoring_params,
         opts,
@@ -204,10 +198,10 @@ pub(crate) fn fuse_and_score(
         ranked,
         &query_tokens,
         opts,
-        limit,
+        ctx.limit,
         explain_enabled,
         scoring_params,
         scoring_strategy,
-        query,
+        &ctx.query,
     )
 }

--- a/src/memory_core/storage/sqlite/pipeline/retrieval.rs
+++ b/src/memory_core/storage/sqlite/pipeline/retrieval.rs
@@ -18,7 +18,7 @@ use super::super::helpers::{
 use super::super::helpers::{hydrate_memories_by_ids, vec_distance_to_similarity, vec_knn_search};
 use super::super::storage::RankedSemanticCandidate;
 use super::advanced_fts_candidate_limit;
-use crate::memory_core::retrieval_strategy::CandidateSet;
+use crate::memory_core::retrieval_strategy::{CandidateSet, QueryContext};
 use crate::memory_core::{
     EventType, ScoringParams, SearchOptions, SemanticResult, priority_factor, type_weight_et,
 };
@@ -347,20 +347,18 @@ pub(crate) fn collect_fts_candidates(
 /// `spawn_blocking` to keep the SQLite connection on a single thread.
 pub(crate) async fn collect_dual_candidates(
     pool: &Arc<ConnPool>,
-    query: &str,
-    query_embedding: &[f32],
-    candidate_limit: usize,
-    include_superseded: bool,
-    opts: &SearchOptions,
-    scoring_params: &ScoringParams,
+    ctx: &QueryContext,
 ) -> Result<(CandidateSet, CandidateSet)> {
+    let candidate_limit = ctx.candidate_limit;
+    let include_superseded = ctx.include_superseded;
+
     if pool.has_readers() {
         let (vec_result, fts_result) = tokio::try_join!(
             tokio::task::spawn_blocking({
                 let pool = Arc::clone(pool);
-                let emb = query_embedding.to_vec();
-                let o = opts.clone();
-                let sp = scoring_params.clone();
+                let emb = ctx.embedding_slice().to_vec();
+                let o = ctx.opts.clone();
+                let sp = ctx.scoring_params.clone();
                 move || {
                     let conn = pool.reader()?;
                     collect_vector_candidates(
@@ -375,9 +373,9 @@ pub(crate) async fn collect_dual_candidates(
             }),
             tokio::task::spawn_blocking({
                 let pool = Arc::clone(pool);
-                let q = query.to_string();
-                let o = opts.clone();
-                let sp = scoring_params.clone();
+                let q = ctx.query.clone();
+                let o = ctx.opts.clone();
+                let sp = ctx.scoring_params.clone();
                 move || {
                     let conn = pool.reader()?;
                     collect_fts_candidates(&conn, &q, candidate_limit, &o, include_superseded, &sp)
@@ -390,10 +388,10 @@ pub(crate) async fn collect_dual_candidates(
         // Sequential: single connection (in-memory / test mode).
         tokio::task::spawn_blocking({
             let pool = Arc::clone(pool);
-            let emb = query_embedding.to_vec();
-            let q = query.to_string();
-            let o = opts.clone();
-            let sp = scoring_params.clone();
+            let emb = ctx.embedding_slice().to_vec();
+            let q = ctx.query.clone();
+            let o = ctx.opts.clone();
+            let sp = ctx.scoring_params.clone();
             move || {
                 let conn = pool.reader()?;
                 let vec_c = collect_vector_candidates(

--- a/src/memory_core/storage/sqlite/pipeline/scoring.rs
+++ b/src/memory_core/storage/sqlite/pipeline/scoring.rs
@@ -9,9 +9,9 @@ use std::sync::Arc;
 
 use anyhow::{Context, Result};
 
-use super::super::storage::{RankedSemanticCandidate, SqliteStorage};
+use super::super::storage::RankedSemanticCandidate;
 use super::abstention::merge_hot_cache_results;
-use crate::memory_core::retrieval_strategy::{CandidateSet, FtsSearcher};
+use crate::memory_core::retrieval_strategy::{CandidateSet, FtsSearcher, QueryContext};
 use crate::memory_core::scoring::query_coverage_boost;
 use crate::memory_core::scoring_strategy::ScoringStrategy;
 use crate::memory_core::{
@@ -210,22 +210,26 @@ pub(crate) fn keyword_candidates_to_results(
 /// only. Pass `Some(hot_results)` when the hot cache had a confident text
 /// match to merge them with the FTS results; pass `None` to skip the merge.
 pub(crate) async fn run_keyword_only_search(
-    storage: &SqliteStorage,
-    query: &str,
-    limit: usize,
-    opts: &SearchOptions,
-    scoring_params: &ScoringParams,
+    fts_searcher: &dyn FtsSearcher,
+    scoring_strategy: &Arc<dyn ScoringStrategy>,
+    ctx: &QueryContext,
     hot_match: Option<Vec<SemanticResult>>,
 ) -> Result<Vec<SemanticResult>> {
-    let include_superseded = opts.include_superseded.unwrap_or(false);
-    let explain_enabled = opts.explain.unwrap_or(false);
-    let candidates: CandidateSet = storage
-        .fts_search(query, limit, opts, include_superseded, scoring_params)
+    let candidates: CandidateSet = fts_searcher
+        .fts_search(
+            &ctx.query,
+            ctx.limit,
+            &ctx.opts,
+            ctx.include_superseded,
+            &ctx.scoring_params,
+        )
         .await?;
 
-    let scoring_strategy = Arc::clone(&storage.scoring_strategy);
-    let query_owned = query.to_string();
-    let sp = scoring_params.clone();
+    let scoring_strategy = Arc::clone(scoring_strategy);
+    let query_owned = ctx.query.clone();
+    let sp = ctx.scoring_params.clone();
+    let limit = ctx.limit;
+    let explain_enabled = ctx.explain_enabled;
     let results = tokio::task::spawn_blocking(move || {
         keyword_candidates_to_results(
             candidates,


### PR DESCRIPTION
## Summary

- Threads `&QueryContext` through five SQLite pipeline helpers (`collect_dual_candidates`, `run_single_query_pipeline`, `enrich_with_decomposition`, `fuse_and_score`, `run_keyword_only_search`), removing three `#[allow(clippy::too_many_arguments)]` suppressions.
- Decouples `pipeline/scoring.rs::run_keyword_only_search` from the concrete `SqliteStorage` type — now takes `&dyn FtsSearcher` + `&Arc<dyn ScoringStrategy>`, making it unit-testable without a SQLite pool.
- Extends `QueryContext` with `explain_enabled` and `candidate_limit` fields plus a small `embedding_slice()` accessor; drops dead-code annotations now that the type is actively consumed.

## Implementation notes

- `advanced_search` builds the context once and threads it through both the keyword-only and the dual-retrieval paths. `query`, `opts`, and `scoring_params` are *moved* into the context (no longer cloned).
- The embedding `Vec<f32>` is moved (not cloned) into the fusion `spawn_blocking` by constructing `decomp_ctx` first and then handing `ctx` over to the closure — so total `Vec<f32>` allocations stay at 1 per query (parity with the prior implementation).
- `run_single_query_pipeline` and `enrich_with_decomposition` take a single `&QueryContext`; for sub-queries the parent ctx is cloned and `query` / `query_embedding` overridden per-sub-query inside `enrich_with_decomposition`.

## Acceptance (per #320)

- [x] All four pre-existing `#[allow(clippy::too_many_arguments)]` annotations on in-scope helpers removed (only three actually existed; `collect_dual_candidates` was at the threshold but never had the annotation).
- [x] `run_keyword_only_search` no longer imports `SqliteStorage`.
- [x] Helpers consume `&QueryContext`.
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.

## Test plan

- [x] `cargo test --all-features --lib` — 611/611 pass.
- [x] `cargo test --all-features` (integration) — 504/504 pass; `cli_output_smoke::cli_commands_emit_json_payloads` is a pre-existing network-dependent flake (HuggingFace download failure in sandbox; same failure on parent commit `286f4d1`).
- [ ] `./scripts/bench.sh --gate` — not runnable in this environment (also needs network for ONNX model download). Refactor is signature-only so behaviour should be identical, but the bench gate should still run on CI / locally before merge.
- [x] Round-1 review: parallel adversarial-parity + simplify reviews; addressed two `IMPORTANT` clone-efficiency findings before commit (`decomp_ctx` and `ctx_for_fuse` no longer clone the `Vec<f32>` embedding).

Closes #320.

https://claude.ai/code/session_01A5yjvQwnaxfZKEv1yTdopD

---
_Generated by [Claude Code](https://claude.ai/code/session_01A5yjvQwnaxfZKEv1yTdopD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored internal query processing to centralize query state management, improving code organization and maintainability across the retrieval pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->