### PR TITLE
fix(substrate): complete Phase 2 — review findings + harness scaffold

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,9 @@ mag-research.md
 data/*
 # But track the local benchmark definition
 !data/local_benchmark.json
+
+# Python bytecode caches
+__pycache__/
+*.pyc
+# Benchmark result outputs
+/results/

--- a/ISSUE_TRACKER.md
+++ b/ISSUE_TRACKER.md
@@ -1,6 +1,6 @@
 # Issue Tracker — Orchestration State
 
-Last updated: 2026-05-21
+Last updated: 2026-05-30
 LoCoMo word-overlap (2-sample): **75.3%** (was 74.4% at session start)
 Evidence Recall: **77.7%**
 
@@ -58,7 +58,7 @@ Key insight: AutoMem gap is in retrieval quality, not evaluation methodology. Ad
 | Issue | Title | Status | Notes |
 |-------|-------|--------|-------|
 | #N | Substrate `MemoryStore` trait lacks bulk-lookup by ID | open | `GraphNeighborScorer` clones HashMap for spawn_blocking; a `get_many` method would be more efficient |
-| #N | `EmbedAndExtractPipeline` double-computes embeddings | open | Pipeline computes embedding, then `SqliteStorage::store` recomputes it internally |
+| #N | `EmbedAndExtractPipeline` double-computes embeddings | resolved | Pipeline now passes pre-computed embedding via `store_with_embedding` (`ingestion_impl.rs`, `store_impl.rs`, `crud.rs`) |
 
 ## Remaining Open Issues (6)
 
@@ -90,23 +90,23 @@ Key insight: AutoMem gap is in retrieval quality, not evaluation methodology. Ad
 5. **EmbedAndExtractPipeline steps incomplete** — Computes embedding then discards it; does not perform auto-supersession, dedup, entity extraction, or relationship creation as documented. (`ingestion_impl.rs`) — **NOTED**: documented with TODO; requires MemoryStore API extension
 
 ### Warnings
-1. **RRF formula deviation** — `RrfFusion` multiplies raw signal score by reciprocal-rank weight, but trait docs define RRF without raw-score scaling. Deviates from standard RRF. (`fusion_impl.rs`)
-2. **Redundant query tokenization** — `SearchPipeline::search` never populates `ctx.query_tokens`, so every scorer independently re-tokenizes the query. (`orchestrators.rs`)
-3. **Cross-encoder length mismatch** — `CrossEncoderScorer` zips `ids` with `ce_scores` without verifying equal lengths. (`enrichment_impl.rs`)
-4. **TTL malformed-data default** — `TtlExpirationPolicy::is_alive` returns `true` (alive) when `expires_at` is missing, non-string, or invalid RFC3339. Should arguably default to `false` for safety. (`lifecycle_impl.rs`)
+1. **RRF formula deviation** — `RrfFusion` multiplies raw signal score by reciprocal-rank weight, but trait docs define RRF without raw-score scaling. Deviates from standard RRF. (`fusion_impl.rs`) — **FIXED**: pure RRF, `existing.score += rrf_score`, `merged.score = rrf_score`
+2. **Redundant query tokenization** — `SearchPipeline::search` never populates `ctx.query_tokens`, so every scorer independently re-tokenizes the query. (`orchestrators.rs`) — **FIXED**: pre-computes `ctx.query_tokens` once before scorer loop
+3. **Cross-encoder length mismatch** — `CrossEncoderScorer` zips `ids` with `ce_scores` without verifying equal lengths. (`enrichment_impl.rs`) — **FIXED**: `bail!` on length mismatch before zip
+4. **TTL malformed-data default** — `TtlExpirationPolicy::is_alive` returns `true` (alive) when `expires_at` is missing, non-string, or invalid RFC3339. Should arguably default to `false` for safety. (`lifecycle_impl.rs`) — **FIXED**: fail-closed, malformed/non-string/unparseable → `is_alive = false`
 
 ### Nits
-1. **Unnecessary query_tokens clone** — `MultiFactorScorer` clones `query_tokens` HashSet when a shared reference would suffice. (`scoring_impl.rs`)
-2. **Redundant id clone in WritePipeline** — `WritePipeline::ingest` clones `input.id` before moving the owned `input` into `WriteContext`; could move instead. (`orchestrators.rs`)
+1. **Unnecessary query_tokens clone** — `MultiFactorScorer` clones `query_tokens` HashSet when a shared reference would suffice. (`scoring_impl.rs`) — **FIXED**: borrows `ctx.query_tokens` instead of cloning
+2. **Redundant id clone in WritePipeline** — `WritePipeline::ingest` clones `input.id` before moving the owned `input` into `WriteContext`; could move instead. (`orchestrators.rs`) — **FIXED**: uses `input.id.take()` instead of clone
 
 ## Adversarial Review Findings — Round 2 (2026-05-21)
 
 ### Critical
-1. ❌ **EmbedAndExtractPipeline still incomplete** — NOT FIXED. Still computes embedding then discards it (acknowledged by TODO). Still lacks auto-supersession, dedup, entity extraction, and relationship creation. (`ingestion_impl.rs`)
+1. **EmbedAndExtractPipeline still incomplete** — (`ingestion_impl.rs`) — **FIXED**: delegates full store path (dedup/supersession/entity/relate) via `store_with_embedding`
 
 ### Warnings
-1. **Cross-encoder length mismatch still present** — `CrossEncoderScorer` zips `ids` with `ce_scores` without verifying equal lengths. Unchanged from Round 1. (`enrichment_impl.rs`)
-2. **Redundant query tokenization still present** — `SearchPipeline::search` never populates `ctx.query_tokens`, so every scorer independently re-tokenizes. Unchanged from Round 1. (`orchestrators.rs`)
+1. **Cross-encoder length mismatch still present** — `CrossEncoderScorer` zips `ids` with `ce_scores` without verifying equal lengths. Unchanged from Round 1. (`enrichment_impl.rs`) — **FIXED**: `bail!` on length mismatch before zip
+2. **Redundant query tokenization still present** — `SearchPipeline::search` never populates `ctx.query_tokens`, so every scorer independently re-tokenizes. Unchanged from Round 1. (`orchestrators.rs`) — **FIXED**: pre-computes `ctx.query_tokens` once before scorer loop
 
 ### Nits
-1. **Redundant id clone still present** — `WritePipeline::ingest` clones `input.id` before moving the owned `input` into `WriteContext`. Unchanged from Round 1. (`orchestrators.rs`)
+1. **Redundant id clone still present** — `WritePipeline::ingest` clones `input.id` before moving the owned `input` into `WriteContext`. Unchanged from Round 1. (`orchestrators.rs`) — **FIXED**: uses `input.id.take()` instead of clone

--- a/python/ama_bench_runner.py
+++ b/python/ama_bench_runner.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""
+Standalone AMA-Bench runner for MAG (SWE domain only).
+
+Usage::
+
+    python python/ama_bench_runner.py \
+        --dataset data/ama_bench/open_end_qa_set.jsonl \
+        --domain SOFTWARE \
+        --samples 5 \
+        --output results/ama_bench_swe.json
+
+Exit codes:
+    0 — success
+    1 — error
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+# Ensure mag_memory is on path
+sys.path.insert(0, str(Path(__file__).parent))
+
+from mag_memory.ama_adapter import MagMethod
+
+# Optional LLM integration
+try:
+    from openai import OpenAI
+
+    _HAS_OPENAI = True
+except ImportError:
+    _HAS_OPENAI = False
+
+
+def load_dataset(path: str, domain: Optional[str] = None) -> List[Dict[str, Any]]:
+    """Load AMA-Bench dataset and filter by domain."""
+    episodes: List[Dict[str, Any]] = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            ep = json.loads(line)
+            if domain is None or ep.get("domain") == domain:
+                episodes.append(ep)
+    return episodes
+
+
+def trajectory_to_text(trajectory: List[Dict[str, Any]]) -> str:
+    """Convert AMA-Bench trajectory list to text format."""
+    parts: List[str] = []
+    for step in trajectory:
+        turn_idx = step.get("turn_idx", 0)
+        action = step.get("action", "")
+        observation = step.get("observation", "")
+        parts.append(f"Step {turn_idx}:")
+        if action:
+            parts.append(f"Action: {action}")
+        if observation:
+            parts.append(f"Observation: {observation}")
+        parts.append("")
+    return "\n".join(parts)
+
+
+def word_overlap_score(prediction: str, reference: str) -> float:
+    """
+    Compute word-overlap F1 between prediction and reference.
+    Simple tokenisation: lowercase, split on whitespace, strip punctuation.
+    """
+    import re
+
+    def tokens(text: str) -> set:
+        return set(
+            re.sub(r"[^\w]", "", t.lower())
+            for t in text.split()
+            if re.sub(r"[^\w]", "", t.lower())
+        )
+
+    pred_tokens = tokens(prediction)
+    ref_tokens = tokens(reference)
+
+    if not pred_tokens or not ref_tokens:
+        return 0.0
+
+    overlap = pred_tokens & ref_tokens
+    precision = len(overlap) / len(pred_tokens) if pred_tokens else 0.0
+    recall = len(overlap) / len(ref_tokens) if ref_tokens else 0.0
+    if precision + recall == 0:
+        return 0.0
+    return 2 * precision * recall / (precision + recall)
+
+
+def exact_match_score(prediction: str, reference: str) -> float:
+    """1.0 if normalised strings match exactly, else 0.0."""
+    return 1.0 if prediction.strip().lower() == reference.strip().lower() else 0.0
+
+
+def generate_answer(
+    question: str,
+    context: str,
+    model: str,
+    api_key: Optional[str],
+    base_url: str,
+    max_tokens: int,
+) -> Tuple[str, float]:
+    """
+    Generate an answer from retrieved context using an LLM.
+
+    Returns (answer_text, latency_ms).
+    """
+    if not _HAS_OPENAI:
+        raise RuntimeError(
+            "openai package not installed. Run: pip install openai"
+        )
+
+    client = OpenAI(api_key=api_key, base_url=base_url)
+
+    system_msg = (
+        "You are a precise assistant. Answer the user's question using ONLY "
+        "the provided context. If the context does not contain the answer, "
+        "say 'I don't know'. Be concise."
+    )
+
+    user_msg = f"Context:\n{context}\n\nQuestion: {question}\n\nAnswer:"
+
+    t0 = time.time()
+    response = client.chat.completions.create(
+        model=model,
+        messages=[
+            {"role": "system", "content": system_msg},
+            {"role": "user", "content": user_msg},
+        ],
+        max_completion_tokens=max_tokens,
+        temperature=0.0,
+    )
+    latency_ms = (time.time() - t0) * 1000
+
+    answer = response.choices[0].message.content or ""
+    return answer.strip(), latency_ms
+
+
+def run_episode(
+    method: MagMethod,
+    episode: Dict[str, Any],
+    top_k: int = 5,
+    llm_model: Optional[str] = None,
+    llm_url: str = "https://api.openai.com/v1",
+    llm_api_key: Optional[str] = None,
+    max_completion_tokens: int = 256,
+) -> Dict[str, Any]:
+    """Run memory construction + retrieval for a single episode."""
+    episode_id = episode["episode_id"]
+    task = episode.get("task", "")
+    trajectory = episode.get("trajectory", [])
+    qa_pairs = episode.get("qa_pairs", [])
+
+    traj_text = trajectory_to_text(trajectory)
+
+    # Phase 1: memory construction
+    t0 = time.time()
+    memory = method.memory_construction(traj_text, task=task)
+    construction_ms = (time.time() - t0) * 1000
+
+    # Phase 2: retrieval for each question
+    results: List[Dict[str, Any]] = []
+    total_retrieve_ms = 0.0
+
+    for qa in qa_pairs:
+        question = qa["question"]
+        reference = qa.get("answer", "")
+
+        t1 = time.time()
+        context = method.memory_retrieve(memory, question)
+        retrieve_ms = (time.time() - t1) * 1000
+        total_retrieve_ms += retrieve_ms
+
+        # Generate answer from context using LLM (if available)
+        prediction = context
+        llm_ms = 0.0
+        if llm_model is not None:
+            try:
+                prediction, llm_ms = generate_answer(
+                    question,
+                    context,
+                    llm_model,
+                    llm_api_key,
+                    llm_url,
+                    max_completion_tokens,
+                )
+            except Exception as exc:
+                prediction = f"[LLM_ERROR: {exc}]"
+
+        em = exact_match_score(prediction, reference)
+        f1 = word_overlap_score(prediction, reference)
+
+        result_entry: Dict[str, Any] = {
+            "question": question,
+            "reference": reference,
+            "prediction": prediction,
+            "context_chars": len(context),
+            "exact_match": em,
+            "word_overlap_f1": f1,
+            "retrieve_ms": retrieve_ms,
+        }
+        if llm_model is not None:
+            result_entry["llm_ms"] = llm_ms
+        results.append(result_entry)
+
+    return {
+        "episode_id": episode_id,
+        "domain": episode.get("domain"),
+        "task_type": episode.get("task_type"),
+        "num_turns": len(trajectory),
+        "total_tokens": episode.get("total_tokens"),
+        "construction_ms": construction_ms,
+        "avg_retrieve_ms": total_retrieve_ms / len(qa_pairs) if qa_pairs else 0,
+        "results": results,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="AMA-Bench runner for MAG")
+    parser.add_argument(
+        "--dataset",
+        type=str,
+        default="data/ama_bench/open_end_qa_set.jsonl",
+        help="Path to AMA-Bench JSONL dataset",
+    )
+    parser.add_argument(
+        "--domain",
+        type=str,
+        default="SOFTWARE",
+        help="Domain filter (e.g. SOFTWARE, WEB, Game)",
+    )
+    parser.add_argument(
+        "--samples",
+        type=int,
+        default=None,
+        help="Number of episodes to evaluate (default: all)",
+    )
+    parser.add_argument(
+        "--top-k",
+        type=int,
+        default=5,
+        help="Number of chunks to retrieve per question",
+    )
+    parser.add_argument(
+        "--chunk-size",
+        type=int,
+        default=2000,
+        help="Trajectory chunk size in characters",
+    )
+    parser.add_argument(
+        "--search-mode",
+        type=str,
+        default="semantic",
+        choices=["text", "semantic"],
+        help="Search mode for retrieval",
+    )
+    parser.add_argument(
+        "--search-limit",
+        type=int,
+        default=20,
+        help="Candidate limit before top-k truncation",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default="results/ama_bench_mag.json",
+        help="Output JSON file for results",
+    )
+    parser.add_argument(
+        "--trace-dir",
+        type=str,
+        default=None,
+        help="Directory for JSONL trace files",
+    )
+    parser.add_argument(
+        "--home-dir",
+        type=str,
+        default=None,
+        help="MAG home directory (default: ~/.mag)",
+    )
+    parser.add_argument(
+        "--mag-binary",
+        type=str,
+        default=None,
+        help="Path to mag binary",
+    )
+    parser.add_argument(
+        "--llm-model",
+        type=str,
+        default="gpt-5.4",
+        help="LLM model for answer generation",
+    )
+    parser.add_argument(
+        "--llm-url",
+        type=str,
+        default="https://api.openai.com/v1",
+        help="OpenAI-compatible API base URL",
+    )
+    parser.add_argument(
+        "--no-llm",
+        action="store_true",
+        help="Skip LLM answer generation (score raw retrieved context instead)",
+    )
+    parser.add_argument(
+        "--max-completion-tokens",
+        type=int,
+        default=256,
+        help="Max tokens for LLM answer generation",
+    )
+    args = parser.parse_args()
+
+    if not os.path.exists(args.dataset):
+        print(f"ERROR: Dataset not found: {args.dataset}", file=sys.stderr)
+        print("Download with:", file=sys.stderr)
+        print(
+            "  curl -L https://huggingface.co/datasets/AMA-bench/AMA-bench/resolve/main/test/open_end_qa_set.jsonl "
+            "-o data/ama_bench/open_end_qa_set.jsonl",
+            file=sys.stderr,
+        )
+        return 1
+
+    episodes = load_dataset(args.dataset, domain=args.domain)
+    if args.samples is not None:
+        episodes = episodes[: args.samples]
+
+    print(f"Loaded {len(episodes)} episodes (domain={args.domain})")
+
+    method = MagMethod(
+        top_k=args.top_k,
+        chunk_size=args.chunk_size,
+        search_mode=args.search_mode,
+        search_limit=args.search_limit,
+        trace_dir=args.trace_dir,
+        mag_binary=args.mag_binary,
+        home_dir=args.home_dir,
+    )
+
+    all_episode_results: List[Dict[str, Any]] = []
+    total_questions = 0
+    total_em = 0.0
+    total_f1 = 0.0
+
+    # Resolve LLM config
+    use_llm = not args.no_llm
+    llm_api_key: Optional[str] = None
+    if use_llm:
+        if not _HAS_OPENAI:
+            print(
+                "WARNING: openai not installed; falling back to no-LLM mode.\n"
+                "Install with: pip install openai",
+                file=sys.stderr,
+            )
+            use_llm = False
+        else:
+            llm_api_key = os.environ.get("OPENAI_API_KEY")
+            if not llm_api_key and os.path.exists(".env.local"):
+                with open(".env.local") as f:
+                    for line in f:
+                        if line.startswith("OPENAI_API_KEY="):
+                            llm_api_key = line.strip().split("=", 1)[1]
+                            break
+            if not llm_api_key:
+                print(
+                    "WARNING: OPENAI_API_KEY not found; falling back to no-LLM mode.",
+                    file=sys.stderr,
+                )
+                use_llm = False
+
+    llm_model = args.llm_model if use_llm else None
+
+    try:
+        for i, ep in enumerate(episodes, 1):
+            print(f"\n[{i}/{len(episodes)}] Episode {ep['episode_id']} — {ep.get('task_type')} ({ep.get('num_turns')} turns)")
+            result = run_episode(
+                method,
+                ep,
+                top_k=args.top_k,
+                llm_model=llm_model,
+                llm_url=args.llm_url,
+                llm_api_key=llm_api_key,
+                max_completion_tokens=args.max_completion_tokens,
+            )
+            all_episode_results.append(result)
+
+            ep_questions = len(result["results"])
+            ep_em = sum(r["exact_match"] for r in result["results"])
+            ep_f1 = sum(r["word_overlap_f1"] for r in result["results"])
+
+            total_questions += ep_questions
+            total_em += ep_em
+            total_f1 += ep_f1
+
+            print(
+                f"  Construction: {result['construction_ms']:.0f}ms | "
+                f"Avg retrieve: {result['avg_retrieve_ms']:.0f}ms | "
+                f"EM: {ep_em}/{ep_questions} | F1: {ep_f1/ep_questions:.2f}"
+            )
+    finally:
+        method.close()
+
+    # Aggregate summary
+    summary = {
+        "domain": args.domain,
+        "episodes_evaluated": len(all_episode_results),
+        "questions_evaluated": total_questions,
+        "exact_match": total_em / total_questions if total_questions else 0.0,
+        "mean_f1": total_f1 / total_questions if total_questions else 0.0,
+        "timestamp": time.time(),
+        "config": {
+            "top_k": args.top_k,
+            "chunk_size": args.chunk_size,
+            "search_mode": args.search_mode,
+            "search_limit": args.search_limit,
+            "llm_model": llm_model,
+            "llm_url": args.llm_url if use_llm else None,
+        },
+        "episodes": all_episode_results,
+    }
+
+    os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(summary, f, indent=2, ensure_ascii=False)
+
+    print(f"\n{'='*60}")
+    print(f"Results written to: {args.output}")
+    print(f"Episodes: {summary['episodes_evaluated']} | Questions: {summary['questions_evaluated']}")
+    print(f"Exact Match: {summary['exact_match']:.2%}")
+    print(f"Mean F1:     {summary['mean_f1']:.2%}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/mag_memory/ama_adapter.py
+++ b/python/mag_memory/ama_adapter.py
@@ -1,0 +1,326 @@
+"""
+MAG adapter for AMA-Bench.
+
+Implements the two-stage protocol via the MCP stdio interface:
+
+1. ``memory_construction(traj_text, task)`` — chunk and store trajectory.
+2. ``memory_retrieve(memory, question)`` — search and return context.
+
+Usage with AMA-Bench::
+
+    from mag_memory.ama_adapter import MagMethod
+
+    method = MagMethod(top_k=5)
+    memory = method.memory_construction(trajectory_text, task="")
+    context = method.memory_retrieve(memory, "What was the first action?")
+
+**Concurrency note:** The adapter uses a single ``mag serve`` subprocess.
+Run AMA-Bench with ``--max-concurrency-episodes 1`` to avoid contention.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# When running inside the AMA-Bench repo, BaseMethod is at src.method.base_method.
+# When running standalone, we define a minimal compatible base class.
+try:
+    from src.method.base_method import BaseMethod
+except ImportError:
+    # Standalone fallback — enough duck-typing for manual use.
+    from abc import ABC, abstractmethod
+
+    class BaseMethod(ABC):  # type: ignore[no-redef]
+        @abstractmethod
+        def memory_construction(self, traj_text: str, task: str = "") -> Any:
+            pass
+
+        @abstractmethod
+        def memory_retrieve(self, memory: Any, question: str) -> str:
+            pass
+
+from .mcp_client import McpClient
+
+
+# ---------------------------------------------------------------------------
+# Chunking
+# ---------------------------------------------------------------------------
+
+DEFAULT_CHUNK_SIZE = 2_000  # characters per chunk
+DEFAULT_CHUNK_OVERLAP = 200
+
+
+def _chunk_text(text: str, chunk_size: int = DEFAULT_CHUNK_SIZE, overlap: int = DEFAULT_CHUNK_OVERLAP) -> List[str]:
+    """
+    Split text into overlapping chunks.
+
+    Tries to split on ``Step N:`` or ``Turn N:`` boundaries first;
+    falls back to sentence boundaries, then hard character cuts.
+    """
+    lines = text.splitlines()
+    if not lines:
+        return []
+
+    # Try step/turn boundaries
+    boundaries = [0]
+    for i, line in enumerate(lines):
+        if re.match(r"^(Step|Turn)\s+\d+", line.strip(), re.IGNORECASE):
+            boundaries.append(i)
+    boundaries.append(len(lines))
+
+    chunks: List[str] = []
+    current: List[str] = []
+    current_len = 0
+
+    for b in range(len(boundaries) - 1):
+        segment = "\n".join(lines[boundaries[b]:boundaries[b + 1]])
+        seg_len = len(segment)
+
+        if current_len + seg_len <= chunk_size:
+            current.append(segment)
+            current_len += seg_len + 1  # +1 for joining newline
+        else:
+            if current:
+                chunks.append("\n".join(current))
+            current = [segment]
+            current_len = seg_len
+
+    if current:
+        chunks.append("\n".join(current))
+
+    # If any chunk is still too large, hard-split it
+    final_chunks: List[str] = []
+    for chunk in chunks:
+        if len(chunk) <= chunk_size * 1.2:  # allow 20% overshoot for natural boundaries
+            final_chunks.append(chunk)
+            continue
+        start = 0
+        while start < len(chunk):
+            end = min(start + chunk_size, len(chunk))
+            final_chunks.append(chunk[start:end])
+            start += chunk_size - overlap
+
+    return final_chunks if final_chunks else [text]
+
+
+# ---------------------------------------------------------------------------
+# Memory object
+# ---------------------------------------------------------------------------
+
+@dataclass
+class MagMemory:
+    """Opaque memory handle returned by ``memory_construction``."""
+    episode_id: str
+    project: str
+    chunk_count: int
+    trace_path: Optional[Path] = None
+    _client: Optional[McpClient] = field(default=None, repr=False)
+
+
+# ---------------------------------------------------------------------------
+# Adapter
+# ---------------------------------------------------------------------------
+
+class MagMethod(BaseMethod):
+    """
+    AMA-Bench memory method backed by MAG via MCP.
+
+    Parameters
+    ----------
+    top_k:
+        Number of memories to retrieve per question.
+    chunk_size:
+        Maximum characters per trajectory chunk.
+    chunk_overlap:
+        Overlap between adjacent chunks.
+    search_mode:
+        ``text`` (default, FTS5 + advanced pipeline) or ``semantic``.
+    search_limit:
+        How many candidates to fetch from MAG before truncating to ``top_k``.
+    trace_dir:
+        Directory for JSONL trace files. Default: ``~/.mag/traces``.
+    mag_binary:
+        Path to the ``mag`` binary. Auto-detected if omitted.
+    home_dir:
+        MAG home directory (where the SQLite DB lives).
+    """
+
+    def __init__(
+        self,
+        top_k: int = 5,
+        chunk_size: int = DEFAULT_CHUNK_SIZE,
+        chunk_overlap: int = DEFAULT_CHUNK_OVERLAP,
+        search_mode: str = "semantic",
+        search_limit: int = 20,
+        trace_dir: Optional[str] = None,
+        mag_binary: Optional[str] = None,
+        home_dir: Optional[str] = None,
+        **kwargs: Any,
+    ):
+        self.top_k = top_k
+        self.chunk_size = chunk_size
+        self.chunk_overlap = chunk_overlap
+        self.search_mode = search_mode
+        self.search_limit = search_limit
+
+        self._trace_dir = Path(trace_dir or os.path.expanduser("~/.mag/traces"))
+        self._trace_dir.mkdir(parents=True, exist_ok=True)
+
+        self._mag_binary = mag_binary
+        self._home_dir = home_dir
+        self._client: Optional[McpClient] = None
+        self._run_id = str(uuid.uuid4())[:8]
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _ensure_client(self) -> McpClient:
+        if self._client is None:
+            self._client = McpClient(
+                mag_binary=self._mag_binary,
+                home_dir=self._home_dir,
+                timeout_secs=120.0,
+            )
+            self._client.start()
+        return self._client
+
+    def _trace(self, event: Dict[str, Any]) -> None:
+        event["_ts"] = time.time()
+        event["_run"] = self._run_id
+        trace_file = self._trace_dir / f"{self._run_id}.jsonl"
+        with open(trace_file, "a", encoding="utf-8") as f:
+            f.write(json.dumps(event, ensure_ascii=False) + "\n")
+
+    # ------------------------------------------------------------------
+    # BaseMethod interface
+    # ------------------------------------------------------------------
+
+    def memory_construction(self, traj_text: str, task: str = "") -> MagMemory:
+        """
+        Chunk *traj_text* and store each chunk in MAG.
+
+        Returns a :class:`MagMemory` handle that carries the episode-scoped
+        ``project`` filter used during retrieval.
+        """
+        client = self._ensure_client()
+        episode_id = str(uuid.uuid4())
+        project = f"ama_bench_{episode_id[:8]}"
+
+        chunks = _chunk_text(traj_text, self.chunk_size, self.chunk_overlap)
+
+        # Build batch items
+        items: List[Dict[str, Any]] = []
+        for idx, chunk in enumerate(chunks):
+            items.append(
+                {
+                    "content": chunk,
+                    "tags": ["ama_bench", f"episode_{episode_id[:8]}"],
+                    "project": project,
+                    "metadata": {
+                        "episode_id": episode_id,
+                        "chunk_index": idx,
+                        "total_chunks": len(chunks),
+                        "task": task,
+                    },
+                }
+            )
+
+        # Store in batches (memory_store_batch has a limit; chunk if needed)
+        BATCH_SIZE = 50
+        stored = 0
+        for i in range(0, len(items), BATCH_SIZE):
+            batch = items[i : i + BATCH_SIZE]
+            result = client.store_batch(batch)
+            stored += len(batch)
+
+        self._trace(
+            {
+                "event": "memory_construction",
+                "episode_id": episode_id,
+                "project": project,
+                "chunks": len(chunks),
+                "task": task,
+                "traj_chars": len(traj_text),
+            }
+        )
+
+        trace_path = self._trace_dir / f"{self._run_id}.jsonl"
+        return MagMemory(
+            episode_id=episode_id,
+            project=project,
+            chunk_count=len(chunks),
+            trace_path=trace_path,
+            _client=client,
+        )
+
+    def memory_retrieve(self, memory: MagMemory, question: str) -> str:
+        """
+        Search MAG for memories scoped to *memory.project* and return the
+        top ``self.top_k`` results concatenated.
+        """
+        if not isinstance(memory, MagMemory):
+            raise ValueError("memory must be a MagMemory object")
+
+        client = self._ensure_client()
+
+        # Try advanced search first; fall back to plain search if abstained.
+        result = client.search(
+            query=question,
+            mode=self.search_mode,
+            limit=self.search_limit,
+            advanced=True,
+            project=memory.project,
+        )
+
+        results = result.get("results", [])
+        abstained = result.get("abstained", False)
+
+        if not results or abstained:
+            result = client.search(
+                query=question,
+                mode=self.search_mode,
+                limit=self.search_limit,
+                advanced=False,
+                project=memory.project,
+            )
+            results = result.get("results", [])
+            abstained = False
+
+        # Take top_k
+        top = results[: self.top_k]
+        context_parts: List[str] = []
+        for r in top:
+            content = r.get("content", "")
+            if content:
+                context_parts.append(content)
+
+        context = "\n\n".join(context_parts)
+
+        self._trace(
+            {
+                "event": "memory_retrieve",
+                "episode_id": memory.episode_id,
+                "project": memory.project,
+                "question": question,
+                "candidates": len(results),
+                "used": len(top),
+                "abstained": abstained,
+                "context_chars": len(context),
+            }
+        )
+
+        return context
+
+    def close(self) -> None:
+        """Terminate the underlying MCP client."""
+        if self._client is not None:
+            self._client.stop()
+            self._client = None

--- a/python/mag_memory/harness.py
+++ b/python/mag_memory/harness.py
@@ -1,0 +1,157 @@
+"""
+Minimal AgentMemoryHarness interface.
+
+This is the Python-side counterpart to the Rust ``AgentMemoryHarness`` trait.
+It provides three operations — *observe*, *retrieve_context*, *trace* —
+without prescribing how they are implemented underneath.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from .mcp_client import McpClient
+
+
+class AgentTurn:
+    """
+    A single turn in an agent trajectory.
+
+    This is intentionally unstructured — callers pass whatever fields
+    are relevant for their domain.
+    """
+
+    def __init__(
+        self,
+        turn_idx: int,
+        action: str = "",
+        observation: str = "",
+        metadata: Optional[Dict[str, Any]] = None,
+    ):
+        self.turn_idx = turn_idx
+        self.action = action
+        self.observation = observation
+        self.metadata = metadata or {}
+
+    def to_text(self) -> str:
+        """Serialise to the AMA-Bench trajectory text format."""
+        parts = [f"Step {self.turn_idx}:"]
+        if self.action:
+            parts.append(f"Action: {self.action}")
+        if self.observation:
+            parts.append(f"Observation: {self.observation}")
+        return "\n".join(parts)
+
+
+class AgentMemoryHarness(ABC):
+    """
+    Three-method harness that sits between a benchmark and MAG.
+
+    Implementations may use the MCP stdio interface (for Python callers)
+    or the Rust storage traits directly (for in-process callers).
+    """
+
+    @abstractmethod
+    def observe(self, turn: AgentTurn) -> None:
+        """Ingest a single turn into memory."""
+        ...
+
+    @abstractmethod
+    def retrieve_context(self, query: str) -> str:
+        """Retrieve relevant context for *query*."""
+        ...
+
+    @abstractmethod
+    def trace(self, event: Dict[str, Any]) -> None:
+        """Emit an unstructured JSON trace event."""
+        ...
+
+
+class MagHarness(AgentMemoryHarness):
+    """
+    In-process harness backed by a :class:`McpClient`.
+
+    This is suitable for Python benchmarks that want to drive MAG
+    turn-by-turn rather than batch-store an entire trajectory.
+    """
+
+    def __init__(
+        self,
+        session_id: Optional[str] = None,
+        project: Optional[str] = None,
+        trace_dir: Optional[str] = None,
+        mag_binary: Optional[str] = None,
+        home_dir: Optional[str] = None,
+        search_mode: str = "text",
+        search_limit: int = 10,
+    ):
+        self.session_id = session_id or str(uuid.uuid4())
+        self.project = project or f"harness_{self.session_id[:8]}"
+        self.search_mode = search_mode
+        self.search_limit = search_limit
+
+        self._trace_dir = Path(trace_dir or os.path.expanduser("~/.mag/traces"))
+        self._trace_dir.mkdir(parents=True, exist_ok=True)
+        self._trace_file = self._trace_dir / f"{self.session_id}.jsonl"
+
+        self._client = McpClient(
+            mag_binary=mag_binary,
+            home_dir=home_dir,
+            timeout_secs=120.0,
+        )
+        self._client.start()
+
+    def observe(self, turn: AgentTurn) -> None:
+        content = turn.to_text()
+        self._client.store(
+            content=content,
+            tags=["harness", "turn"],
+            project=self.project,
+            session_id=self.session_id,
+            metadata={
+                "turn_idx": turn.turn_idx,
+                **turn.metadata,
+            },
+        )
+        self.trace(
+            {
+                "event": "observe",
+                "turn_idx": turn.turn_idx,
+                "content_chars": len(content),
+            }
+        )
+
+    def retrieve_context(self, query: str) -> str:
+        result = self._client.search(
+            query=query,
+            mode=self.search_mode,
+            limit=self.search_limit,
+            advanced=True,
+            project=self.project,
+        )
+        results = result.get("results", [])
+        context = "\n\n".join(r.get("content", "") for r in results)
+        self.trace(
+            {
+                "event": "retrieve",
+                "query": query,
+                "results": len(results),
+                "context_chars": len(context),
+            }
+        )
+        return context
+
+    def trace(self, event: Dict[str, Any]) -> None:
+        event["_ts"] = time.time()
+        event["_session"] = self.session_id
+        with open(self._trace_file, "a", encoding="utf-8") as f:
+            f.write(json.dumps(event, ensure_ascii=False) + "\n")
+
+    def close(self) -> None:
+        self._client.stop()

--- a/python/memory_arena_agent.py
+++ b/python/memory_arena_agent.py
@@ -1,0 +1,554 @@
+#!/usr/bin/env python3
+"""
+MemoryArena Progressive Web Search agent with MAG memory.
+
+Follows the Mem0 benchmark pattern:
+1. Ingest: agent runs through tasks, storing observations in MAG
+2. Search/Evaluate: score answers against ground truth
+
+Three conditions:
+- no_memory: agent uses web search only, no memory between subtasks
+- passive: agent can query MAG for relevant context before each subtask
+- active: MAG automatically injects context at subtask boundaries
+
+Usage::
+
+    python python/memory_arena_agent.py \
+        --samples 5 \
+        --conditions no_memory,passive,active \
+        --output results/memory_arena_agent.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from mag_memory.mcp_client import McpClient
+
+try:
+    from openai import OpenAI
+    from datasets import load_dataset
+    from duckduckgo_search import DDGS
+
+    _HAS_DEPS = True
+except ImportError:
+    _HAS_DEPS = False
+
+
+# ---------------------------------------------------------------------------
+# Web search
+# ---------------------------------------------------------------------------
+
+def web_search(query: str, max_results: int = 5) -> List[Dict[str, str]]:
+    """Search the web via DuckDuckGo. Returns list of {title, href, body}."""
+    try:
+        with DDGS() as ddgs:
+            results = ddgs.text(query, max_results=max_results)
+            return [
+                {"title": r["title"], "href": r["href"], "body": r["body"]}
+                for r in results
+            ]
+    except Exception as exc:
+        print(f"  [search warning] {exc}", file=sys.stderr)
+        return []
+
+
+# ---------------------------------------------------------------------------
+# LLM
+# ---------------------------------------------------------------------------
+
+@dataclass
+class LlmConfig:
+    model: str = "gpt-5.4"
+    api_key: Optional[str] = None
+    base_url: str = "https://api.openai.com/v1"
+    max_completion_tokens: int = 1024
+    temperature: float = 0.0
+
+
+class LlmClient:
+    def __init__(self, cfg: LlmConfig):
+        self.cfg = cfg
+        self._client = OpenAI(api_key=cfg.api_key, base_url=cfg.base_url)
+
+    def generate_search_query(
+        self, subtask: str, memory_context: str
+    ) -> Tuple[str, float]:
+        """Generate a web search query for the subtask."""
+        system_msg = (
+            "You are a research assistant. Given a question and any relevant "
+            "context from prior research, generate a concise web search query "
+            "that will help find the answer. Output ONLY the search query, "
+            "nothing else."
+        )
+        user_parts = [f"Question: {subtask}"]
+        if memory_context:
+            user_parts.append(f"Prior context:\n{memory_context}")
+        user_parts.append("Search query:")
+        user_msg = "\n\n".join(user_parts)
+
+        t0 = time.time()
+        response = self._client.chat.completions.create(
+            model=self.cfg.model,
+            messages=[
+                {"role": "system", "content": system_msg},
+                {"role": "user", "content": user_msg},
+            ],
+            max_completion_tokens=100,
+            temperature=0.0,
+        )
+        latency_ms = (time.time() - t0) * 1000
+        query = (response.choices[0].message.content or "").strip().strip('"')
+        return query, latency_ms
+
+    def answer_from_search(
+        self, subtask: str, search_results: List[Dict[str, str]], memory_context: str
+    ) -> Tuple[str, float]:
+        """Generate an answer from search results."""
+        system_msg = (
+            "You are a precise research assistant. Answer the user's question "
+            "using ONLY the provided search results and prior context. "
+            "If the information is insufficient, say 'I don't know'. "
+            "Be concise but complete."
+        )
+
+        context_parts = []
+        if memory_context:
+            context_parts.append(f"Prior context from memory:\n{memory_context}")
+
+        if search_results:
+            search_text = "\n\n".join(
+                f"Result {i+1}:\n{r['body'][:500]}"
+                for i, r in enumerate(search_results[:5])
+            )
+            context_parts.append(f"Search results:\n{search_text}")
+
+        user_parts = context_parts + [f"Question: {subtask}", "Answer:"]
+        user_msg = "\n\n".join(user_parts)
+
+        t0 = time.time()
+        response = self._client.chat.completions.create(
+            model=self.cfg.model,
+            messages=[
+                {"role": "system", "content": system_msg},
+                {"role": "user", "content": user_msg},
+            ],
+            max_completion_tokens=self.cfg.max_completion_tokens,
+            temperature=self.cfg.temperature,
+        )
+        latency_ms = (time.time() - t0) * 1000
+        answer = (response.choices[0].message.content or "").strip()
+        return answer, latency_ms
+
+
+# ---------------------------------------------------------------------------
+# Memory backends
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SubtaskObservation:
+    subtask_idx: int
+    question: str
+    search_query: str
+    search_results: List[Dict[str, str]]
+    answer: str
+
+
+class NoMemory:
+    def observe(self, obs: SubtaskObservation) -> None:
+        pass
+
+    def retrieve(self, question: str) -> str:
+        return ""
+
+    def close(self) -> None:
+        pass
+
+
+class PassiveMemory:
+    """Agent decides when to retrieve. We simulate by always retrieving."""
+
+    def __init__(self, client: McpClient):
+        self.client = client
+        self.project = f"arena_passive_{uuid.uuid4().hex[:8]}"
+
+    def observe(self, obs: SubtaskObservation) -> None:
+        results_text = "\n".join(
+            f"- {r['title']}: {r['body'][:200]}" for r in obs.search_results
+        )
+        content = (
+            f"Subtask {obs.subtask_idx}\n"
+            f"Question: {obs.question}\n"
+            f"Search query: {obs.search_query}\n"
+            f"Search results:\n{results_text}\n"
+            f"Answer: {obs.answer}"
+        )
+        self.client.store(
+            content=content,
+            tags=["arena", f"subtask_{obs.subtask_idx}"],
+            project=self.project,
+            metadata={
+                "subtask_idx": obs.subtask_idx,
+                "question": obs.question,
+            },
+        )
+
+    def retrieve(self, question: str) -> str:
+        result = self.client.search(
+            query=question,
+            mode="semantic",
+            limit=10,
+            advanced=True,
+            project=self.project,
+        )
+        if result.get("abstained") or not result.get("results"):
+            result = self.client.search(
+                query=question,
+                mode="semantic",
+                limit=10,
+                advanced=False,
+                project=self.project,
+            )
+        results = result.get("results", [])
+        return "\n\n".join(r.get("content", "") for r in results[:3])
+
+    def close(self) -> None:
+        pass
+
+
+class ActiveMemory:
+    """Memory is automatically retrieved and injected at subtask boundaries."""
+
+    def __init__(self, client: McpClient):
+        self.client = client
+        self.project = f"arena_active_{uuid.uuid4().hex[:8]}"
+
+    def observe(self, obs: SubtaskObservation) -> None:
+        results_text = "\n".join(
+            f"- {r['title']}: {r['body'][:200]}" for r in obs.search_results
+        )
+        content = (
+            f"Subtask {obs.subtask_idx}\n"
+            f"Question: {obs.question}\n"
+            f"Search query: {obs.search_query}\n"
+            f"Search results:\n{results_text}\n"
+            f"Answer: {obs.answer}"
+        )
+        self.client.store(
+            content=content,
+            tags=["arena", f"subtask_{obs.subtask_idx}"],
+            project=self.project,
+            metadata={
+                "subtask_idx": obs.subtask_idx,
+                "question": obs.question,
+            },
+        )
+
+    def retrieve(self, question: str) -> str:
+        # Same retrieval as passive — difference is WHO calls it
+        result = self.client.search(
+            query=question,
+            mode="semantic",
+            limit=10,
+            advanced=True,
+            project=self.project,
+        )
+        if result.get("abstained") or not result.get("results"):
+            result = self.client.search(
+                query=question,
+                mode="semantic",
+                limit=10,
+                advanced=False,
+                project=self.project,
+            )
+        results = result.get("results", [])
+        return "\n\n".join(r.get("content", "") for r in results[:3])
+
+    def close(self) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+def word_overlap_f1(prediction: str, reference: str) -> float:
+    import re
+
+    def tokens(text: str) -> set:
+        return set(
+            re.sub(r"[^\w]", "", t.lower())
+            for t in text.split()
+            if re.sub(r"[^\w]", "", t.lower())
+        )
+
+    pred_tok = tokens(prediction)
+    ref_tok = tokens(reference)
+    if not pred_tok or not ref_tok:
+        return 0.0
+
+    overlap = pred_tok & ref_tok
+    precision = len(overlap) / len(pred_tok)
+    recall = len(overlap) / len(ref_tok)
+    if precision + recall == 0:
+        return 0.0
+    return 2 * precision * recall / (precision + recall)
+
+
+def exact_match(prediction: str, reference: str) -> float:
+    return 1.0 if prediction.strip().lower() == reference.strip().lower() else 0.0
+
+
+# ---------------------------------------------------------------------------
+# Task runner
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SubtaskResult:
+    subtask_idx: int
+    question: str
+    reference: str
+    prediction: str
+    search_query: str
+    exact_match: float
+    word_overlap_f1: float
+    llm_ms: float
+    search_ms: float
+
+
+@dataclass
+class TaskResult:
+    task_id: int
+    condition: str
+    subtasks: List[SubtaskResult]
+
+
+def run_task(
+    task: Dict[str, Any],
+    condition: str,
+    memory: Any,
+    llm: LlmClient,
+) -> TaskResult:
+    subtasks: List[SubtaskResult] = []
+    questions: List[str] = task["questions"]
+    references: List[str] = task["answers"]
+
+    for idx, (question, reference) in enumerate(zip(questions, references)):
+        # Retrieve memory
+        mem_context = ""
+        if condition != "no_memory":
+            mem_context = memory.retrieve(question)
+
+        # Generate search query
+        search_query, query_ms = llm.generate_search_query(question, mem_context)
+
+        # Execute web search
+        t_search = time.time()
+        search_results = web_search(search_query, max_results=5)
+        search_ms = (time.time() - t_search) * 1000
+
+        # Generate answer
+        prediction, answer_ms = llm.answer_from_search(
+            question, search_results, mem_context
+        )
+
+        em = exact_match(prediction, reference)
+        f1 = word_overlap_f1(prediction, reference)
+
+        subtasks.append(
+            SubtaskResult(
+                subtask_idx=idx,
+                question=question,
+                reference=reference,
+                prediction=prediction,
+                search_query=search_query,
+                exact_match=em,
+                word_overlap_f1=f1,
+                llm_ms=query_ms + answer_ms,
+                search_ms=search_ms,
+            )
+        )
+
+        # Store observation
+        memory.observe(
+            SubtaskObservation(
+                subtask_idx=idx,
+                question=question,
+                search_query=search_query,
+                search_results=search_results,
+                answer=prediction,
+            )
+        )
+
+    return TaskResult(task_id=task["id"], condition=condition, subtasks=subtasks)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="MemoryArena agent harness")
+    parser.add_argument("--samples", type=int, default=None)
+    parser.add_argument(
+        "--conditions",
+        type=str,
+        default="no_memory,passive,active",
+        help="Comma-separated: no_memory,passive,active",
+    )
+    parser.add_argument("--output", type=str, default="results/memory_arena_agent.json")
+    parser.add_argument("--llm-model", type=str, default="gpt-5.4")
+    parser.add_argument("--llm-url", type=str, default="https://api.openai.com/v1")
+    parser.add_argument("--max-completion-tokens", type=int, default=1024)
+    parser.add_argument("--home-dir", type=str, default=None)
+    parser.add_argument("--skip-search", action="store_true", help="Skip web search (for testing)")
+    args = parser.parse_args()
+
+    if not _HAS_DEPS:
+        print("ERROR: pip install openai datasets duckduckgo-search", file=sys.stderr)
+        return 1
+
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key and os.path.exists(".env.local"):
+        with open(".env.local") as f:
+            for line in f:
+                if line.startswith("OPENAI_API_KEY="):
+                    api_key = line.strip().split("=", 1)[1]
+                    break
+    if not api_key:
+        print("ERROR: OPENAI_API_KEY not found", file=sys.stderr)
+        return 1
+
+    print("Loading MemoryArena progressive_search dataset...")
+    ds = load_dataset("ZexueHe/memoryarena", "progressive_search", split="test")
+    tasks = list(ds)
+    if args.samples is not None:
+        tasks = tasks[: args.samples]
+    print(f"Loaded {len(tasks)} tasks")
+
+    llm = LlmClient(
+        LlmConfig(
+            model=args.llm_model,
+            api_key=api_key,
+            base_url=args.llm_url,
+            max_completion_tokens=args.max_completion_tokens,
+        )
+    )
+
+    conditions = [c.strip() for c in args.conditions.split(",")]
+    print(f"Conditions: {conditions}")
+
+    # Monkey-patch web_search if --skip-search
+    if args.skip_search:
+        global web_search
+        web_search = lambda query, max_results=5: []
+        print("WARNING: Web search disabled (--skip-search)")
+
+    all_results: List[Dict[str, Any]] = []
+
+    for condition in conditions:
+        print(f"\n{'='*60}")
+        print(f"Condition: {condition}")
+        print(f"{'='*60}")
+
+        condition_results: List[Dict[str, Any]] = []
+
+        for i, task in enumerate(tasks, 1):
+            mcp = McpClient(home_dir=args.home_dir)
+            mcp.start()
+
+            if condition == "no_memory":
+                memory: Any = NoMemory()
+            elif condition == "passive":
+                memory = PassiveMemory(mcp)
+            elif condition == "active":
+                memory = ActiveMemory(mcp)
+            else:
+                print(f"ERROR: unknown condition {condition}", file=sys.stderr)
+                return 1
+
+            result = run_task(task, condition, memory, llm)
+
+            condition_results.append(
+                {
+                    "task_id": result.task_id,
+                    "subtasks": [
+                        {
+                            "subtask_idx": s.subtask_idx,
+                            "question": s.question,
+                            "reference": s.reference,
+                            "prediction": s.prediction,
+                            "search_query": s.search_query,
+                            "exact_match": s.exact_match,
+                            "word_overlap_f1": s.word_overlap_f1,
+                            "llm_ms": s.llm_ms,
+                            "search_ms": s.search_ms,
+                        }
+                        for s in result.subtasks
+                    ],
+                }
+            )
+
+            memory.close()
+            mcp.stop()
+
+            avg_f1 = sum(s.word_overlap_f1 for s in result.subtasks) / len(
+                result.subtasks
+            )
+            print(
+                f"  [{i}/{len(tasks)}] Task {result.task_id} — "
+                f"subtasks={len(result.subtasks)} avg_f1={avg_f1:.2f}"
+            )
+
+        # Aggregate
+        total_subtasks = sum(len(r["subtasks"]) for r in condition_results)
+        total_em = sum(
+            s["exact_match"] for r in condition_results for s in r["subtasks"]
+        )
+        total_f1 = sum(
+            s["word_overlap_f1"] for r in condition_results for s in r["subtasks"]
+        )
+
+        summary = {
+            "condition": condition,
+            "tasks_evaluated": len(condition_results),
+            "subtasks_evaluated": total_subtasks,
+            "exact_match": total_em / total_subtasks if total_subtasks else 0.0,
+            "mean_f1": total_f1 / total_subtasks if total_subtasks else 0.0,
+            "tasks": condition_results,
+        }
+        all_results.append(summary)
+
+        print(f"\n{condition} summary:")
+        print(f"  Exact match: {summary['exact_match']:.2%}")
+        print(f"  Mean F1:     {summary['mean_f1']:.2%}")
+
+    os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "timestamp": time.time(),
+                "model": args.llm_model,
+                "conditions": all_results,
+            },
+            f,
+            indent=2,
+            ensure_ascii=False,
+        )
+
+    print(f"\nResults written to: {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/memory_arena_harness.py
+++ b/python/memory_arena_harness.py
@@ -1,0 +1,500 @@
+#!/usr/bin/env python3
+"""
+MemoryArena Progressive Web Search harness for MAG.
+
+Tests three conditions head-to-head:
+1. No-memory baseline
+2. Passive retrieval (agent asks MAG for relevant context)
+3. Active injection (MAG automatically surfaces context at subtask boundaries)
+
+Usage::
+
+    python python/memory_arena_harness.py --samples 10 --output results/arena.json
+
+Requires OPENAI_API_KEY (env var or .env.local).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from mag_memory.mcp_client import McpClient
+
+# Optional dependencies
+try:
+    from openai import OpenAI
+    from datasets import load_dataset
+
+    _HAS_DEPS = True
+except ImportError:
+    _HAS_DEPS = False
+
+
+# ---------------------------------------------------------------------------
+# LLM interface
+# ---------------------------------------------------------------------------
+
+@dataclass
+class LlmConfig:
+    model: str = "gpt-5.4"
+    api_key: Optional[str] = None
+    base_url: str = "https://api.openai.com/v1"
+    max_completion_tokens: int = 512
+    temperature: float = 0.0
+
+
+class LlmClient:
+    def __init__(self, cfg: LlmConfig):
+        self.cfg = cfg
+        self._client = OpenAI(api_key=cfg.api_key, base_url=cfg.base_url)
+
+    def answer(
+        self,
+        question: str,
+        context: str = "",
+        system: Optional[str] = None,
+    ) -> Tuple[str, float]:
+        """Generate answer. Returns (text, latency_ms)."""
+        system_msg = system or (
+            "You are a helpful research assistant. Answer the question "
+            "concisely and factually. If you are unsure, say 'I don't know'."
+        )
+
+        user_parts = []
+        if context:
+            user_parts.append(f"Relevant context from previous research:\n{context}")
+        user_parts.append(f"Question: {question}")
+        user_msg = "\n\n".join(user_parts)
+
+        t0 = time.time()
+        response = self._client.chat.completions.create(
+            model=self.cfg.model,
+            messages=[
+                {"role": "system", "content": system_msg},
+                {"role": "user", "content": user_msg},
+            ],
+            max_completion_tokens=self.cfg.max_completion_tokens,
+            temperature=self.cfg.temperature,
+        )
+        latency_ms = (time.time() - t0) * 1000
+
+        text = (response.choices[0].message.content or "").strip()
+        return text, latency_ms
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+def word_overlap_f1(prediction: str, reference: str) -> float:
+    import re
+
+    def tokens(text: str) -> set:
+        return set(
+            re.sub(r"[^\w]", "", t.lower())
+            for t in text.split()
+            if re.sub(r"[^\w]", "", t.lower())
+        )
+
+    pred_tok = tokens(prediction)
+    ref_tok = tokens(reference)
+    if not pred_tok or not ref_tok:
+        return 0.0
+
+    overlap = pred_tok & ref_tok
+    precision = len(overlap) / len(pred_tok)
+    recall = len(overlap) / len(ref_tok)
+    if precision + recall == 0:
+        return 0.0
+    return 2 * precision * recall / (precision + recall)
+
+
+def exact_match(prediction: str, reference: str) -> float:
+    return 1.0 if prediction.strip().lower() == reference.strip().lower() else 0.0
+
+
+# ---------------------------------------------------------------------------
+# Memory backends
+# ---------------------------------------------------------------------------
+
+class NoMemory:
+    """Baseline: no memory between subtasks."""
+
+    def observe(self, subtask_idx: int, question: str, answer: str) -> None:
+        pass
+
+    def retrieve(self, question: str) -> str:
+        return ""
+
+    def close(self) -> None:
+        pass
+
+
+class PassiveMemory:
+    """
+    Passive retrieval: the agent decides what to search for.
+
+    We simulate this by always searching with the current question,
+    but the *agent* could theoretically choose a different query.
+    """
+
+    def __init__(self, client: McpClient):
+        self.client = client
+        self.project = f"arena_passive_{int(time.time())}"
+
+    def observe(self, subtask_idx: int, question: str, answer: str) -> None:
+        self.client.store(
+            content=f"Subtask {subtask_idx}\nQuestion: {question}\nAnswer: {answer}",
+            tags=["arena", f"subtask_{subtask_idx}"],
+            project=self.project,
+            metadata={"subtask_idx": subtask_idx, "question": question},
+        )
+
+    def retrieve(self, question: str) -> str:
+        result = self.client.search(
+            query=question,
+            mode="semantic",
+            limit=10,
+            advanced=True,
+            project=self.project,
+        )
+        if result.get("abstained") or not result.get("results"):
+            # Fallback to plain search
+            result = self.client.search(
+                query=question,
+                mode="semantic",
+                limit=10,
+                advanced=False,
+                project=self.project,
+            )
+        results = result.get("results", [])
+        return "\n\n".join(r.get("content", "") for r in results[:3])
+
+    def close(self) -> None:
+        pass
+
+
+class ActiveMemory:
+    """
+    Active injection: memory is automatically retrieved based on the
+    upcoming question and injected into the prompt.
+    """
+
+    def __init__(self, client: McpClient, similarity_threshold: float = 0.5):
+        self.client = client
+        self.project = f"arena_active_{int(time.time())}"
+        self.threshold = similarity_threshold
+
+    def observe(self, subtask_idx: int, question: str, answer: str) -> None:
+        self.client.store(
+            content=f"Subtask {subtask_idx}\nQuestion: {question}\nAnswer: {answer}",
+            tags=["arena", f"subtask_{subtask_idx}"],
+            project=self.project,
+            metadata={"subtask_idx": subtask_idx, "question": question},
+        )
+
+    def retrieve(self, question: str) -> str:
+        # Same retrieval logic as passive — the difference is WHO decides
+        # to call retrieve(). In active mode, the harness calls it
+        # automatically before every subtask.
+        result = self.client.search(
+            query=question,
+            mode="semantic",
+            limit=10,
+            advanced=True,
+            project=self.project,
+        )
+        if result.get("abstained") or not result.get("results"):
+            result = self.client.search(
+                query=question,
+                mode="semantic",
+                limit=10,
+                advanced=False,
+                project=self.project,
+            )
+        results = result.get("results", [])
+
+        # Optional: filter by similarity threshold
+        # (MCP doesn't expose raw scores easily, so we skip threshold filtering
+        # for now and use top-3 results regardless.)
+        return "\n\n".join(r.get("content", "") for r in results[:3])
+
+    def close(self) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Task runner
+# ---------------------------------------------------------------------------
+
+@dataclass
+class SubtaskResult:
+    subtask_idx: int
+    question: str
+    reference: str
+    prediction: str
+    context: str
+    exact_match: float
+    word_overlap_f1: float
+    llm_ms: float
+
+
+@dataclass
+class TaskResult:
+    task_id: int
+    condition: str
+    subtasks: List[SubtaskResult]
+    total_llm_ms: float
+
+
+def run_task(
+    task: Dict[str, Any],
+    condition: str,
+    memory: Any,
+    llm: LlmClient,
+) -> TaskResult:
+    """Run a single MemoryArena task under a given condition."""
+    subtasks: List[SubtaskResult] = []
+    total_llm_ms = 0.0
+
+    questions: List[str] = task["questions"]
+    references: List[str] = task["answers"]
+
+    for idx, (question, reference) in enumerate(zip(questions, references)):
+        # Retrieve context based on condition
+        context = ""
+        if condition != "no_memory":
+            context = memory.retrieve(question)
+
+        # Generate answer
+        prediction, llm_ms = llm.answer(question, context)
+        total_llm_ms += llm_ms
+
+        # Score
+        em = exact_match(prediction, reference)
+        f1 = word_overlap_f1(prediction, reference)
+
+        subtasks.append(
+            SubtaskResult(
+                subtask_idx=idx,
+                question=question,
+                reference=reference,
+                prediction=prediction,
+                context=context,
+                exact_match=em,
+                word_overlap_f1=f1,
+                llm_ms=llm_ms,
+            )
+        )
+
+        # Store observation for next subtask
+        memory.observe(idx, question, prediction)
+
+    return TaskResult(
+        task_id=task["id"],
+        condition=condition,
+        subtasks=subtasks,
+        total_llm_ms=total_llm_ms,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="MemoryArena harness for MAG")
+    parser.add_argument(
+        "--samples",
+        type=int,
+        default=None,
+        help="Number of tasks to evaluate (default: all 221)",
+    )
+    parser.add_argument(
+        "--conditions",
+        type=str,
+        default="no_memory,passive,active",
+        help="Comma-separated list of conditions to run",
+    )
+    parser.add_argument(
+        "--output",
+        type=str,
+        default="results/memory_arena.json",
+        help="Output JSON file",
+    )
+    parser.add_argument(
+        "--llm-model",
+        type=str,
+        default="gpt-5.4",
+        help="LLM model",
+    )
+    parser.add_argument(
+        "--llm-url",
+        type=str,
+        default="https://api.openai.com/v1",
+        help="OpenAI-compatible API base",
+    )
+    parser.add_argument(
+        "--max-completion-tokens",
+        type=int,
+        default=512,
+        help="Max tokens per LLM call",
+    )
+    parser.add_argument(
+        "--home-dir",
+        type=str,
+        default=None,
+        help="MAG home directory",
+    )
+    args = parser.parse_args()
+
+    if not _HAS_DEPS:
+        print(
+            "ERROR: Missing dependencies. Run:\n"
+            "  pip install openai datasets",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Resolve API key
+    api_key = os.environ.get("OPENAI_API_KEY")
+    if not api_key and os.path.exists(".env.local"):
+        with open(".env.local") as f:
+            for line in f:
+                if line.startswith("OPENAI_API_KEY="):
+                    api_key = line.strip().split("=", 1)[1]
+                    break
+    if not api_key:
+        print("ERROR: OPENAI_API_KEY not found", file=sys.stderr)
+        return 1
+
+    # Load dataset
+    print("Loading MemoryArena progressive_search dataset...")
+    ds = load_dataset("ZexueHe/memoryarena", "progressive_search", split="test")
+    tasks = list(ds)
+    if args.samples is not None:
+        tasks = tasks[: args.samples]
+    print(f"Loaded {len(tasks)} tasks")
+
+    llm = LlmClient(
+        LlmConfig(
+            model=args.llm_model,
+            api_key=api_key,
+            base_url=args.llm_url,
+            max_completion_tokens=args.max_completion_tokens,
+        )
+    )
+
+    conditions = [c.strip() for c in args.conditions.split(",")]
+    print(f"Conditions: {conditions}")
+
+    all_results: List[Dict[str, Any]] = []
+
+    for condition in conditions:
+        print(f"\n{'='*60}")
+        print(f"Running condition: {condition}")
+        print(f"{'='*60}")
+
+        condition_results: List[Dict[str, Any]] = []
+
+        for i, task in enumerate(tasks, 1):
+            # Fresh MAG instance per condition to avoid cross-contamination
+            mcp = McpClient(home_dir=args.home_dir)
+            mcp.start()
+
+            if condition == "no_memory":
+                memory: Any = NoMemory()
+            elif condition == "passive":
+                memory = PassiveMemory(mcp)
+            elif condition == "active":
+                memory = ActiveMemory(mcp)
+            else:
+                print(f"ERROR: Unknown condition: {condition}", file=sys.stderr)
+                return 1
+
+            result = run_task(task, condition, memory, llm)
+
+            # Convert to serializable dict
+            condition_results.append(
+                {
+                    "task_id": result.task_id,
+                    "subtasks": [
+                        {
+                            "subtask_idx": s.subtask_idx,
+                            "question": s.question,
+                            "reference": s.reference,
+                            "prediction": s.prediction,
+                            "exact_match": s.exact_match,
+                            "word_overlap_f1": s.word_overlap_f1,
+                            "llm_ms": s.llm_ms,
+                        }
+                        for s in result.subtasks
+                    ],
+                    "total_llm_ms": result.total_llm_ms,
+                }
+            )
+
+            memory.close()
+            mcp.stop()
+
+            # Progress
+            avg_f1 = sum(s.word_overlap_f1 for s in result.subtasks) / len(
+                result.subtasks
+            )
+            print(
+                f"  [{i}/{len(tasks)}] Task {result.task_id} — "
+                f"subtasks={len(result.subtasks)} avg_f1={avg_f1:.2f}"
+            )
+
+        # Aggregate condition stats
+        total_subtasks = sum(len(r["subtasks"]) for r in condition_results)
+        total_em = sum(
+            s["exact_match"] for r in condition_results for s in r["subtasks"]
+        )
+        total_f1 = sum(
+            s["word_overlap_f1"] for r in condition_results for s in r["subtasks"]
+        )
+
+        summary = {
+            "condition": condition,
+            "tasks_evaluated": len(condition_results),
+            "subtasks_evaluated": total_subtasks,
+            "exact_match": total_em / total_subtasks if total_subtasks else 0.0,
+            "mean_f1": total_f1 / total_subtasks if total_subtasks else 0.0,
+            "tasks": condition_results,
+        }
+        all_results.append(summary)
+
+        print(f"\n{condition} summary:")
+        print(f"  Exact match: {summary['exact_match']:.2%}")
+        print(f"  Mean F1:     {summary['mean_f1']:.2%}")
+
+    # Write output
+    os.makedirs(os.path.dirname(args.output) or ".", exist_ok=True)
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(
+            {
+                "timestamp": time.time(),
+                "model": args.llm_model,
+                "conditions": all_results,
+            },
+            f,
+            indent=2,
+            ensure_ascii=False,
+        )
+
+    print(f"\nResults written to: {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/harness.rs
+++ b/src/harness.rs
@@ -1,0 +1,105 @@
+//! AgentMemoryHarness — minimal three-method interface between agents and MAG.
+//!
+//! This trait is intentionally small (observe / retrieve_context / trace) so
+//! that benchmarks and agent loops can swap storage implementations without
+//! changing their orchestration code.
+//!
+//! # Phase 2a scope
+//!
+//! - Trait definition only.
+//! - No in-process implementations yet (those ship with Phase 2b MemoryArena
+//!   integration).
+//! - The AMA-Bench adapter uses the Python-side harness via MCP stdio.
+
+use anyhow::Result;
+use serde_json::Value;
+
+/// A single turn in an agent trajectory.
+///
+/// All fields are optional — callers pass whatever is relevant for their
+/// domain (software engineering, web navigation, embodied AI, etc.).
+#[derive(Debug, Clone, Default)]
+pub struct AgentTurn {
+    /// Turn index within the episode.
+    pub turn_idx: usize,
+    /// Agent action (e.g. tool call, code edit, navigation command).
+    pub action: String,
+    /// Environment observation (e.g. tool output, test result, page HTML).
+    pub observation: String,
+    /// Unstructured metadata (timestamps, tool names, file paths, etc.).
+    pub metadata: Value,
+}
+
+impl AgentTurn {
+    /// Build a turn from action + observation text.
+    pub fn new(turn_idx: usize, action: impl Into<String>, observation: impl Into<String>) -> Self {
+        Self {
+            turn_idx,
+            action: action.into(),
+            observation: observation.into(),
+            metadata: Value::Null,
+        }
+    }
+
+    /// Attach metadata and return self for chaining.
+    pub fn with_metadata(mut self, metadata: Value) -> Self {
+        self.metadata = metadata;
+        self
+    }
+
+    /// Serialise to the AMA-Bench trajectory text format.
+    pub fn to_text(&self) -> String {
+        let mut parts = vec![format!("Step {}:", self.turn_idx)];
+        if !self.action.is_empty() {
+            parts.push(format!("Action: {}", self.action));
+        }
+        if !self.observation.is_empty() {
+            parts.push(format!("Observation: {}", self.observation));
+        }
+        parts.join("\n")
+    }
+}
+
+/// Minimal harness between an agent loop and a memory backend.
+///
+/// Implementations may use in-process storage (e.g. `SqliteStorage`) or
+/// communicate with a remote MAG server via MCP.
+pub trait AgentMemoryHarness: Send + Sync {
+    /// Ingest a single turn into memory.
+    fn observe(&self, turn: &AgentTurn) -> Result<()>;
+
+    /// Retrieve relevant context for a query.
+    ///
+    /// Callers compose the returned string into their prompts — the harness
+    /// does not perform injection itself.
+    fn retrieve_context(&self, query: &str) -> Result<String>;
+
+    /// Emit an unstructured JSON trace event.
+    ///
+    /// Events are appended to `~/.mag/traces/<run-id>.jsonl` by typical
+    /// implementations, but the trait does not prescribe a sink.
+    fn trace(&self, event: Value) -> Result<()>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn agent_turn_to_text() {
+        let turn = AgentTurn::new(3, "Edit src/main.rs", "Added println! for debugging");
+        let text = turn.to_text();
+        assert!(text.contains("Step 3:"));
+        assert!(text.contains("Action: Edit src/main.rs"));
+        assert!(text.contains("Observation: Added println! for debugging"));
+    }
+
+    #[test]
+    fn agent_turn_empty_fields_omitted() {
+        let turn = AgentTurn::new(0, "", "hello");
+        let text = turn.to_text();
+        assert!(text.contains("Step 0:"));
+        assert!(!text.contains("Action:"));
+        assert!(text.contains("Observation: hello"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod benchmarking;
 pub(crate) mod config_writer;
 #[cfg(feature = "daemon-http")]
 pub mod daemon;
+pub mod harness;
 pub mod memory_core;
 pub mod setup;
 #[cfg(feature = "substrate")]

--- a/src/memory_core/storage/sqlite/crud.rs
+++ b/src/memory_core/storage/sqlite/crud.rs
@@ -1,8 +1,13 @@
 use super::*;
 
-#[async_trait]
-impl Storage for SqliteStorage {
-    async fn store(&self, id: &str, data: &str, input: &MemoryInput) -> Result<()> {
+impl SqliteStorage {
+    pub(super) async fn store_inner(
+        &self,
+        id: &str,
+        data: &str,
+        input: &MemoryInput,
+        provided_embedding: Option<Vec<f32>>,
+    ) -> Result<()> {
         let tags_json =
             serde_json::to_string(&input.tags).context("failed to serialize tags to JSON")?;
         let metadata_json = serde_json::to_string(&input.metadata)
@@ -139,11 +144,12 @@ impl Storage for SqliteStorage {
                     return Ok::<_, anyhow::Error>((StoreOutcome::Deduped, Vec::new(), Vec::new()));
                 }
             }
-
             // ── Phase 2: Embedding (the real bottleneck, ~8ms) ──
-            let embedding_vec = embedder.embed(&data)?;
+            let embedding_vec = match provided_embedding {
+                Some(e) => e,
+                None => embedder.embed(&data)?,
+            };
             let embedding = encode_embedding(&embedding_vec);
-
             // ── Phase 3: Supersession detection ──
             let mut superseded_ids: Vec<String> = Vec::new();
             if let Some(ref event_type_value) = event_type
@@ -477,7 +483,12 @@ impl Storage for SqliteStorage {
         Ok(())
     }
 }
-
+#[async_trait]
+impl Storage for SqliteStorage {
+    async fn store(&self, id: &str, data: &str, input: &MemoryInput) -> Result<()> {
+        self.store_inner(id, data, input, None).await
+    }
+}
 #[async_trait]
 impl Retriever for SqliteStorage {
     async fn retrieve(&self, id: &str) -> Result<String> {

--- a/src/memory_core/storage/sqlite/storage.rs
+++ b/src/memory_core/storage/sqlite/storage.rs
@@ -181,6 +181,16 @@ impl SqliteStorage {
     pub async fn store(&self, id: &str, data: &str, input: &MemoryInput) -> Result<()> {
         <Self as Storage>::store(self, id, data, input).await
     }
+    #[allow(dead_code)]
+    pub async fn store_with_embedding(
+        &self,
+        id: &str,
+        data: &str,
+        input: &MemoryInput,
+        embedding: Vec<f32>,
+    ) -> Result<()> {
+        self.store_inner(id, data, input, Some(embedding)).await
+    }
 
     #[allow(dead_code)]
     pub async fn update(&self, id: &str, input: &MemoryUpdate) -> Result<()> {

--- a/src/substrate/enrichment_impl.rs
+++ b/src/substrate/enrichment_impl.rs
@@ -127,6 +127,13 @@ impl Scorer for crate::substrate::traits::CrossEncoderScorer {
         .await
         .context("spawn_blocking join error")??;
 
+        if ids.len() != ce_scores.len() {
+            anyhow::bail!(
+                "cross-encoder score count mismatch: ids={} ce_scores={}",
+                ids.len(),
+                ce_scores.len()
+            );
+        }
         for (id, ce_score) in ids.iter().zip(ce_scores.iter()) {
             if let Some(candidate) = candidates.get_mut(id) {
                 candidate.score = alpha * candidate.score + (1.0 - alpha) * f64::from(*ce_score);

--- a/src/substrate/fusion_impl.rs
+++ b/src/substrate/fusion_impl.rs
@@ -30,12 +30,11 @@ impl FusionStrategy for super::traits::RrfFusion {
                 } else if strategy_name == "fts" {
                     fts_ranks.insert(id.clone(), rank);
                 }
-
                 if let Some(existing) = output.get_mut(id) {
-                    existing.score += candidate.score * rrf_score;
+                    existing.score += rrf_score;
                 } else {
                     let mut merged = candidate.clone();
-                    merged.score *= rrf_score;
+                    merged.score = rrf_score;
                     output.insert(id.clone(), merged);
                 }
             }

--- a/src/substrate/ingestion_impl.rs
+++ b/src/substrate/ingestion_impl.rs
@@ -17,19 +17,14 @@ impl IngestionPipeline for EmbedAndExtractPipeline {
         } else {
             ctx.assigned_id
         };
-
         let content = ctx.input.content.clone();
         let embedder = Arc::clone(&self.embedder);
-
-        // TODO: The embedding is computed here but MemoryStore::store does not accept
-        // a pre-computed embedding, so it is recomputed inside SqliteStorage::store.
-        // Extend MemoryStore with a store_with_embedding method to avoid double work.
-        let _embedding = tokio::task::spawn_blocking(move || embedder.embed(&content))
+        let embedding = tokio::task::spawn_blocking(move || embedder.embed(&content))
             .await
             .map_err(|e| anyhow::anyhow!("spawn_blocking join error: {e:?}"))??;
-
-        store.store(&id, &ctx.input.content, &ctx.input).await?;
-
+        store
+            .store_with_embedding(&id, &ctx.input.content, &ctx.input, embedding)
+            .await?;
         Ok(id)
     }
 }

--- a/src/substrate/lifecycle_impl.rs
+++ b/src/substrate/lifecycle_impl.rs
@@ -14,16 +14,14 @@ impl LifecyclePolicy for crate::substrate::traits::TtlExpirationPolicy {
         let expires_at = match candidate.result.metadata.get("expires_at") {
             Some(v) => match v.as_str() {
                 Some(s) => s,
-                None => return true,
+                None => return false,
             },
             None => return true,
         };
-
         let expires = match DateTime::parse_from_rfc3339(expires_at) {
             Ok(dt) => dt.with_timezone(&Utc),
-            Err(_) => return true,
+            Err(_) => return false,
         };
-
         expires >= Utc::now()
     }
 

--- a/src/substrate/orchestrators.rs
+++ b/src/substrate/orchestrators.rs
@@ -42,7 +42,11 @@ impl SearchPipeline {
     ///   5. Apply abstention gate (max text_overlap < abstention_min_text → return empty).
     ///   6. Sort descending by score, truncate to `ctx.limit`.
     ///   7. Map to `SemanticResult`.
-    pub async fn search(&self, ctx: QueryContext) -> Result<Vec<SemanticResult>> {
+    pub async fn search(&self, mut ctx: QueryContext) -> Result<Vec<SemanticResult>> {
+        // Pre-compute query tokens once so scorers don't re-tokenize independently.
+        if ctx.query_tokens.is_none() {
+            ctx.query_tokens = Some(crate::memory_core::scoring::token_set(&ctx.query, 3));
+        }
         // Step 1: Run all retrieval strategies concurrently.
         let mut candidate_sets: HashMap<&str, CandidateSet> =
             HashMap::with_capacity(self.retrieval.len());
@@ -51,16 +55,13 @@ impl SearchPipeline {
         for (strategy, result) in self.retrieval.iter().zip(sets) {
             candidate_sets.insert(strategy.name(), result?);
         }
-
         // Step 2: Fuse candidates into a single ranked list.
         let fused = self.fusion.fuse(candidate_sets, &ctx.scoring_params);
-
         // Step 3: Convert to HashMap for scorer chain.
         let mut candidates: HashMap<String, ScoredCandidate> = fused
             .into_iter()
             .map(|c| (c.result.id.clone(), c))
             .collect();
-
         // Step 4: Apply each scorer in order.
         for scorer in &self.scorers {
             scorer.score_batch(&mut candidates, &ctx).await?;
@@ -126,9 +127,9 @@ pub struct WritePipeline {
 }
 
 impl WritePipeline {
-    pub async fn ingest(&self, input: MemoryInput) -> Result<String> {
+    pub async fn ingest(&self, mut input: MemoryInput) -> Result<String> {
         let ctx = WriteContext {
-            assigned_id: input.id.clone().unwrap_or_default(),
+            assigned_id: input.id.take().unwrap_or_default(),
             embedding: None,
             input,
         };

--- a/src/substrate/scoring_impl.rs
+++ b/src/substrate/scoring_impl.rs
@@ -18,19 +18,21 @@ impl Scorer for MultiFactorScorer {
         candidates: &mut HashMap<String, ScoredCandidate>,
         ctx: &QueryContext,
     ) -> Result<()> {
-        let tokens = ctx
-            .query_tokens
-            .clone()
-            .unwrap_or_else(|| crate::memory_core::scoring::token_set(&ctx.query, 3));
-
+        let default_tokens;
+        let tokens = match &ctx.query_tokens {
+            Some(t) => t,
+            None => {
+                default_tokens = crate::memory_core::scoring::token_set(&ctx.query, 3);
+                &default_tokens
+            }
+        };
         refine_scores(
             candidates,
-            &tokens,
+            tokens,
             &ctx.opts,
             ctx.opts.explain.unwrap_or(false),
             &ctx.scoring_params,
         );
-
         Ok(())
     }
 }

--- a/src/substrate/store_impl.rs
+++ b/src/substrate/store_impl.rs
@@ -40,7 +40,15 @@ impl MemoryStore for SqliteStorage {
     async fn store(&self, id: &str, data: &str, input: &MemoryInput) -> Result<()> {
         self.store(id, data, input).await
     }
-
+    async fn store_with_embedding(
+        &self,
+        id: &str,
+        data: &str,
+        input: &MemoryInput,
+        embedding: Vec<f32>,
+    ) -> Result<()> {
+        self.store_with_embedding(id, data, input, embedding).await
+    }
     async fn retrieve(&self, id: &str) -> Result<String> {
         self.retrieve(id).await
     }

--- a/src/substrate/traits.rs
+++ b/src/substrate/traits.rs
@@ -22,6 +22,13 @@ use std::sync::Arc;
 pub trait MemoryStore: Send + Sync {
     // ── Core CRUD ─────────────────────────────────────────────────────────
     async fn store(&self, id: &str, data: &str, input: &MemoryInput) -> Result<()>;
+    async fn store_with_embedding(
+        &self,
+        id: &str,
+        data: &str,
+        input: &MemoryInput,
+        embedding: Vec<f32>,
+    ) -> Result<()>;
     async fn retrieve(&self, id: &str) -> Result<String>;
     async fn delete(&self, id: &str) -> Result<bool>;
     async fn update(&self, id: &str, update: &MemoryUpdate) -> Result<()>;


### PR DESCRIPTION
## Summary

Completes the substrate campaign's **Phase 2 (Implement)** and resolves all outstanding adversarial-review findings recorded in `ISSUE_TRACKER.md`.

### Changes

**1. chore(gitignore): ignore python caches and benchmark results**
- Adds `__pycache__/`, `*.pyc`, and `/results/` to `.gitignore`
- Cleans up build/run noise from Python benchmark harnesses

**2. fix(substrate): resolve adversarial review findings (10 files)**
| File | Fix | Finding |
|---|---|---|
| `fusion_impl.rs` | Pure RRF without raw-score scaling | R1 Warning 1 |
| `orchestrators.rs` | Pre-compute `query_tokens`; `input.id.take()` instead of clone | R1 Warning 2 / R2 Warning 2 / R1 Nit 2 / R2 Nit 1 |
| `enrichment_impl.rs` | `bail!` on cross-encoder length mismatch | R1 Warning 3 / R2 Warning 1 |
| `lifecycle_impl.rs` | TTL fail-closed: malformed `expires_at` → `is_alive = false` | R1 Warning 4 |
| `scoring_impl.rs` | Borrow `query_tokens` instead of cloning | R1 Nit 1 |
| `ingestion_impl.rs` | Pass pre-computed embedding via `store_with_embedding` | R2 Critical 1 + discovered double-compute |
| `traits.rs` | Add `MemoryStore::store_with_embedding` | (supports above) |
| `store_impl.rs` | Implement `store_with_embedding` | (supports above) |
| `crud.rs` | Extract `store_inner` with optional embedding | (supports above) |
| `storage.rs` | Add inherent `store_with_embedding` → `store_inner` | (supports above) |

**3. feat(harness): AMA-Bench agent memory harness scaffold (Phase 2a)**
- Wires `pub mod harness;` into `src/lib.rs`
- Adds `AgentMemoryHarness` trait + `AgentTurn` struct with tests
- Stages 5 Python files for AMA-Bench / MemoryArena integration

### Verification

- `cargo fmt --all -- --check` ✅ clean
- `cargo clippy --all-targets --all-features -- -D warnings` ✅ clean
- `cargo test --all-features` ✅ 1257 passed
- `cargo build` (default features, substrate OFF) ✅ OK

### Benchmark gate

No gate required — changes touch `substrate/**` and `storage/**` but not `scoring/**` or `search*` paths that trigger the CI benchmark gate. The `advanced_search` hot path is unchanged (Phase 3 wiring not yet done).

### Next step

**Phase 3 Wire**: delegate `SqliteStorage::advanced_search` to `substrate::SearchPipeline::search`, enable `substrate` by default, benchmark-gate for zero regression.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes Substrate Phase 2 by resolving all adversarial-review findings and scaffolds an AMA-Bench/MemoryArena harness. This aligns RRF, removes double embedding work, hardens TTL and cross-encoder checks, and introduces a minimal `AgentMemoryHarness` for upcoming benchmarks.

- **Bug Fixes**
  - RRF is now pure (no raw-score scaling).
  - Query tokens are computed once; scorers borrow instead of cloning.
  - Cross-encoder bails on id/score length mismatch.
  - TTL policy fails closed on malformed or invalid `expires_at`.
  - `WritePipeline::ingest` avoids cloning IDs via `input.id.take()`.
  - `EmbedAndExtractPipeline` passes precomputed embeddings to storage (see Migration).

- **Migration**
  - Add `MemoryStore::store_with_embedding(id, data, input, embedding)` to your store implementations.
  - Until you support precomputed embeddings, you may delegate this method to your existing `store` path.

<sup>Written for commit 9429e0df611625f657b9feb7e3436dcd05ad873c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/George-RD/mag/pull/347?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

