### PR TITLE
🔒 harden local transport security and documentation

### DIFF
--- a/benches/locomo/main.rs
+++ b/benches/locomo/main.rs
@@ -57,7 +57,7 @@ use bench_utils::metrics::PeakRss;
 
 const DEFAULT_LLM_MODEL: &str = "gpt-5.4";
 const DEFAULT_LOCAL_MODEL: &str = "qwen3.5-9b-optiq";
-const DEFAULT_LOCAL_URL: &str = "http://localhost:1234/v1/chat/completions";
+const DEFAULT_LOCAL_URL: &str = "http://127.0.0.1:1234/v1/chat/completions";
 
 #[derive(Debug, Parser)]
 #[command(name = "locomo_bench")]

--- a/src/config_writer.rs
+++ b/src/config_writer.rs
@@ -14,6 +14,9 @@ use crate::tool_detection::{AiTool, ConfigFormat, DetectedTool};
 // ---------------------------------------------------------------------------
 
 /// Which transport to configure for the MCP connection.
+///
+/// HTTP transport uses the loopback address (127.0.0.1) for secure local-only
+/// communication, avoiding external network exposure.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TransportMode {
     /// HTTP transport: `{ "type": "http", "url": "http://127.0.0.1:{port}/mcp" }`
@@ -296,6 +299,12 @@ pub fn build_mag_entry(tool: AiTool, mode: TransportMode) -> serde_json::Value {
 
     match mode {
         TransportMode::Http { port } => {
+            // Security Rationale:
+            // We use unencrypted HTTP for loopback (127.0.0.1) communication.
+            // This is the standard for local MCP servers and avoids the
+            // certificate management overhead of local TLS. Security is
+            // maintained by strictly binding to the loopback interface,
+            // which prevents any external network access to the server.
             serde_json::json!({
                 "type": "http",
                 "url": format!("http://127.0.0.1:{port}/mcp")


### PR DESCRIPTION
🎯 **What:** Hardened local loopback binding in configuration and benchmarking, and added security rationale documentation.
⚠️ **Risk:** Potential for external network interception if the server were to bind to non-loopback interfaces or if local DNS (`localhost`) were hijacked.
🛡️ **Solution:** Explicitly documented the security rationale for using unencrypted HTTP on the loopback address (`127.0.0.1`) for local MCP communication, avoiding local TLS overhead while maintaining isolation. Updated benchmark code to use `127.0.0.1` instead of `localhost` for consistent loopback enforcement.

---
*PR created automatically by Jules for task [15555843503027724490](https://jules.google.com/task/15555843503027724490) started by @George-RD*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened local MCP transport by binding HTTP endpoints to 127.0.0.1 and documenting why unencrypted loopback is safe. Updated the LoCoMo benchmark default URL from localhost to 127.0.0.1 to prevent DNS hijack risks and enforce local-only access.

<sup>Written for commit 8b9b8f11d7ac0e52902d444e0a4e6f1eb1b4340c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added security rationale comments for local MCP communication configuration.

* **Chores**
  * Updated local LLM server URL constant configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->