### PR TITLE
🧪 [test: add explicit schema test for tool_registry_json]

### DIFF
--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -686,6 +686,25 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_tool_registry_json_schema() {
+        let json = tool_registry_json();
+        assert!(json.is_object(), "Result should be a JSON object");
+
+        let obj = json.as_object().unwrap();
+        assert!(obj.contains_key("tools"), "Must contain 'tools' key");
+        assert!(
+            obj.contains_key("tool_count"),
+            "Must contain 'tool_count' key"
+        );
+
+        assert!(json["tools"].is_array(), "'tools' should be an array");
+        assert!(
+            json["tool_count"].is_number(),
+            "'tool_count' should be a number"
+        );
+    }
+
     /// `MINIMAL_TOOL_NAMES` must be a strict subset of the names in the tool router.
     #[test]
     fn minimal_tool_names_are_valid_router_entries() {


### PR DESCRIPTION
🎯 **What:** Added an explicit test `test_tool_registry_json_schema` for `tool_registry_json` in `src/mcp/mod.rs` to explicitly check the structure/schema of the JSON output, instead of just iterating over registry elements.
📊 **Coverage:** The schema structure of the `tool_registry_json` return value is now tested to ensure the required `tools` and `tool_count` keys exist and are strictly the correct types (Array and Number, respectively).
✨ **Result:** Improved test reliability by formally pinning the expected API output schema.

---
*PR created automatically by Jules for task [12790552315221142858](https://jules.google.com/task/12790552315221142858) started by @George-RD*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an explicit schema test for `tool_registry_json` to verify its JSON shape. The test asserts the result is an object with `tools` (array) and `tool_count` (number).

<sup>Written for commit fea80d9e37dbb28a4a794bc7ac97a16c9bd6ccfa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for JSON schema validation in the tool registry functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->