### PR TITLE
🧪 Add tests for unconfigured tools logic

### DIFF
--- a/src/tool_detection.rs
+++ b/src/tool_detection.rs
@@ -1392,4 +1392,48 @@ mod tests {
     fn opencode_uses_json_format() {
         assert_eq!(AiTool::OpenCode.config_format(), ConfigFormat::Json);
     }
+
+    #[test]
+    fn unconfigured_filters_all_status_variants() {
+        let result = DetectionResult {
+            detected: vec![
+                DetectedTool {
+                    tool: AiTool::ClaudeCode,
+                    config_path: PathBuf::from("/test/1"),
+                    scope: ConfigScope::Global,
+                    mag_status: MagConfigStatus::Configured,
+                },
+                DetectedTool {
+                    tool: AiTool::Cursor,
+                    config_path: PathBuf::from("/test/2"),
+                    scope: ConfigScope::Global,
+                    mag_status: MagConfigStatus::NotConfigured,
+                },
+                DetectedTool {
+                    tool: AiTool::Windsurf,
+                    config_path: PathBuf::from("/test/3"),
+                    scope: ConfigScope::Global,
+                    mag_status: MagConfigStatus::Misconfigured("missing field".to_string()),
+                },
+                DetectedTool {
+                    tool: AiTool::Zed,
+                    config_path: PathBuf::from("/test/4"),
+                    scope: ConfigScope::Global,
+                    mag_status: MagConfigStatus::Unreadable("permission denied".to_string()),
+                },
+                DetectedTool {
+                    tool: AiTool::ClaudeDesktop,
+                    config_path: PathBuf::from("/test/5"),
+                    scope: ConfigScope::Global,
+                    mag_status: MagConfigStatus::InstalledAsPlugin,
+                },
+            ],
+            not_found: vec![],
+        };
+
+        let unconfigured = result.unconfigured();
+        assert_eq!(unconfigured.len(), 1);
+        assert_eq!(unconfigured[0].tool, AiTool::Cursor);
+        assert_eq!(unconfigured[0].mag_status, MagConfigStatus::NotConfigured);
+    }
 }


### PR DESCRIPTION
This PR adds a comprehensive unit test for the `unconfigured` method in the tool detection module.

🎯 **What:** Addressed the testing gap for the state-based filtering logic in `DetectionResult::unconfigured`.
📊 **Coverage:** The new test case `unconfigured_filters_all_status_variants` ensures that all possible `MagConfigStatus` variants are correctly handled, asserting that only tools with the `NotConfigured` status are returned.
✨ **Result:** Improved test coverage and reliability for the AI tool detection and setup flow.

---
*PR created automatically by Jules for task [17092053547064141390](https://jules.google.com/task/17092053547064141390) started by @George-RD*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a unit test for `DetectionResult::unconfigured()` to ensure it correctly filters all `MagConfigStatus` variants and returns only `NotConfigured` tools. Improves test coverage and reliability of the tool detection setup flow.

<sup>Written for commit ffff28a9c5ba61b8ae5ff72b3cb260ac6218c939. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for tool detection filtering to verify correct behavior across multiple configuration status scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->