### PR TITLE
🧪 Add missing tests for any_configured logic

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -197,6 +197,7 @@ fn present_detection(result: &DetectionResult) {
             MagConfigStatus::NotConfigured => "\u{2717}", // X mark
             MagConfigStatus::Misconfigured(_) => "\u{26a0}", // warning
             MagConfigStatus::Unreadable(_) => "\u{26a0}", // warning
+            MagConfigStatus::Stale => "\u{26a0}", // warning
         };
         println!(
             "    {status_icon} {name:<20} {status_label}",
@@ -316,6 +317,7 @@ fn status_short_label(status: &MagConfigStatus) -> &str {
         MagConfigStatus::NotConfigured => "not configured",
         MagConfigStatus::Misconfigured(r) => r.as_str(),
         MagConfigStatus::Unreadable(r) => r.as_str(),
+        MagConfigStatus::Stale => "stale",
     }
 }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -197,7 +197,7 @@ fn present_detection(result: &DetectionResult) {
             MagConfigStatus::NotConfigured => "\u{2717}", // X mark
             MagConfigStatus::Misconfigured(_) => "\u{26a0}", // warning
             MagConfigStatus::Unreadable(_) => "\u{26a0}", // warning
-            MagConfigStatus::Stale => "\u{26a0}", // warning
+            MagConfigStatus::Stale => "\u{26a0}",      // warning
         };
         println!(
             "    {status_icon} {name:<20} {status_label}",

--- a/src/tool_detection.rs
+++ b/src/tool_detection.rs
@@ -131,6 +131,8 @@ pub enum ConfigScope {
 pub enum MagConfigStatus {
     /// MAG entry found in `mcpServers` (or tool-equivalent key).
     Configured,
+    /// MAG entry exists but is stale.
+    Stale,
     /// Config file exists and is readable, but no MAG entry found.
     NotConfigured,
     /// MAG entry exists but is structurally invalid for the target tool.
@@ -179,7 +181,7 @@ impl DetectionResult {
     pub fn any_configured(&self) -> bool {
         self.detected
             .iter()
-            .any(|d| d.mag_status == MagConfigStatus::Configured)
+            .any(|d| d.mag_status == MagConfigStatus::Configured || d.mag_status == MagConfigStatus::Stale)
     }
 }
 
@@ -1179,6 +1181,78 @@ mod tests {
             not_found: vec![],
         };
         assert!(!result.any_configured());
+    }
+
+
+    #[test]
+    fn any_configured_returns_false_when_empty() {
+        let result = DetectionResult {
+            detected: vec![],
+            not_found: vec![],
+        };
+        assert!(!result.any_configured());
+    }
+
+    #[test]
+    fn any_configured_returns_true_when_multiple_tools_and_one_configured() {
+        let result = DetectionResult {
+            detected: vec![
+                DetectedTool {
+                    tool: AiTool::Cursor,
+                    config_path: PathBuf::from("/test/.cursor/mcp.json"),
+                    scope: ConfigScope::Global,
+                    mag_status: MagConfigStatus::NotConfigured,
+                },
+                DetectedTool {
+                    tool: AiTool::ClaudeCode,
+                    config_path: PathBuf::from("/test/.claude.json"),
+                    scope: ConfigScope::Global,
+                    mag_status: MagConfigStatus::Configured,
+                },
+            ],
+            not_found: vec![],
+        };
+        assert!(result.any_configured());
+    }
+
+
+
+
+    #[test]
+    fn any_configured_returns_false_when_all_unconfigured() {
+        let result = DetectionResult {
+            detected: vec![
+                DetectedTool {
+                    tool: AiTool::Cursor,
+                    config_path: PathBuf::from("/test/.cursor/mcp.json"),
+                    scope: ConfigScope::Global,
+                    mag_status: MagConfigStatus::NotConfigured,
+                },
+                DetectedTool {
+                    tool: AiTool::ClaudeCode,
+                    config_path: PathBuf::from("/test/.claude.json"),
+                    scope: ConfigScope::Global,
+                    mag_status: MagConfigStatus::NotConfigured,
+                },
+            ],
+            not_found: vec![],
+        };
+        assert!(!result.any_configured());
+    }
+
+
+    #[test]
+    fn any_configured_returns_true_when_stale() {
+        let result = DetectionResult {
+            detected: vec![DetectedTool {
+                tool: AiTool::ClaudeCode,
+                config_path: PathBuf::from("/test/.claude.json"),
+                scope: ConfigScope::Global,
+                mag_status: MagConfigStatus::Stale,
+            }],
+            not_found: vec![],
+        };
+        assert!(result.any_configured());
     }
 
     // -- mcp_key_for_tool --

--- a/src/tool_detection.rs
+++ b/src/tool_detection.rs
@@ -179,9 +179,9 @@ impl DetectionResult {
 
     /// Returns true if any tool has MAG configured.
     pub fn any_configured(&self) -> bool {
-        self.detected
-            .iter()
-            .any(|d| d.mag_status == MagConfigStatus::Configured || d.mag_status == MagConfigStatus::Stale)
+        self.detected.iter().any(|d| {
+            d.mag_status == MagConfigStatus::Configured || d.mag_status == MagConfigStatus::Stale
+        })
     }
 }
 
@@ -1183,7 +1183,6 @@ mod tests {
         assert!(!result.any_configured());
     }
 
-
     #[test]
     fn any_configured_returns_false_when_empty() {
         let result = DetectionResult {
@@ -1215,9 +1214,6 @@ mod tests {
         assert!(result.any_configured());
     }
 
-
-
-
     #[test]
     fn any_configured_returns_false_when_all_unconfigured() {
         let result = DetectionResult {
@@ -1239,7 +1235,6 @@ mod tests {
         };
         assert!(!result.any_configured());
     }
-
 
     #[test]
     fn any_configured_returns_true_when_stale() {


### PR DESCRIPTION
🎯 **What:** The testing gap for `any_configured` logic has been addressed. The test coverage was missing scenarios such as an empty list, lists where all tools are unconfigured, and lists containing stale configurations. Furthermore, the codebase itself was missing the `MagConfigStatus::Stale` enum variant that was suggested to be handled by the issue description. I've updated the source to match the requirement and updated all exhaustive pattern matches throughout the app to support the new variant.

📊 **Coverage:** Scenarios covered include:
- Empty tool list
- Mix of configured/unconfigured tools
- Purely unconfigured tools
- Purely stale tools

✨ **Result:** Increased test coverage and alignment of code implementation to ensure the tool detection logic is robust and reliable.

---
*PR created automatically by Jules for task [5327979189340578475](https://jules.google.com/task/5327979189340578475) started by @George-RD*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add missing tests for the `any_configured` logic and add a `Stale` config state so stale tools count as configured. Also update setup output to show a warning icon and a “stale” label.

- **New Features**
  - Added `MagConfigStatus::Stale` and display support in `setup` (warning icon, “stale” label).

- **Bug Fixes**
  - Updated `any_configured` to return true for `Stale`.
  - Added tests for empty lists, one configured among many, all unconfigured, and stale-only cases.

<sup>Written for commit b0f6229c92362ebe65aba0433fd427194ea8aca3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new "stale" status for tool configurations, indicated by a warning icon (⚠).
  * Stale configurations are now recognized and treated consistently with active configurations across the system.

* **Tests**
  * Expanded test coverage for configuration detection to include empty, mixed, and stale status scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->