### PR TITLE
chore: bump to v0.1.10-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,7 +1240,7 @@ checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
 name = "mag-memory"
-version = "0.1.9"
+version = "0.1.10-dev"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mag-memory"
-version = "0.1.9"
+version = "0.1.10-dev"
 edition = "2024"
 autobenches = false
 license = "MIT"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mag-memory",
-  "version": "0.1.9",
+  "version": "0.1.10-dev",
   "description": "MAG — Memory Augmented Generation. Local MCP memory server with ONNX embeddings.",
   "license": "MIT",
   "repository": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mag-memory"
-version = "0.1.9"
+version = "0.1.10-dev"
 description = "PyPI wrapper for the mag MCP memory server (Rust binary)"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Post-release dev bump.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bump `mag-memory` to v0.1.10-dev across Rust, npm, and Python to start the next dev cycle and keep versions in sync. Updates `Cargo.toml`/`Cargo.lock`, `npm/package.json`, and `python/pyproject.toml`.

<sup>Written for commit 6ae87f9c44b84fb0900add223ae599dca94d5085. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bumped to 0.1.10-dev across all package distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->