### PR TITLE
🔒 [security] Enforce strict file permissions on config files

### DIFF
--- a/src/config_writer.rs
+++ b/src/config_writer.rs
@@ -554,8 +554,26 @@ fn atomic_write(path: &Path, content: &[u8]) -> Result<()> {
         .unwrap_or_else(|| Path::new("."))
         .join(&tmp_name);
 
-    std::fs::write(&tmp_path, content)
-        .with_context(|| format!("writing temp file {}", tmp_path.display()))?;
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(0o600)
+            .open(&tmp_path)
+            .with_context(|| format!("creating temp file {}", tmp_path.display()))?;
+        f.write_all(content)
+            .with_context(|| format!("writing temp file {}", tmp_path.display()))?;
+        f.sync_all()
+            .with_context(|| format!("syncing temp file {}", tmp_path.display()))?;
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(&tmp_path, content)
+            .with_context(|| format!("writing temp file {}", tmp_path.display()))?;
+    }
 
     match std::fs::rename(&tmp_path, path) {
         Ok(()) => Ok(()),

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -468,6 +468,17 @@ fn atomic_write(path: &Path, content: &str) -> Result<()> {
     }
     let tmp = path.with_extension(format!("mag-tmp.{}", std::process::id()));
     let result = (|| -> Result<()> {
+        #[cfg(unix)]
+        let mut f = {
+            use std::os::unix::fs::OpenOptionsExt;
+            std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .mode(0o600)
+                .open(&tmp)
+                .with_context(|| format!("creating temp file {}", tmp.display()))?
+        };
+        #[cfg(not(unix))]
         let mut f = std::fs::File::create(&tmp)
             .with_context(|| format!("creating temp file {}", tmp.display()))?;
         f.write_all(content.as_bytes())


### PR DESCRIPTION
🎯 **What:** Modified temp file creation in `src/setup.rs` and `src/config_writer.rs` to enforce `0o600` file permissions on Unix environments, restricting access to the file owner exclusively.

⚠️ **Risk:** The previous implementation utilized `std::fs::File::create` without specifying explicit permissions. This relied on the system's `umask`, potentially leading to sensitive data—such as configuration tokens, credentials, or context—being written to disk with overly permissive read rights (`0o644` typically), making it readable by any other user on the same system.

🛡️ **Solution:** Switched the file creation mechanisms in `atomic_write` methods to use `std::fs::OpenOptions` paired with `std::os::unix::fs::OpenOptionsExt::mode(0o600)` on Unix architectures. This guarantees that newly created files (which will subsequently be swapped out atomically via a file rename) are immediately inaccessible to other system users upon creation, mitigating the risk of unauthorized read access. Retained the original default fallback for non-Unix systems.

---
*PR created automatically by Jules for task [17961958751014488581](https://jules.google.com/task/17961958751014488581) started by @George-RD*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforce `0o600` permissions for temp config files on Unix and sync writes before rename to keep sensitive data private and durable. Use `OpenOptions.mode(0o600)` in `atomic_write` for `src/config_writer.rs` and `src/setup.rs` with `write_all` + `sync_all` on Unix, keeping the existing default for non-Unix systems.

<sup>Written for commit 59ea7a270e6de40877bfc6da2d4fe2e4f385bf80. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved atomic file write operations with platform-specific optimizations. Configuration files are now written more safely and reliably across all supported systems, with enhanced data integrity protection to prevent potential corruption during the write process. This ensures consistent and stable system behavior when managing critical configuration data across different operating system environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->