### PR TITLE
🔒 Fix Command Injection via Unsanitized Input in Shell Command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1273,6 +1273,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "which",
 ]
 
 [[package]]
@@ -3032,6 +3033,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "8.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81995fafaaaf6ae47a7d0cc83c67caf92aeb7e5331650ae6ff856f7c0c60c459"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ regex = "1"
 lru = "0.12"
 mimalloc = { version = "0.1", optional = true }
 sqlite-vec = { version = "0.1.6", optional = true }
+which = "8.0.2"
 
 [lints.rust]
 unused_must_use = "deny"

--- a/src/config_writer.rs
+++ b/src/config_writer.rs
@@ -450,30 +450,11 @@ pub fn verify_claude_plugin() -> Result<bool> {
 
 /// Locates the `claude` CLI binary on the system PATH.
 ///
-/// Uses `command -v claude` on Unix (or `where claude` on Windows) to resolve
-/// the binary path without requiring an external crate.
+/// Uses the `which` crate to resolve
+/// the binary path safely without spawning shells.
 fn find_claude_cli() -> Result<PathBuf> {
-    let output = if cfg!(target_os = "windows") {
-        std::process::Command::new("where").arg("claude").output()
-    } else {
-        std::process::Command::new("sh")
-            .args(["-c", "command -v claude"])
-            .output()
-    };
-
-    match output {
-        Ok(o) if o.status.success() => {
-            let path_str = String::from_utf8_lossy(&o.stdout);
-            let path = path_str.trim();
-            if path.is_empty() {
-                anyhow::bail!("claude CLI not found on PATH — install Claude Code first");
-            }
-            Ok(PathBuf::from(path))
-        }
-        _ => {
-            anyhow::bail!("claude CLI not found on PATH — install Claude Code first");
-        }
-    }
+    which::which("claude")
+        .map_err(|_| anyhow::anyhow!("claude CLI not found on PATH — install Claude Code first"))
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a potential command injection issue where `find_claude_cli` spawned a shell via `sh -c` to find the `claude` binary.
⚠️ **Risk:** Spawning a shell exposes the process to environment variable manipulation (like `BASH_ENV`) or shell alias injection, which could lead to arbitrary command execution.
🛡️ **Solution:** Replaced the external shell command execution with the `which` crate, which safely and deterministically locates the executable without spawning a shell, eliminating the command injection vector.

---
*PR created automatically by Jules for task [18107834611887354909](https://jules.google.com/task/18107834611887354909) started by @George-RD*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix command injection risk in `find_claude_cli` by replacing shell-based lookup with the `which` crate. This prevents shell attacks (e.g., `BASH_ENV` or alias injection) and makes locating the `claude` binary deterministic.

- **Dependencies**
  - Added `which` `8.0.2`.

<sup>Written for commit 6ad334981eeddb59734bb7620cd0914831f6990d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

