### PR TITLE
perf: wrap set_profile in single transaction with cached statement

### DIFF
--- a/src/memory_core/storage/sqlite/session.rs
+++ b/src/memory_core/storage/sqlite/session.rs
@@ -71,16 +71,26 @@ impl ProfileManager for SqliteStorage {
                 .ok_or_else(|| anyhow!("profile updates must be a JSON object"))?;
             let conn = pool.writer()?;
 
-            for (key, value) in updates_obj {
-                let value_json = serde_json::to_string(value)
-                    .context("failed to serialize user profile value")?;
-                conn.execute(
-                    "INSERT OR REPLACE INTO user_profile (key, value, updated_at)
-                     VALUES (?1, ?2, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))",
-                    params![key, value_json],
-                )
-                .context("failed to upsert user profile value")?;
+            let tx = retry_on_lock(|| conn.unchecked_transaction())
+                .context("failed to start profile update transaction")?;
+            {
+                let mut stmt = tx
+                    .prepare_cached(
+                        "INSERT OR REPLACE INTO user_profile (key, value, updated_at)
+                         VALUES (?1, ?2, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))",
+                    )
+                    .context("failed to prepare profile upsert statement")?;
+                for (key, value) in updates_obj {
+                    let value_json = serde_json::to_string(value)
+                        .context("failed to serialize user profile value")?;
+                    stmt.execute(params![key, value_json])
+                        .context("failed to upsert user profile value")?;
+                }
             }
+            tx.commit()
+                .context("failed to commit profile update transaction")?;
+            drop(conn);
+            pool.note_write();
 
             Ok::<_, anyhow::Error>(())
         })


### PR DESCRIPTION
## Summary
- Wraps the per-key `INSERT OR REPLACE` loop in `set_profile` in a single explicit SQLite transaction with a `prepare_cached` statement
- Eliminates N+1 implicit transactions when updating multiple profile keys at once
- Follows existing patterns from `crud.rs` (retry_on_lock, drop conn before note_write)

## Test plan
- [x] `cargo check` passes
- [x] All 6 `test_profile_*` tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch profile updates in `set_profile` into one SQLite transaction using a cached prepared statement to remove per-key implicit transactions and speed up multi-key writes.

- **Refactors**
  - Wrap the upsert loop in `retry_on_lock(|| conn.unchecked_transaction())` and commit once.
  - Use a single `prepare_cached` upsert and execute it for each key.
  - Drop the connection before `pool.note_write()` to match `crud.rs` patterns.

<sup>Written for commit 4599252c45738c2a1c7dac14a6318b6ccc136129. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved database transaction handling for profile storage operations to enhance reliability during concurrent access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->