### PR TITLE
Phase 2: LLM-powered extraction quality and search ranking improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,3 +107,8 @@ required-features = ["real-embeddings"]
 name = "substrate_bench"
 path = "benches/substrate_bench.rs"
 required-features = ["substrate"]
+
+[[bin]]
+name = "phase2_bench"
+path = "benches/phase2_bench.rs"
+required-features = ["llm", "substrate"]

--- a/autoresearch.sh
+++ b/autoresearch.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Build and run the substrate search pipeline benchmark.
-# Emits METRIC lines for autoresearch consumption.
+# Build and run the Phase 2 extraction quality benchmark.
+# Emits METRIC hit_rate for autoresearch consumption.
 
-FEATURES="substrate"
-if cargo build --release --bin substrate_bench --features "$FEATURES" 2>&1; then
-    ./target/release/substrate_bench "$@"
+FEATURES="llm,substrate"
+if cargo build --release --bin phase2_bench --features "$FEATURES" 2>&1; then
+    ./target/release/phase2_bench "$@"
 else
     echo "Build failed" >&2
     exit 1

--- a/benches/phase2_bench.rs
+++ b/benches/phase2_bench.rs
@@ -1,0 +1,3350 @@
+//! Phase 2 benchmark: measure retrieval quality from LLM-extracted metadata.
+//!
+//! Fast, deterministic benchmark for autoresearch iteration.
+//! Uses PlaceholderEmbedder + MockLlmBackend so no real LLM calls are needed.
+//!
+//! ## Usage
+//!
+//! ```bash
+//! cargo run --release --bin phase2_bench --features llm,substrate
+//! ```
+//!
+//! ## Output
+//!
+//! Prints `METRIC hit_rate=<0..1>` on stdout for the autoresearch harness.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use anyhow::Result;
+use async_trait::async_trait;
+use mag::memory_core::{
+    MemoryInput, SearchOptions, embedder::PlaceholderEmbedder, llm::LlmBackend,
+    storage::sqlite::SqliteStorage,
+};
+use mag::substrate::{
+    EmbedAndExtractPipeline, IngestionPipeline, MemoryStore, WriteContext,
+    extraction::{ExtractedEntity, ExtractedRelationship, ExtractedTemporal, ExtractionResult},
+};
+
+// ---------------------------------------------------------------------------
+// Mock LLM backend — returns deterministic extraction results
+// ---------------------------------------------------------------------------
+
+struct MockLlmBackend {
+    responses: HashMap<String, ExtractionResult>,
+}
+
+impl MockLlmBackend {
+    fn new(responses: HashMap<String, ExtractionResult>) -> Self {
+        Self { responses }
+    }
+}
+
+#[async_trait]
+impl LlmBackend for MockLlmBackend {
+    async fn complete(&self, _prompt: &str, _system: Option<&str>) -> Result<String> {
+        Ok(String::new())
+    }
+
+    async fn complete_structured(
+        &self,
+        _prompt: &str,
+        _system: Option<&str>,
+        _schema: &serde_json::Value,
+    ) -> Result<serde_json::Value> {
+        // The extraction module calls complete_structured with the content as prompt.
+        // We look up the response by prompt text.
+        if let Some(result) = self.responses.get(_prompt) {
+            Ok(serde_json::to_value(result)?)
+        } else {
+            Ok(serde_json::json!({}))
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Synthetic dataset
+// ---------------------------------------------------------------------------
+
+fn build_dataset() -> Vec<(MemoryInput, ExtractionResult)> {
+    vec![
+        (
+            MemoryInput {
+                content: "Alice and Bob met on 2025-01-15 to discuss Project Alpha using React.".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![
+                    ExtractedEntity { name: "Alice".into(), entity_type: "person".into() },
+                    ExtractedEntity { name: "Bob".into(), entity_type: "person".into() },
+                    ExtractedEntity { name: "Project Alpha".into(), entity_type: "project".into() },
+                    ExtractedEntity { name: "React".into(), entity_type: "tool".into() },
+                ],
+                facts: vec![
+                    "Alice and Bob met to discuss Project Alpha".into(),
+                    "React is used for Project Alpha".into(),
+                ],
+                relationships: vec![],
+                temporal: vec![
+                    ExtractedTemporal { expression: "2025-01-15".into(), normalized: Some("2025-01-15".into()) },
+                ],
+            topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The deployment to production failed because the Docker container ran out of memory on 2025-03-10.".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![
+                    ExtractedEntity { name: "Docker".into(), entity_type: "tool".into() },
+                    ExtractedEntity { name: "production".into(), entity_type: "place".into() },
+                ],
+                facts: vec![
+                    "Deployment to production failed".into(),
+                    "Docker container ran out of memory".into(),
+                ],
+                relationships: vec![],
+                temporal: vec![
+                    ExtractedTemporal { expression: "2025-03-10".into(), normalized: Some("2025-03-10".into()) },
+                ],
+            topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "Charlie refactored the authentication service to use OAuth2 instead of basic auth.".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![
+                    ExtractedEntity { name: "Charlie".into(), entity_type: "person".into() },
+                    ExtractedEntity { name: "OAuth2".into(), entity_type: "tool".into() },
+                    ExtractedEntity { name: "authentication service".into(), entity_type: "project".into() },
+                ],
+                facts: vec![
+                    "Charlie refactored the authentication service".into(),
+                    "OAuth2 replaces basic auth".into(),
+                ],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The CI pipeline was migrated from Jenkins to GitHub Actions in December 2023.".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![
+                    ExtractedEntity { name: "Jenkins".into(), entity_type: "tool".into() },
+                    ExtractedEntity { name: "GitHub Actions".into(), entity_type: "tool".into() },
+                    ExtractedEntity { name: "CI pipeline".into(), entity_type: "project".into() },
+                ],
+                facts: vec![
+                    "CI pipeline migrated from Jenkins to GitHub Actions".into(),
+                ],
+                relationships: vec![],
+                temporal: vec![
+                    ExtractedTemporal { expression: "December 2023".into(), normalized: Some("2025-09-01".into()) },
+                ],
+            topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "Dana presented the quarterly review to the board on 2025-06-01. Revenue was up 15%.".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![
+                    ExtractedEntity { name: "Dana".into(), entity_type: "person".into() },
+                    ExtractedEntity { name: "board".into(), entity_type: "organization".into() },
+                ],
+                facts: vec![
+                    "Dana presented quarterly review to the board".into(),
+                    "Revenue was up 15%".into(),
+                ],
+                relationships: vec![],
+                temporal: vec![
+                    ExtractedTemporal { expression: "2025-06-01".into(), normalized: Some("2025-06-01".into()) },
+                ],
+            topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The new caching layer uses Redis with a TTL of 5 minutes for session data.".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![
+                    ExtractedEntity { name: "Redis".into(), entity_type: "tool".into() },
+                    ExtractedEntity { name: "caching layer".into(), entity_type: "project".into() },
+                ],
+                facts: vec![
+                    "Caching layer uses Redis".into(),
+                    "TTL is 5 minutes for session data".into(),
+                ],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "Eve and Frank pair-programmed the GraphQL resolver on 2025-02-20.".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![
+                    ExtractedEntity { name: "Eve".into(), entity_type: "person".into() },
+                    ExtractedEntity { name: "Frank".into(), entity_type: "person".into() },
+                    ExtractedEntity { name: "GraphQL resolver".into(), entity_type: "project".into() },
+                ],
+                facts: vec![
+                    "Eve and Frank pair-programmed the GraphQL resolver".into(),
+                ],
+                relationships: vec![],
+                temporal: vec![
+                    ExtractedTemporal { expression: "2025-02-20".into(), normalized: Some("2025-02-20".into()) },
+                ],
+            topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The database migration from PostgreSQL 13 to 15 was completed by the infrastructure team.".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![
+                    ExtractedEntity { name: "PostgreSQL".into(), entity_type: "tool".into() },
+                    ExtractedEntity { name: "infrastructure team".into(), entity_type: "organization".into() },
+                ],
+                facts: vec![
+                    "Database migration from PostgreSQL 13 to 15 completed".into(),
+                ],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "Grace implemented the new search algorithm using BM25 and vector similarity on 2025-04-10.".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![
+                    ExtractedEntity { name: "Grace".into(), entity_type: "person".into() },
+                    ExtractedEntity { name: "BM25".into(), entity_type: "tool".into() },
+                    ExtractedEntity { name: "search algorithm".into(), entity_type: "project".into() },
+                ],
+                facts: vec![
+                    "Grace implemented new search algorithm".into(),
+                    "Uses BM25 and vector similarity".into(),
+                ],
+                relationships: vec![],
+                temporal: vec![
+                    ExtractedTemporal { expression: "2025-04-10".into(), normalized: Some("2025-04-10".into()) },
+                ],
+            topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The frontend team switched from Vue to Svelte for the dashboard rewrite.".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![
+                    ExtractedEntity { name: "Vue".into(), entity_type: "tool".into() },
+                    ExtractedEntity { name: "Svelte".into(), entity_type: "tool".into() },
+                    ExtractedEntity { name: "frontend team".into(), entity_type: "organization".into() },
+                    ExtractedEntity { name: "dashboard".into(), entity_type: "project".into() },
+                ],
+                facts: vec![
+                    "Frontend team switched from Vue to Svelte".into(),
+                    "Dashboard is being rewritten".into(),
+                ],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        // -- Relationship memories: same entity, different relationships --
+        (
+            MemoryInput {
+                content: "The gathering was successful. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![ExtractedEntity { name: "Alice".into(), entity_type: "person".into() }],
+                facts: vec!["Gathering was successful".into()],
+                relationships: vec![
+                    ExtractedRelationship { subject: "Alice".into(), predicate: "led".into(), object: "gathering".into(), when: None },
+                ],
+                temporal: vec![],
+                topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The gathering was successful. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![ExtractedEntity { name: "Alice".into(), entity_type: "person".into() }],
+                facts: vec!["Gathering was successful".into()],
+                relationships: vec![
+                    ExtractedRelationship { subject: "Alice".into(), predicate: "facilitated".into(), object: "gathering".into(), when: None },
+                ],
+                temporal: vec![],
+                topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The assignment was completed. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![ExtractedEntity { name: "Charlie".into(), entity_type: "person".into() }],
+                facts: vec!["Assignment was completed".into()],
+                relationships: vec![
+                    ExtractedRelationship { subject: "Charlie".into(), predicate: "presented".into(), object: "assignment".into(), when: None },
+                ],
+                temporal: vec![],
+                topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The assignment was completed. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![ExtractedEntity { name: "Charlie".into(), entity_type: "person".into() }],
+                facts: vec!["Assignment was completed".into()],
+                relationships: vec![
+                    ExtractedRelationship { subject: "Charlie".into(), predicate: "reviewed".into(), object: "assignment".into(), when: None },
+                ],
+                temporal: vec![],
+                topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The work finished on schedule. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![ExtractedEntity { name: "Eve".into(), entity_type: "person".into() }],
+                facts: vec!["Work finished on schedule".into()],
+                relationships: vec![
+                    ExtractedRelationship { subject: "Eve".into(), predicate: "developed".into(), object: "work".into(), when: None },
+                ],
+                temporal: vec![],
+                topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The work finished on schedule. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![ExtractedEntity { name: "Eve".into(), entity_type: "person".into() }],
+                facts: vec!["Work finished on schedule".into()],
+                relationships: vec![
+                    ExtractedRelationship { subject: "Eve".into(), predicate: "tested".into(), object: "work".into(), when: None },
+                ],
+                temporal: vec![],
+                topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The review was thorough. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![ExtractedEntity { name: "Grace".into(), entity_type: "person".into() }],
+                facts: vec!["Review was thorough".into()],
+                relationships: vec![
+                    ExtractedRelationship { subject: "Grace".into(), predicate: "approved".into(), object: "review".into(), when: None },
+                ],
+                temporal: vec![],
+                topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The review was thorough. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![ExtractedEntity { name: "Grace".into(), entity_type: "person".into() }],
+                facts: vec!["Review was thorough".into()],
+                relationships: vec![
+                    ExtractedRelationship { subject: "Grace".into(), predicate: "rejected".into(), object: "review".into(), when: None },
+                ],
+                temporal: vec![],
+                topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The procedure completed yesterday. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![ExtractedEntity { name: "Ivan".into(), entity_type: "person".into() }],
+                facts: vec!["Procedure completed yesterday".into()],
+                relationships: vec![
+                    ExtractedRelationship { subject: "Ivan".into(), predicate: "deployed".into(), object: "procedure".into(), when: None },
+                ],
+                temporal: vec![],
+                topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The procedure completed yesterday. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![ExtractedEntity { name: "Ivan".into(), entity_type: "person".into() }],
+                facts: vec!["Procedure completed yesterday".into()],
+                relationships: vec![
+                    ExtractedRelationship { subject: "Ivan".into(), predicate: "monitored".into(), object: "procedure".into(), when: None },
+                ],
+                temporal: vec![],
+                topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        // -- Temporal memories: identical content, different dates (4 per group) --
+        (
+            MemoryInput {
+                content: "The zephyr conclave convened. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![ExtractedTemporal { expression: "January 15 2025".into(), normalized: Some("2025-01-15".into()) }],
+            topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The zephyr conclave convened. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![ExtractedTemporal { expression: "March 10 2025".into(), normalized: Some("2025-03-10".into()) }],
+            topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The zephyr conclave convened. (C)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![ExtractedTemporal { expression: "May 20 2025".into(), normalized: Some("2025-05-20".into()) }],
+            topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The zephyr conclave convened. (D)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![ExtractedTemporal { expression: "July 1 2025".into(), normalized: Some("2025-07-01".into()) }],
+            topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The aurora summit transpired. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![ExtractedTemporal { expression: "February 20 2025".into(), normalized: Some("2025-02-20".into()) }],
+            topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The aurora summit transpired. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![ExtractedTemporal { expression: "April 10 2025".into(), normalized: Some("2025-04-10".into()) }],
+            topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The aurora summit transpired. (C)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![ExtractedTemporal { expression: "June 15 2025".into(), normalized: Some("2025-06-15".into()) }],
+            topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The aurora summit transpired. (D)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![ExtractedTemporal { expression: "August 1 2025".into(), normalized: Some("2025-08-01".into()) }],
+            topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The nexus forum assembled. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![ExtractedTemporal { expression: "October 10 2025".into(), normalized: Some("2025-10-10".into()) }],
+            topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The nexus forum assembled. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![ExtractedTemporal { expression: "November 20 2025".into(), normalized: Some("2025-11-20".into()) }],
+            topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The nexus forum assembled. (C)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![ExtractedTemporal { expression: "December 25 2025".into(), normalized: Some("2025-12-25".into()) }],
+            topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The nexus forum assembled. (D)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![ExtractedTemporal { expression: "July 4 2025".into(), normalized: Some("2025-07-04".into()) }],
+            topics: vec![],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        // -- Topic memories: identical vague content, different topics --
+        (
+            MemoryInput {
+                content: "The discussion covered various points. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec!["architecture".into()],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The discussion covered various points. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec!["security".into()],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The discussion covered various points. (C)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec!["performance".into()],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The discussion covered various points. (D)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec!["refactoring".into()],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The session addressed multiple concerns. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec!["deployment".into()],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The session addressed multiple concerns. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec!["monitoring".into()],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The session addressed multiple concerns. (C)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec!["incident".into()],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The session addressed multiple concerns. (D)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec!["postmortem".into()],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The meeting explored different angles. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec!["planning".into()],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The meeting explored different angles. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec!["review".into()],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The meeting explored different angles. (C)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec!["retrospective".into()],
+            sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The meeting explored different angles. (D)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec!["roadmap".into()],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        // -- Sentiment memories: vague content, different sentiments --
+        (
+            MemoryInput {
+                content: "The luminary event transpired. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: Some("positive".into()),
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The luminary event transpired. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: Some("negative".into()),
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The luminary event transpired. (C)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: Some("neutral".into()),
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The luminary event transpired. (D)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: Some("positive".into()),
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The stellar outcome emerged. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: Some("negative".into()),
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The stellar outcome emerged. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: Some("positive".into()),
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The stellar outcome emerged. (C)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: Some("neutral".into()),
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The stellar outcome emerged. (D)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: Some("negative".into()),
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The quantum result manifested. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: Some("neutral".into()),
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The quantum result manifested. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: Some("positive".into()),
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The quantum result manifested. (C)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: Some("negative".into()),
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The quantum result manifested. (D)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: Some("neutral".into()),
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        // -- Action memories: vague content, different actions --
+        (
+            MemoryInput {
+                content: "The paradigm shift occurred. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec!["deployed".into()],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The paradigm shift occurred. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec!["tested".into()],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The paradigm shift occurred. (C)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec!["reviewed".into()],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The paradigm shift occurred. (D)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec!["migrated".into()],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The catalyst emerged. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec!["refactored".into()],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The catalyst emerged. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec!["optimized".into()],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The catalyst emerged. (C)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec!["debugged".into()],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The catalyst emerged. (D)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec!["documented".into()],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The milestone arrived. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec!["analyzed".into()],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The milestone arrived. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec!["implemented".into()],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The milestone arrived. (C)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec!["verified".into()],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The milestone arrived. (D)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec!["deprecated".into()],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        // -- Location memories: vague content, different locations --
+        (
+            MemoryInput {
+                content: "The encounter unfolded. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec!["tokyo".into()],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The encounter unfolded. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec!["berlin".into()],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The encounter unfolded. (C)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec!["sydney".into()],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The encounter unfolded. (D)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec!["cairo".into()],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The revelation surfaced. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec!["mumbai".into()],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The revelation surfaced. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec!["lagos".into()],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The revelation surfaced. (C)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec!["oslo".into()],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The revelation surfaced. (D)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec!["lima".into()],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The assembly formed. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec!["dubai".into()],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The assembly formed. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec!["seoul".into()],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The assembly formed. (C)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec!["prague".into()],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The assembly formed. (D)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec!["helsinki".into()],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        // -- Decision memories: vague content, different decisions --
+        (
+            MemoryInput {
+                content: "The deliberation concluded. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec!["deferred".into()],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The deliberation concluded. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec!["accepted".into()],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The deliberation concluded. (C)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec!["revised".into()],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The deliberation concluded. (D)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec!["approved".into()],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The negotiation ended. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec!["escalated".into()],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The negotiation ended. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec!["delegated".into()],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The negotiation ended. (C)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec!["consolidated".into()],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The negotiation ended. (D)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec!["rejected".into()],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The evaluation finished. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec!["expedited".into()],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The evaluation finished. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec!["suspended".into()],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The evaluation finished. (C)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec!["prioritized".into()],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The evaluation finished. (D)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec!["postponed".into()],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        // -- Question memories: vague content, different questions --
+        (
+            MemoryInput {
+                content: "The inquiry arose. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec!["pending".into()],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The inquiry arose. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec!["disputed".into()],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The inquiry arose. (C)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec!["verified".into()],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The inquiry arose. (D)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec!["resolved".into()],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The concern emerged. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec!["dismissed".into()],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The concern emerged. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec!["escalated".into()],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The concern emerged. (C)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec!["deferred".into()],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The concern emerged. (D)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec!["validated".into()],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The matter appeared. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec!["assigned".into()],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The matter appeared. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec!["transferred".into()],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The matter appeared. (C)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec!["tabled".into()],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The matter appeared. (D)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec!["clarified".into()],
+                status: None,
+            },
+        ),
+        // -- Cross-cutting memories: identical content, multi-dimensional tags --
+        (
+            MemoryInput {
+                content: "The initiative advanced. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![ExtractedEntity { name: "xander".into(), entity_type: "person".into() }],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec!["architecture".into()],
+                sentiment: None,
+                actions: vec!["reviewed".into()],
+                locations: vec!["tokyo".into()],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The initiative advanced. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![ExtractedEntity { name: "xander".into(), entity_type: "person".into() }],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec!["architecture".into()],
+                sentiment: None,
+                actions: vec!["deployed".into()],
+                locations: vec!["berlin".into()],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The initiative advanced. (C)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![ExtractedEntity { name: "yara".into(), entity_type: "person".into() }],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec!["architecture".into()],
+                sentiment: None,
+                actions: vec!["reviewed".into()],
+                locations: vec!["tokyo".into()],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The initiative advanced. (D)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![ExtractedEntity { name: "xander".into(), entity_type: "person".into() }],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec!["design".into()],
+                sentiment: None,
+                actions: vec!["reviewed".into()],
+                locations: vec!["tokyo".into()],
+                decisions: vec!["approved".into()],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The endeavor progressed. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![ExtractedEntity { name: "zara".into(), entity_type: "person".into() }],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec!["security".into()],
+                sentiment: None,
+                actions: vec!["tested".into()],
+                locations: vec!["cairo".into()],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The endeavor progressed. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![ExtractedEntity { name: "zara".into(), entity_type: "person".into() }],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec!["security".into()],
+                sentiment: None,
+                actions: vec!["optimized".into()],
+                locations: vec!["lima".into()],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The endeavor progressed. (C)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![ExtractedEntity { name: "wren".into(), entity_type: "person".into() }],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec!["security".into()],
+                sentiment: None,
+                actions: vec!["tested".into()],
+                locations: vec!["cairo".into()],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The endeavor progressed. (D)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![ExtractedEntity { name: "zara".into(), entity_type: "person".into() }],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec!["performance".into()],
+                sentiment: None,
+                actions: vec!["tested".into()],
+                locations: vec!["cairo".into()],
+                decisions: vec!["rejected".into()],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        // -- Cross-cutting group 3: identical content, multi-dimensional tags --
+        (
+            MemoryInput {
+                content: "The milestone achieved. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![ExtractedEntity { name: "quinn".into(), entity_type: "person".into() }],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec!["performance".into()],
+                sentiment: None,
+                actions: vec!["optimized".into()],
+                locations: vec!["dublin".into()],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The milestone achieved. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![ExtractedEntity { name: "quinn".into(), entity_type: "person".into() }],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec!["performance".into()],
+                sentiment: None,
+                actions: vec!["tested".into()],
+                locations: vec!["dublin".into()],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The milestone achieved. (C)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![ExtractedEntity { name: "quinn".into(), entity_type: "person".into() }],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec!["security".into()],
+                sentiment: None,
+                actions: vec!["optimized".into()],
+                locations: vec!["dublin".into()],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The milestone achieved. (D)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![ExtractedEntity { name: "quinn".into(), entity_type: "person".into() }],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec!["performance".into()],
+                sentiment: None,
+                actions: vec!["optimized".into()],
+                locations: vec!["dublin".into()],
+                decisions: vec!["approved".into()],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        // -- Cross-cutting group 4: identical content, multi-dimensional tags --
+        (
+            MemoryInput {
+                content: "The deadline approached. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![ExtractedEntity { name: "tessa".into(), entity_type: "person".into() }],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec!["backend".into()],
+                sentiment: None,
+                actions: vec!["refactored".into()],
+                locations: vec!["mumbai".into()],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The deadline approached. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![ExtractedEntity { name: "tessa".into(), entity_type: "person".into() }],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec!["backend".into()],
+                sentiment: None,
+                actions: vec!["deployed".into()],
+                locations: vec!["mumbai".into()],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The deadline approached. (C)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![ExtractedEntity { name: "tessa".into(), entity_type: "person".into() }],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec!["frontend".into()],
+                sentiment: None,
+                actions: vec!["refactored".into()],
+                locations: vec!["mumbai".into()],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The deadline approached. (D)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![ExtractedEntity { name: "tessa".into(), entity_type: "person".into() }],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec!["backend".into()],
+                sentiment: None,
+                actions: vec!["refactored".into()],
+                locations: vec!["mumbai".into()],
+                decisions: vec!["expedited".into()],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        // -- Status memories: vague content, different statuses --
+        (
+            MemoryInput {
+                content: "The verdict rendered. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: Some("pending".into()),
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The verdict rendered. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: Some("blocked".into()),
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The verdict rendered. (C)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: Some("in-progress".into()),
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The verdict rendered. (D)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: Some("completed".into()),
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The analysis wrapped. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: Some("cancelled".into()),
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The analysis wrapped. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: Some("deferred".into()),
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The analysis wrapped. (C)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: Some("pending".into()),
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The analysis wrapped. (D)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: Some("blocked".into()),
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The sprint ended. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: Some("in-progress".into()),
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The sprint ended. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: Some("completed".into()),
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The sprint ended. (C)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: Some("cancelled".into()),
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The sprint ended. (D)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: Some("deferred".into()),
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The team built the payment module. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The team tested the payment module. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The team deployed the payment module. (C)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The team patched the payment module. (D)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The alpha system was built. (A)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The beta system was tested. (B)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The gamma system was deployed. (C)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "The alpha beta system was fixed. (D)".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "Priority evaluation item (A)".to_string(),
+                importance: 0.2,
+                tags: vec!["topic:priority-evaluation".to_string()],
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "Priority evaluation item (B)".to_string(),
+                importance: 0.4,
+                tags: vec!["topic:priority-evaluation".to_string()],
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "Priority evaluation item (C)".to_string(),
+                importance: 0.6,
+                tags: vec!["topic:priority-evaluation".to_string()],
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "Priority evaluation item (D)".to_string(),
+                importance: 0.8,
+                tags: vec!["topic:priority-evaluation".to_string()],
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![],
+                facts: vec![],
+                relationships: vec![],
+                temporal: vec![],
+                topics: vec![],
+                sentiment: None,
+                actions: vec![],
+                locations: vec![],
+                decisions: vec![],
+                questions: vec![],
+                status: None,
+            },
+        ),
+        // ── Content-only group (FTS5-only path) ────────────────────────────
+        (
+            MemoryInput {
+                content: "Alpha content only item".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![], facts: vec![], relationships: vec![],
+                temporal: vec![], topics: vec![], sentiment: None,
+                actions: vec![], locations: vec![], decisions: vec![],
+                questions: vec![], status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "Beta content only item".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![], facts: vec![], relationships: vec![],
+                temporal: vec![], topics: vec![], sentiment: None,
+                actions: vec![], locations: vec![], decisions: vec![],
+                questions: vec![], status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "Gamma content only item".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![], facts: vec![], relationships: vec![],
+                temporal: vec![], topics: vec![], sentiment: None,
+                actions: vec![], locations: vec![], decisions: vec![],
+                questions: vec![], status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "Delta content only item".to_string(),
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![], facts: vec![], relationships: vec![],
+                temporal: vec![], topics: vec![], sentiment: None,
+                actions: vec![], locations: vec![], decisions: vec![],
+                questions: vec![], status: None,
+            },
+        ),
+        // ── Tag-only group (tag search carries, no FTS5 match) ─────────────
+        (
+            MemoryInput {
+                content: "Unrelated note alpha".to_string(),
+                tags: vec!["topic:target-query".to_string()],
+                importance: 0.9,
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![], facts: vec![], relationships: vec![],
+                temporal: vec![], topics: vec![], sentiment: None,
+                actions: vec![], locations: vec![], decisions: vec![],
+                questions: vec![], status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "Unrelated note beta".to_string(),
+                tags: vec!["topic:other-topic".to_string()],
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![], facts: vec![], relationships: vec![],
+                temporal: vec![], topics: vec![], sentiment: None,
+                actions: vec![], locations: vec![], decisions: vec![],
+                questions: vec![], status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "Unrelated note gamma".to_string(),
+                tags: vec!["topic:another-topic".to_string()],
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![], facts: vec![], relationships: vec![],
+                temporal: vec![], topics: vec![], sentiment: None,
+                actions: vec![], locations: vec![], decisions: vec![],
+                questions: vec![], status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "Unrelated note delta".to_string(),
+                tags: vec!["topic:yet-another".to_string()],
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![], facts: vec![], relationships: vec![],
+                temporal: vec![], topics: vec![], sentiment: None,
+                actions: vec![], locations: vec![], decisions: vec![],
+                questions: vec![], status: None,
+            },
+        ),
+        // ── Low-coverage group (many query tokens, few tag matches) ─────────
+        (
+            MemoryInput {
+                content: "Quasar nebula partial match test (A)".to_string(),
+                tags: vec!["topic:quasar".to_string(), "topic:nebula".to_string(), "topic:pulsar".to_string(), "topic:comet".to_string(), "priority:low".to_string()],
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![], facts: vec![], relationships: vec![],
+                temporal: vec![], topics: vec![], sentiment: None,
+                actions: vec![], locations: vec![], decisions: vec![],
+                questions: vec![], status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "Quasar nebula partial match test (B)".to_string(),
+                tags: vec!["topic:quasar".to_string(), "topic:nebula".to_string(), "topic:pulsar".to_string(), "topic:comet".to_string(), "priority:medium".to_string()],
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![], facts: vec![], relationships: vec![],
+                temporal: vec![], topics: vec![], sentiment: None,
+                actions: vec![], locations: vec![], decisions: vec![],
+                questions: vec![], status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "Quasar nebula partial match test (C)".to_string(),
+                tags: vec!["topic:quasar".to_string(), "topic:nebula".to_string(), "topic:pulsar".to_string(), "topic:comet".to_string(), "priority:high".to_string()],
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![], facts: vec![], relationships: vec![],
+                temporal: vec![], topics: vec![], sentiment: None,
+                actions: vec![], locations: vec![], decisions: vec![],
+                questions: vec![], status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "Quasar nebula partial match test (D)".to_string(),
+                tags: vec!["topic:quasar".to_string(), "topic:nebula".to_string(), "topic:pulsar".to_string(), "topic:comet".to_string(), "priority:critical".to_string()],
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![], facts: vec![], relationships: vec![],
+                temporal: vec![], topics: vec![], sentiment: None,
+                actions: vec![], locations: vec![], decisions: vec![],
+                questions: vec![], status: None,
+            },
+        ),
+        // ── Tag-synonym group (tag search synonym expansion) ───────────────
+        (
+            MemoryInput {
+                content: "Zenith system note (A)".to_string(),
+                tags: vec!["action:patch".to_string()],
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![], facts: vec![], relationships: vec![],
+                temporal: vec![], topics: vec![], sentiment: None,
+                actions: vec![], locations: vec![], decisions: vec![],
+                questions: vec![], status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "Zenith system note (B)".to_string(),
+                tags: vec!["action:patch".to_string()],
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![], facts: vec![], relationships: vec![],
+                temporal: vec![], topics: vec![], sentiment: None,
+                actions: vec![], locations: vec![], decisions: vec![],
+                questions: vec![], status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "Zenith system note (C)".to_string(),
+                tags: vec!["action:patch".to_string()],
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![], facts: vec![], relationships: vec![],
+                temporal: vec![], topics: vec![], sentiment: None,
+                actions: vec![], locations: vec![], decisions: vec![],
+                questions: vec![], status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "Zenith system note (D)".to_string(),
+                tags: vec!["action:patch".to_string(), "topic:vertex-fix".to_string()],
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![], facts: vec![], relationships: vec![],
+                temporal: vec![], topics: vec![], sentiment: None,
+                actions: vec![], locations: vec![], decisions: vec![],
+                questions: vec![], status: None,
+            },
+        ),
+        // ── Temporal date expansion group ──────────────────────────────────
+        (
+            MemoryInput {
+                content: "Orion quarterly review (A)".to_string(),
+                tags: vec!["temporal:2024-01-15".to_string()],
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![], facts: vec![], relationships: vec![],
+                temporal: vec![], topics: vec![], sentiment: None,
+                actions: vec![], locations: vec![], decisions: vec![],
+                questions: vec![], status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "Orion quarterly review (B)".to_string(),
+                tags: vec!["temporal:2024-04-20".to_string()],
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![], facts: vec![], relationships: vec![],
+                temporal: vec![], topics: vec![], sentiment: None,
+                actions: vec![], locations: vec![], decisions: vec![],
+                questions: vec![], status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "Orion quarterly review (C)".to_string(),
+                tags: vec!["temporal:2024-07-10".to_string()],
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![], facts: vec![], relationships: vec![],
+                temporal: vec![], topics: vec![], sentiment: None,
+                actions: vec![], locations: vec![], decisions: vec![],
+                questions: vec![], status: None,
+            },
+        ),
+        (
+            MemoryInput {
+                content: "Orion quarterly review (D)".to_string(),
+                tags: vec!["temporal:2024-10-05".to_string()],
+                ..Default::default()
+            },
+            ExtractionResult {
+                entities: vec![], facts: vec![], relationships: vec![],
+                temporal: vec![], topics: vec![], sentiment: None,
+                actions: vec![], locations: vec![], decisions: vec![],
+                questions: vec![], status: None,
+            },
+        ),
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// Queries — each targets a specific memory by entity/fact/temporal
+// ---------------------------------------------------------------------------
+
+fn build_queries() -> Vec<(&'static str, usize)> {
+    // (query_text, expected_memory_index)
+    vec![
+        ("Who met to discuss Project Alpha?", 0),
+        ("What tool is used for Project Alpha?", 0),
+        ("What happened on January 15 2025?", 0),
+        ("Docker memory issue", 1),
+        ("deployment failure March 2024", 1),
+        ("Who refactored authentication?", 2),
+        ("OAuth2 migration", 2),
+        ("Jenkins to GitHub Actions", 3),
+        ("CI pipeline migration 2023", 3),
+        ("quarterly review board presentation", 4),
+        ("Dana revenue report", 4),
+        ("Redis caching session data", 5),
+        ("caching layer TTL", 5),
+        ("Eve Frank pair programming", 6),
+        ("GraphQL resolver February 2024", 6),
+        ("PostgreSQL migration infrastructure", 7),
+        ("database upgrade team", 7),
+        ("Grace search algorithm BM25", 8),
+        ("vector similarity implementation", 8),
+        ("Vue to Svelte switch", 9),
+        ("frontend dashboard rewrite", 9),
+        // Relationship queries (require tag search on relationships)
+        ("Alice led gathering", 10),
+        ("Alice facilitated gathering", 11),
+        ("Charlie presented task", 12),
+        ("Charlie reviewed assignment", 13),
+        ("Eve developed activity", 14),
+        ("Eve tested work", 15),
+        ("Grace approved process", 16),
+        ("Grace rejected review", 17),
+        ("Ivan deployed operation", 18),
+        ("Ivan monitored procedure", 19),
+        // Temporal queries (require tag search on temporal tags; expect 4th in group)
+        ("zephyr conclave 2025-07-01", 23),
+        ("nexus forum 2025-07-04", 31),
+        // Topic queries (require tag search on topic tags; expect 4th in group)
+        ("refactoring discussion", 35),
+        ("postmortem session", 39),
+        ("roadmap meeting", 43),
+        // Sentiment queries (require tag search on sentiment tags; expect 4th in group)
+        ("positive luminary event", 47),
+        ("negative stellar outcome", 51),
+        ("neutral quantum result", 55),
+        // Action queries (require tag search on action tags; expect 4th in group)
+        ("migrated paradigm shift", 59),
+        ("documented catalyst", 63),
+        ("deprecated milestone", 67),
+        // Location queries (require tag search on location tags; expect 4th in group)
+        ("cairo encounter", 71),
+        ("lima revelation", 75),
+        ("helsinki assembly", 79),
+        // Decision queries (require tag search on decision tags; expect 4th in group)
+        ("approved deliberation", 83),
+        ("rejected negotiation", 87),
+        ("postponed evaluation", 91),
+        // Question queries (require tag search on question tags; expect 4th in group)
+        ("resolved inquiry", 95),
+        ("validated concern", 99),
+        ("clarified matter", 103),
+        // Cross-cutting queries (match multiple dimensions; expect specific combination)
+        ("xander architecture tokyo reviewed initiative", 104),
+        ("xander tokyo reviewed approved initiative", 107),
+        ("zara security cairo tested endeavor", 108),
+        ("zara cairo tested rejected endeavor", 111),
+        // Cross-cutting group 3/4 queries
+        ("quinn performance optimized dublin milestone", 112),
+        ("quinn performance optimized dublin approved milestone", 115),
+        ("tessa backend refactored mumbai deadline", 116),
+        ("tessa backend refactored mumbai expedited deadline", 119),
+        // Status queries (require tag search on status tags; expect 4th in group)
+        ("completed verdict", 123),
+        ("blocked analysis", 127),
+        ("deferred sprint", 131),
+        // Synonym queries (require FTS5 synonym expansion; expect 4th in group)
+        ("fix payment", 135),
+        // Bigram phrase queries (test FTS5 bigram path; expect 4th in group)
+        ("alpha beta system", 139),
+        // Importance queries (test importance ranking; expect highest importance)
+        ("priority evaluation", 143),
+        // Content-only group
+        ("delta content only", 147),
+        // Tag-only group
+        ("target query", 148),
+        // Low-coverage group
+        ("quasar nebula pulsar comet epsilon zeta critical", 155),
+        // Tag-synonym group
+        ("fix zenith system", 159),
+        // Temporal date expansion group
+        ("july orion", 162),
+    ]
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+#[allow(clippy::cast_precision_loss)]
+#[tokio::main]
+async fn main() -> Result<()> {
+    let dataset = build_dataset();
+    let queries = build_queries();
+
+    // Build mock LLM responses keyed by content string.
+    let mut responses = HashMap::<String, ExtractionResult>::new();
+    for (input, result) in &dataset {
+        responses.insert(input.content.clone(), result.clone());
+    }
+    let mock_llm = Arc::new(MockLlmBackend::new(responses));
+
+    // Create storage with PlaceholderEmbedder (fast, deterministic).
+    let embedder: Arc<dyn mag::memory_core::embedder::Embedder> = Arc::new(PlaceholderEmbedder);
+    let storage = SqliteStorage::new_in_memory_with_embedder(Arc::clone(&embedder))?;
+
+    // Create pipeline with mock LLM.
+    let pipeline = EmbedAndExtractPipeline::new(Arc::clone(&embedder)).with_llm(mock_llm);
+
+    // Store all memories with deterministic IDs.
+    let mut ids = Vec::new();
+    for (idx, (input, _result)) in dataset.iter().enumerate() {
+        let assigned_id = format!("mem-{idx:03}");
+        let ctx = WriteContext {
+            input: input.clone(),
+            assigned_id: assigned_id.clone(),
+            embedding: None,
+        };
+        pipeline.ingest(ctx, &storage).await?;
+        ids.push(assigned_id);
+    }
+
+    // Run queries and compute hit rate.
+    let opts = SearchOptions::default();
+    let mut hits = 0usize;
+
+    for (query, expected_idx) in &queries {
+        let results = storage.search(query, 3, &opts).await?;
+
+        let expected_id = &ids[*expected_idx];
+        let found = results.iter().any(|r| r.id == *expected_id);
+        if found {
+            hits += 1;
+        }
+    }
+
+    let hit_rate = hits as f64 / queries.len() as f64;
+    println!("METRIC hit_rate={hit_rate:.4}");
+    println!(
+        "ASI total_queries={} hits={} miss={}",
+        queries.len(),
+        hits,
+        queries.len() - hits
+    );
+
+    Ok(())
+}

--- a/src/memory_core/storage/sqlite/entities.rs
+++ b/src/memory_core/storage/sqlite/entities.rs
@@ -152,7 +152,7 @@ fn extract_projects(text: &str) -> Vec<String> {
 }
 
 /// Convert a name to a URL-safe slug.
-pub(super) fn slugify(value: &str) -> String {
+pub fn slugify(value: &str) -> String {
     let cleaned: String = value
         .to_lowercase()
         .chars()
@@ -185,7 +185,7 @@ pub(super) fn slugify(value: &str) -> String {
 /// - Min 2 chars after slugification
 /// - Max 6 words (hyphens count as word separators)
 /// - Reject pure stopwords, code class names (*Handler/*Service), boolean literals
-pub(super) fn is_valid_entity(slug: &str) -> bool {
+pub fn is_valid_entity(slug: &str) -> bool {
     if slug.len() < 2 {
         return false;
     }

--- a/src/memory_core/storage/sqlite/helpers.rs
+++ b/src/memory_core/storage/sqlite/helpers.rs
@@ -91,7 +91,7 @@ const SYNONYM_CAP: usize = 3;
 /// every word in a group maps to all *other* words in that group.
 ///
 /// Returns an empty slice for words without known synonyms.
-fn get_synonyms(word: &str) -> &'static [&'static str] {
+pub(crate) fn get_synonyms(word: &str) -> &'static [&'static str] {
     match word {
         "buy" | "purchase" | "bought" => match word {
             "buy" => &["purchase", "bought"],
@@ -431,10 +431,12 @@ fn get_synonyms(word: &str) -> &'static [&'static str] {
             "come" => &["arrive", "reach"],
             _ => &[],
         },
-        "fix" | "repair" | "mend" => match word {
-            "fix" => &["repair", "mend"],
-            "repair" => &["fix", "mend"],
-            "mend" => &["fix", "repair"],
+        "fix" | "repair" | "resolve" | "patch" | "mend" => match word {
+            "fix" => &["repair", "resolve", "patch", "mend"],
+            "repair" => &["fix", "resolve", "patch", "mend"],
+            "resolve" => &["fix", "repair", "patch", "mend"],
+            "patch" => &["fix", "repair", "resolve", "mend"],
+            "mend" => &["fix", "repair", "resolve", "patch"],
             _ => &[],
         },
         "break" | "shatter" | "crack" | "damage" => match word {
@@ -458,6 +460,77 @@ fn get_synonyms(word: &str) -> &'static [&'static str] {
         },
         _ => &[],
     }
+}
+/// Expands ISO dates in text to natural language month names.
+/// Returns a space-separated string of expanded tokens.
+pub(crate) fn expand_date_tokens(text: &str) -> String {
+    const MONTHS: [&str; 13] = [
+        "",
+        "January",
+        "February",
+        "March",
+        "April",
+        "May",
+        "June",
+        "July",
+        "August",
+        "September",
+        "October",
+        "November",
+        "December",
+    ];
+    let mut extra = String::new();
+    let bytes = text.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+    while i < len {
+        // Check if current position starts a 4-digit sequence
+        if i + 4 <= len
+            && bytes[i].is_ascii_digit()
+            && bytes[i + 1].is_ascii_digit()
+            && bytes[i + 2].is_ascii_digit()
+            && bytes[i + 3].is_ascii_digit()
+        {
+            // Ensure this is a word boundary (not preceded by alphanumeric)
+            let at_word_start = i == 0 || !bytes[i - 1].is_ascii_alphanumeric();
+            if at_word_start
+                && i + 10 <= len
+                && bytes[i + 4] == b'-'
+                && bytes[i + 5].is_ascii_digit()
+                && bytes[i + 6].is_ascii_digit()
+                && bytes[i + 7] == b'-'
+                && bytes[i + 8].is_ascii_digit()
+                && bytes[i + 9].is_ascii_digit()
+            {
+                // Full YYYY-MM-DD pattern
+                let year = &text[i..i + 4];
+                let month_num: usize = text[i + 5..i + 7].parse().unwrap_or(0);
+                let day: usize = text[i + 8..i + 10].parse().unwrap_or(0);
+                if (1..=12).contains(&month_num) && (1..=31).contains(&day) {
+                    let month_name = MONTHS[month_num];
+                    extra.push(' ');
+                    extra.push_str(&format!("{month_name} {year} {day} {month_name} {year}"));
+                }
+                i += 10;
+            } else if at_word_start {
+                // Standalone 4-digit year (1900-2099) not part of ISO date
+                let at_word_end = i + 4 >= len || !bytes[i + 4].is_ascii_alphanumeric();
+                if at_word_end {
+                    let year_num: u16 = text[i..i + 4].parse().unwrap_or(0);
+                    if (1900..=2099).contains(&year_num) {
+                        extra.push(' ');
+                        extra.push_str(&text[i..i + 4]);
+                    }
+                }
+                i += 4;
+            } else {
+                i += 1;
+            }
+        } else {
+            i += 1;
+        }
+    }
+    extra
 }
 
 pub(super) fn build_fts5_query(input: &str) -> String {
@@ -522,7 +595,8 @@ pub(super) fn build_fts5_query(input: &str) -> String {
     // For 1-2 token queries, bigrams would be redundant (either a single
     // token or an exact duplicate of the full query). Just join with OR.
     if effective_tokens.len() < 3 {
-        let mut parts = escaped;
+        let mut parts = Vec::with_capacity(escaped.len() + synonym_terms.len());
+        parts.extend(escaped);
         parts.extend(synonym_terms);
         return parts.join(" OR ");
     }
@@ -537,7 +611,8 @@ pub(super) fn build_fts5_query(input: &str) -> String {
         })
         .collect();
 
-    let mut parts = escaped;
+    let mut parts = Vec::with_capacity(escaped.len() + bigrams.len() + synonym_terms.len());
+    parts.extend(escaped);
     parts.extend(bigrams);
     parts.extend(synonym_terms);
     parts.join(" OR ")
@@ -1233,5 +1308,15 @@ mod tests {
         assert!(q.contains("\"movie\""));
         assert!(q.contains("\"film\""));
         assert!(!q.contains("\"the\""));
+    }
+
+    #[test]
+    fn fts5_query_fix_expands_to_patch_repair_resolve() {
+        let q = build_fts5_query("fix payment");
+        assert!(q.contains("\"fix\""), "original term present");
+        assert!(q.contains("\"patch\""), "synonym patch present");
+        assert!(q.contains("\"repair\""), "synonym repair present");
+        assert!(q.contains("\"resolve\""), "synonym resolve present");
+        assert!(q.contains("\"payment\""), "non-synonym term present");
     }
 }

--- a/src/memory_core/storage/sqlite/mod.rs
+++ b/src/memory_core/storage/sqlite/mod.rs
@@ -69,12 +69,15 @@ pub use storage::{InitMode, RankedSemanticCandidate, SqliteStorage};
 use conn_pool::retry_on_lock;
 pub(crate) use embedding_codec::dot_product;
 use embedding_codec::{decode_embedding, encode_embedding};
+#[allow(unused_imports)]
+pub(crate) use entities::{is_valid_entity, slugify};
 #[cfg(test)]
 use helpers::normalize_for_dedup;
 use helpers::{
     EPOCH_FALLBACK, append_search_filters, build_fts5_query, canonical_hash, content_hash,
-    escape_like_pattern, event_type_from_sql, event_type_to_sql, parse_metadata_from_db,
-    parse_tags_from_db, query_cache_key, search_result_from_row, to_param_refs, validate_iso8601,
+    escape_like_pattern, event_type_from_sql, event_type_to_sql, expand_date_tokens, get_synonyms,
+    parse_metadata_from_db, parse_tags_from_db, query_cache_key, search_result_from_row,
+    to_param_refs, validate_iso8601,
 };
 #[cfg(test)]
 use hot_cache::{HOT_CACHE_REFRESH_SECS, HotTierCache};

--- a/src/memory_core/storage/sqlite/search.rs
+++ b/src/memory_core/storage/sqlite/search.rs
@@ -25,6 +25,14 @@ impl Searcher for SqliteStorage {
 
             let fts_query = build_fts5_query(&query);
             let include_superseded = opts.include_superseded.unwrap_or(false);
+            let mut all_results: Vec<SearchResult> = Vec::with_capacity(limit * 2);
+            let mut seen_ids: std::collections::HashSet<String> =
+                std::collections::HashSet::with_capacity(limit * 2);
+            let mut tag_match_count: std::collections::HashMap<String, usize> =
+                std::collections::HashMap::with_capacity(limit * 2);
+            let mut fts_position: std::collections::HashMap<String, usize> =
+                std::collections::HashMap::with_capacity(limit * 2);
+            // ── Phase 1: FTS5 content search ──
             let mut fts_sql = String::from(
                 "SELECT f.id, m.content, m.tags, m.importance, m.metadata, m.event_type, m.session_id, m.project, m.entity_id, m.agent_type
                  FROM memories_fts f
@@ -45,71 +53,189 @@ impl Searcher for SqliteStorage {
                 "m.tags",
             );
             fts_sql.push_str(" ORDER BY bm25(memories_fts)");
+            let candidate_limit = effective_limit * 10;
             fts_sql.push_str(&format!(" LIMIT ?{param_idx}"));
-            fts_params.push(SqlValue::Integer(effective_limit));
+            fts_params.push(SqlValue::Integer(candidate_limit));
 
-            let fts_result = conn.prepare(&fts_sql);
-
-            if let Ok(mut stmt) = fts_result {
+            if let Ok(mut stmt) = conn.prepare(&fts_sql) {
                 let fts_param_refs = to_param_refs(&fts_params);
-                let rows = stmt
-                    .query_map(fts_param_refs.as_slice(), search_result_from_row);
-
+                let rows = stmt.query_map(fts_param_refs.as_slice(), search_result_from_row);
                 if let Err(ref e) = rows {
-                    tracing::warn!("FTS5 search failed, falling back to LIKE: {e}");
+                    tracing::warn!("FTS5 search failed: {e}");
                 }
                 if let Ok(rows) = rows {
-                    let mut results = Vec::new();
-                    for row in rows {
-                        results.push(row.context("failed to decode FTS5 search row")?);
-                    }
-
-                    if !results.is_empty() {
-                        return Ok(results);
+                    for (pos, row) in rows.enumerate() {
+                        let result = row.context("failed to decode FTS5 search row")?;
+                        seen_ids.insert(result.id.clone());
+                        fts_position.insert(result.id.clone(), pos);
+                        all_results.push(result);
                     }
                 }
             }
 
-            let pattern = escape_like_pattern(&query);
+            // ── Phase 2: Tokenized tag search ──
+            let raw_tokens: Vec<&str> = query.split_whitespace().collect();
+            let tag_tokens: Vec<String> = raw_tokens
+                .iter()
+                .map(|t| t.to_lowercase())
+                .filter(|t| !t.is_empty() && !is_stopword(t))
+                .collect();
 
-            let mut sql = String::from(
-                "SELECT id, content, tags, importance, metadata, event_type, session_id, project, entity_id, agent_type
-                 FROM memories
-                 WHERE lower(content) LIKE ?1 ESCAPE '\\'",
-            );
-            if !include_superseded {
-                sql.push_str(" AND superseded_by_id IS NULL");
+            if !tag_tokens.is_empty() {
+                let mut tag_sql = String::from(
+                    "SELECT id, content, tags, importance, metadata, event_type, session_id, project, entity_id, agent_type
+                     FROM memories
+                     WHERE (",
+                );
+                let mut tag_params: Vec<SqlValue> = Vec::new();
+                for (i, token) in tag_tokens.iter().enumerate() {
+                    if i > 0 {
+                        tag_sql.push_str(" OR ");
+                    }
+                    tag_sql.push_str(&format!("lower(tags) LIKE ?{}", i + 1));
+                    tag_params.push(SqlValue::Text(format!("%{}%", token)));
+                }
+                tag_sql.push(')');
+
+                if !include_superseded {
+                    tag_sql.push_str(" AND superseded_by_id IS NULL");
+                }
+                let mut tag_idx = tag_tokens.len() + 1;
+                append_search_filters(
+                    &mut tag_sql, &mut tag_params, &mut tag_idx, &opts, "");
+                append_context_tag_filters(
+                    &mut tag_sql,
+                    &mut tag_params,
+                    &mut tag_idx,
+                    opts.context_tags.as_deref(),
+                    "tags",
+                );
+                tag_sql.push_str(" ORDER BY last_accessed_at DESC");
+
+                if let Ok(mut stmt) = conn.prepare(&tag_sql) {
+                    let tag_param_refs = to_param_refs(&tag_params);
+                    if let Ok(rows) = stmt.query_map(tag_param_refs.as_slice(), search_result_from_row) {
+                        for row in rows {
+                            let result = row.context("failed to decode tag search row")?;
+                            let mut tag_text = result.tags.join(" ");
+                            if tag_text.is_ascii() {
+                                tag_text.make_ascii_lowercase();
+                            } else {
+                                tag_text = tag_text.to_lowercase();
+                            }
+                            let mut tag_words: Vec<&str> = tag_text
+                                .split(|c: char| !c.is_alphanumeric() && c != '-')
+                                .filter(|w| !w.is_empty())
+                                .collect();
+                            // Also add fully-split words (e.g. "machine-learning" → "machine", "learning")
+                            let split_words: Vec<&str> = tag_text
+                                .split(|c: char| !c.is_alphanumeric())
+                                .filter(|w| !w.is_empty() && w.len() > 2)
+                                .collect();
+                            tag_words.extend(split_words);
+                            // Expand ISO dates in tags to natural language month names
+                            let date_expansion = expand_date_tokens(&tag_text);
+                            let date_words: Vec<&str> = date_expansion.split_whitespace().collect();
+                            let match_count = tag_tokens
+                                .iter()
+                                .filter(|t| {
+                                    if tag_words.contains(&t.as_str()) || date_words.contains(&t.as_str()) {
+                                        return true;
+                                    }
+                                    let stemmed_t = simple_stem(t);
+                                    if stemmed_t != **t
+                                        && (tag_words.iter().any(|word| simple_stem(word) == stemmed_t)
+                                            || date_words.iter().any(|word| simple_stem(word) == stemmed_t))
+                                    {
+                                        return true;
+                                    }
+                                    // Synonym expansion: check if any synonym matches a tag word
+                                    for syn in get_synonyms(t) {
+                                        if tag_words.contains(syn) || date_words.contains(syn) {
+                                            return true;
+                                        }
+                                        let stemmed_syn = simple_stem(syn);
+                                        if stemmed_syn != *syn
+                                            && (tag_words.iter().any(|word| simple_stem(word) == stemmed_syn)
+                                                || date_words.iter().any(|word| simple_stem(word) == stemmed_syn))
+                                        {
+                                            return true;
+                                        }
+                                    }
+                                    false
+                                })
+                                .count();
+                            if match_count > 0 {
+                                tag_match_count.insert(result.id.clone(), match_count);
+                            }
+                            if seen_ids.insert(result.id.clone()) {
+                                all_results.push(result);
+                            }
+                        }
+                    }
+                }
             }
-            let mut params_values: Vec<SqlValue> = vec![SqlValue::Text(pattern)];
-            let mut idx = 2;
-            append_search_filters(&mut sql, &mut params_values, &mut idx, &opts, "");
-            append_context_tag_filters(
-                &mut sql,
-                &mut params_values,
-                &mut idx,
-                opts.context_tags.as_deref(),
-                "tags",
-            );
-            sql.push_str(" ORDER BY last_accessed_at DESC");
-            sql.push_str(&format!(" LIMIT ?{idx}"));
-            params_values.push(SqlValue::Integer(effective_limit));
+            // ── Phase 3: Re-rank by composite score ──
+            // Score = tag_matches * 100 * coverage - fts_position + dual_bonus
+            // where coverage = match_count / query_token_count.
+            // Coverage weighting rewards memories that match a higher fraction
+            // of the query tokens, creating tighter margins between fully
+            // relevant and partially relevant matches.
+            let query_token_count = tag_tokens.len().max(1) as i64;
+            #[allow(clippy::cast_precision_loss)]
+            all_results.sort_by(|a, b| {
+                let a_match = tag_match_count.get(&a.id).copied().unwrap_or(0) as i64;
+                let b_match = tag_match_count.get(&b.id).copied().unwrap_or(0) as i64;
+                let a_pos = fts_position.get(&a.id).copied().unwrap_or(1000) as i64;
+                let b_pos = fts_position.get(&b.id).copied().unwrap_or(1000) as i64;
+                let a_dual = if fts_position.contains_key(&a.id) && tag_match_count.contains_key(&a.id) { 10 } else { 0 };
+                let b_dual = if fts_position.contains_key(&b.id) && tag_match_count.contains_key(&b.id) { 10 } else { 0 };
+                let a_coverage = a_match as f64 / query_token_count as f64;
+                let b_coverage = b_match as f64 / query_token_count as f64;
+                let a_imp = a.importance * 50.0;
+                let b_imp = b.importance * 50.0;
+                let a_score = (a_match * 100) as f64 * a_coverage - a_pos as f64 + a_dual as f64 + a_imp;
+                let b_score = (b_match * 100) as f64 * b_coverage - b_pos as f64 + b_dual as f64 + b_imp;
+                b_score.partial_cmp(&a_score).unwrap_or(std::cmp::Ordering::Equal)
+            });
+            if all_results.is_empty() {
+                let pattern = escape_like_pattern(&query);
+                let mut sql = String::from(
+                    "SELECT id, content, tags, importance, metadata, event_type, session_id, project, entity_id, agent_type
+                     FROM memories
+                     WHERE lower(content) LIKE ?1 ESCAPE '\\'",
+                );
+                if !include_superseded {
+                    sql.push_str(" AND superseded_by_id IS NULL");
+                }
+                let mut params_values: Vec<SqlValue> = vec![SqlValue::Text(pattern)];
+                let mut idx = 2;
+                append_search_filters(&mut sql, &mut params_values, &mut idx, &opts, "");
+                append_context_tag_filters(
+                    &mut sql,
+                    &mut params_values,
+                    &mut idx,
+                    opts.context_tags.as_deref(),
+                    "tags",
+                );
+                sql.push_str(" ORDER BY last_accessed_at DESC");
+                sql.push_str(&format!(" LIMIT ?{idx}"));
+                params_values.push(SqlValue::Integer(effective_limit));
 
-            let mut stmt = conn
-                .prepare(&sql)
-                .context("failed to prepare LIKE search query")?;
-
-            let like_param_refs = to_param_refs(&params_values);
-
-            let rows = stmt
-                .query_map(like_param_refs.as_slice(), search_result_from_row)
-                .context("failed to execute LIKE search query")?;
-
-            let mut results = Vec::new();
-            for row in rows {
-                results.push(row.context("failed to decode LIKE search row")?);
+                let mut stmt = conn
+                    .prepare(&sql)
+                    .context("failed to prepare LIKE search query")?;
+                let like_param_refs = to_param_refs(&params_values);
+                let rows = stmt
+                    .query_map(like_param_refs.as_slice(), search_result_from_row)
+                    .context("failed to execute LIKE search query")?;
+                for row in rows {
+                    all_results.push(row.context("failed to decode LIKE search row")?);
+                }
             }
 
-            Ok::<_, anyhow::Error>(results)
+            all_results.truncate(limit);
+            Ok::<_, anyhow::Error>(all_results)
         })
         .await
         .context("spawn_blocking join error")?
@@ -378,7 +504,6 @@ impl PhraseSearcher for SqliteStorage {
             let conn = pool.reader()?;
 
             let pattern = escape_like_pattern(&phrase);
-
             let mut sql = String::from(
                 "SELECT id, content, tags, importance, metadata, event_type, session_id, project, entity_id, agent_type
                  FROM memories

--- a/src/substrate/extraction.rs
+++ b/src/substrate/extraction.rs
@@ -1,0 +1,461 @@
+//! Phase 2: LLM-powered extraction of facts, entities, relationships, and temporal data.
+//!
+//! Gated by the `llm` feature flag. When disabled, the module still compiles but
+//! the extractor is a no-op stub so that callers do not need cfg-gates everywhere.
+//!
+//! ## Extraction schema
+//!
+//! The LLM returns structured JSON with:
+//! - `entities`: named entities with type classification
+//! - `facts`: discrete factual statements
+//! - `relationships`: subject-predicate-object triples
+//! - `temporal`: date/time expressions with ISO 8601 normalization
+//!
+//! ## Integration
+//!
+//! Results are merged into `MemoryInput` before storage:
+//! - Entities -> `entity:{type}:{slug}` tags (augmenting rule-based extraction)
+//! - Facts -> `llm:fact:{slug}` tags + full list in `metadata["llm_facts"]`
+//! - Relationships -> `metadata["llm_relationships"]`
+//! - Temporal -> normalizes `referenced_date` if unset
+
+#[cfg(feature = "llm")]
+use std::sync::Arc;
+
+#[cfg(feature = "llm")]
+use crate::memory_core::llm::LlmBackend;
+use crate::memory_core::storage::sqlite::{is_valid_entity, slugify};
+#[cfg(feature = "llm")]
+use anyhow::Context;
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+// ---------------------------------------------------------------------------
+// Output types
+// ---------------------------------------------------------------------------
+
+/// Entity extracted from memory content.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExtractedEntity {
+    /// Display name, e.g. "Alice Smith"
+    pub name: String,
+    /// One of: person | tool | project | organization | place | concept | other
+    pub entity_type: String,
+}
+
+/// A relationship triple.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExtractedRelationship {
+    pub subject: String,
+    pub predicate: String,
+    pub object: String,
+    /// ISO 8601 date/time when the relationship occurred, if known.
+    pub when: Option<String>,
+}
+
+/// Temporal expression with normalized form.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExtractedTemporal {
+    /// Raw text from source ("last Tuesday", "January 15, 2024")
+    pub expression: String,
+    /// ISO 8601 normalized form, if determinable ("2024-01-15")
+    pub normalized: Option<String>,
+}
+
+/// Full extraction result from the LLM.
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ExtractionResult {
+    /// Named entities found in the content.
+    #[serde(default)]
+    pub entities: Vec<ExtractedEntity>,
+    /// Discrete factual statements (short, imperative form).
+    #[serde(default)]
+    pub facts: Vec<String>,
+    /// Relationship triples.
+    #[serde(default)]
+    pub relationships: Vec<ExtractedRelationship>,
+    /// Date/time references.
+    #[serde(default)]
+    pub temporal: Vec<ExtractedTemporal>,
+    /// High-level topics or themes.
+    #[serde(default)]
+    pub topics: Vec<String>,
+    /// Overall sentiment: positive | negative | neutral.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sentiment: Option<String>,
+    /// Key actions or verbs describing what happened.
+    #[serde(default)]
+    pub actions: Vec<String>,
+    /// Geographic or location references.
+    #[serde(default)]
+    pub locations: Vec<String>,
+    /// Questions raised in the content.
+    #[serde(default)]
+    pub questions: Vec<String>,
+    /// Decisions or resolutions made.
+    #[serde(default)]
+    pub decisions: Vec<String>,
+    /// Status or state.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+}
+
+impl ExtractionResult {
+    /// Convert extracted entities to `entity:{type}:{slug}` tags.
+    pub fn entity_tags(&self) -> Vec<String> {
+        self.entities
+            .iter()
+            .filter_map(|e| {
+                let s = slugify(&e.name);
+                let ty = normalize_entity_type(&e.entity_type);
+                if is_valid_entity(&s) {
+                    Some(format!("entity:{ty}:{s}"))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
+    /// Convert extracted facts to `llm:fact:{slug}` tags (capped at 32 chars per slug).
+    pub fn fact_tags(&self) -> Vec<String> {
+        self.facts
+            .iter()
+            .map(|f| {
+                let s = slugify_fact(f);
+                format!("llm:fact:{s}")
+            })
+            .collect()
+    }
+    /// Convert extracted relationships to `rel:{subject}:{predicate}:{object}` tags.
+    pub fn relationship_tags(&self) -> Vec<String> {
+        self.relationships
+            .iter()
+            .filter_map(|r| {
+                let sub = slugify(&r.subject);
+                let pred = slugify(&r.predicate);
+                let obj = slugify(&r.object);
+                if sub.is_empty() || pred.is_empty() || obj.is_empty() {
+                    return None;
+                }
+                Some(format!("rel:{sub}:{pred}:{obj}"))
+            })
+            .collect()
+    }
+
+    /// Return the earliest/most specific normalized temporal expression, for
+    /// use as `referenced_date` when the caller has not set one.
+    pub fn best_temporal_date(&self) -> Option<&str> {
+        for t in &self.temporal {
+            if let Some(ref norm) = t.normalized
+                && norm.len() >= 10
+            {
+                return Some(norm.as_str());
+            }
+        }
+        None
+    }
+
+    /// Convert extracted temporal expressions to `temporal:{date}` tags.
+    pub fn temporal_tags(&self) -> Vec<String> {
+        self.temporal
+            .iter()
+            .filter_map(|t| {
+                t.normalized.as_ref().and_then(|norm| {
+                    if norm.len() >= 7 {
+                        Some(format!("temporal:{norm}"))
+                    } else {
+                        None
+                    }
+                })
+            })
+            .collect()
+    }
+
+    /// Convert extracted topics to `topic:{slug}` tags.
+    pub fn topic_tags(&self) -> Vec<String> {
+        self.topics
+            .iter()
+            .filter_map(|t| {
+                let s = slugify(t);
+                if s.is_empty() {
+                    None
+                } else {
+                    Some(format!("topic:{s}"))
+                }
+            })
+            .collect()
+    }
+
+    /// Convert sentiment to a `sentiment:{value}` tag.
+    pub fn sentiment_tags(&self) -> Vec<String> {
+        self.sentiment
+            .as_ref()
+            .and_then(|s| {
+                let lower = s.to_lowercase();
+                match lower.as_str() {
+                    "positive" | "negative" | "neutral" => Some(format!("sentiment:{lower}")),
+                    _ => None,
+                }
+            })
+            .into_iter()
+            .collect()
+    }
+
+    /// Convert extracted actions to `action:{slug}` tags.
+    pub fn action_tags(&self) -> Vec<String> {
+        self.actions
+            .iter()
+            .filter_map(|a| {
+                let s = slugify(a);
+                if s.is_empty() {
+                    None
+                } else {
+                    Some(format!("action:{s}"))
+                }
+            })
+            .collect()
+    }
+
+    /// Convert extracted locations to `location:{slug}` tags.
+    pub fn location_tags(&self) -> Vec<String> {
+        self.locations
+            .iter()
+            .filter_map(|l| {
+                let s = slugify(l);
+                if s.is_empty() {
+                    None
+                } else {
+                    Some(format!("location:{s}"))
+                }
+            })
+            .collect()
+    }
+    /// Convert extracted decisions to `decision:{slug}` tags.
+    pub fn decision_tags(&self) -> Vec<String> {
+        self.decisions
+            .iter()
+            .filter_map(|d| {
+                let s = slugify(d);
+                if s.is_empty() {
+                    None
+                } else {
+                    Some(format!("decision:{s}"))
+                }
+            })
+            .collect()
+    }
+    /// Convert extracted questions to `question:{slug}` tags.
+    pub fn question_tags(&self) -> Vec<String> {
+        self.questions
+            .iter()
+            .filter_map(|q| {
+                let s = slugify(q);
+                if s.is_empty() {
+                    None
+                } else {
+                    Some(format!("question:{s}"))
+                }
+            })
+            .collect()
+    }
+    /// Convert extracted status to status tag.
+    pub fn status_tags(&self) -> Vec<String> {
+        self.status
+            .as_ref()
+            .and_then(|s: &String| {
+                let lower = s.to_lowercase();
+                match lower.as_str() {
+                    "completed" | "blocked" | "in-progress" | "pending" | "deferred"
+                    | "cancelled" => Some(format!("status:{lower}")),
+                    _ => None,
+                }
+            })
+            .into_iter()
+            .collect()
+    }
+    /// Return all extraction data as a JSON value for storage in metadata.
+    pub fn to_metadata(&self) -> serde_json::Value {
+        match serde_json::to_value(self) {
+            Ok(v) => v,
+            Err(_) => serde_json::json!({}),
+        }
+    }
+}
+
+fn normalize_entity_type(raw: &str) -> &'static str {
+    let lower = raw.to_lowercase();
+    match lower.as_str() {
+        "people" | "person" => "people",
+        "tool" | "tools" => "tools",
+        "project" | "projects" => "projects",
+        "organization" | "org" | "company" => "organization",
+        "place" | "location" => "place",
+        "concept" | "idea" => "concept",
+        _ => "other",
+    }
+}
+fn slugify_fact(fact: &str) -> String {
+    let cleaned: String = fact
+        .to_lowercase()
+        .chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == ' ' {
+                c
+            } else {
+                ' '
+            }
+        })
+        .collect();
+    let words: Vec<&str> = cleaned.split_whitespace().take(5).collect();
+    let slug = words.join("-");
+    if slug.len() > 32 {
+        slug[..32].to_string()
+    } else {
+        slug
+    }
+}
+
+#[cfg(feature = "llm")]
+const SYSTEM_PROMPT: &str = r#"Extract structured metadata from the memory snippet:
+
+- entities: people, tools, projects, organizations, places, concepts
+- facts: standalone factual statements
+- relationships: subject-predicate-object triples (optional date)
+- temporal: date/time expressions (ISO 8601 YYYY-MM-DD when possible)
+- topics: high-level themes (1-3 words each)
+- sentiment: positive, negative, or neutral
+- actions: key verbs describing what happened
+- locations: cities, countries, buildings, regions
+- decisions: resolutions or conclusions reached
+- questions: questions raised in the content
+- status: completed, blocked, in-progress, pending, deferred, cancelled
+
+Return valid JSON only. No prose outside JSON."#;
+
+#[cfg(feature = "llm")]
+fn extraction_schema() -> serde_json::Value {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "entities": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "name": { "type": "string" },
+                        "entity_type": { "type": "string", "enum": ["person", "tool", "project", "organization", "place", "concept", "other"] }
+                    },
+                    "required": ["name", "entity_type"]
+                }
+            },
+            "facts": {
+                "type": "array",
+                "items": { "type": "string" }
+            },
+            "relationships": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "subject": { "type": "string" },
+                        "predicate": { "type": "string" },
+                        "object": { "type": "string" },
+                        "when": { "type": ["string", "null"] }
+                    },
+                    "required": ["subject", "predicate", "object"]
+                }
+            },
+            "temporal": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "expression": { "type": "string" },
+                        "normalized": { "type": ["string", "null"] }
+                    },
+                    "required": ["expression"]
+                }
+            },
+            "topics": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Themes (1-3 words)"
+            },
+            "sentiment": {
+                "type": "string",
+                "enum": ["positive", "negative", "neutral"],
+                "description": "Emotional tone"
+            },
+            "actions": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Key verbs or actions"
+            },
+            "locations": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Geographic references"
+            },
+            "decisions": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Resolutions or conclusions"
+            },
+            "questions": {
+                "type": "array",
+                "items": { "type": "string" },
+                "description": "Questions raised"
+            },
+            "status": {
+                "type": "string",
+                "enum": ["completed", "blocked", "in-progress", "pending", "deferred", "cancelled"],
+                "description": "Task or project status"
+            }
+        }
+    })
+}
+
+// ---------------------------------------------------------------------------
+// LlmExtractor (requires llm feature)
+#[cfg(feature = "llm")]
+/// Extracts structured information from memory content using an LLM backend.
+pub struct LlmExtractor {
+    // ---------------------------------------------------------------------------
+    pub llm: Arc<dyn LlmBackend>,
+}
+
+#[cfg(feature = "llm")]
+impl LlmExtractor {
+    pub async fn extract(&self, content: &str) -> Result<ExtractionResult> {
+        let schema = extraction_schema();
+        let raw: serde_json::Value = self
+            .llm
+            .complete_structured(content, Some(SYSTEM_PROMPT), &schema)
+            .await
+            .context("LLM extraction failed")?;
+        let result: ExtractionResult =
+            serde_json::from_value(raw).context("LLM extraction deserialization failed")?;
+        Ok(result)
+    }
+}
+// No-op stub (used when llm feature is off)
+// ---------------------------------------------------------------------------
+
+/// When the `llm` feature is disabled, extraction returns empty results.
+pub struct NoOpExtractor;
+
+impl Default for NoOpExtractor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+impl NoOpExtractor {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub async fn extract(&self, _content: &str) -> Result<ExtractionResult> {
+        Ok(ExtractionResult::default())
+    }
+}

--- a/src/substrate/ingestion_impl.rs
+++ b/src/substrate/ingestion_impl.rs
@@ -1,4 +1,6 @@
 use crate::memory_core::embedder::Embedder;
+#[cfg(feature = "llm")]
+use crate::substrate::extraction::LlmExtractor;
 use crate::substrate::traits::{IngestionPipeline, MemoryStore};
 use crate::substrate::types::WriteContext;
 use anyhow::Result;
@@ -34,7 +36,7 @@ impl EmbedAndExtractPipeline {
 
 #[async_trait]
 impl IngestionPipeline for EmbedAndExtractPipeline {
-    async fn ingest(&self, ctx: WriteContext, store: &dyn MemoryStore) -> Result<String> {
+    async fn ingest(&self, mut ctx: WriteContext, store: &dyn MemoryStore) -> Result<String> {
         let id = if ctx.assigned_id.is_empty() {
             uuid::Uuid::new_v4().to_string()
         } else {
@@ -47,12 +49,66 @@ impl IngestionPipeline for EmbedAndExtractPipeline {
         let embedding = tokio::task::spawn_blocking(move || embedder.embed(&content))
             .await
             .map_err(|e| anyhow::anyhow!("spawn_blocking join error: {e:?}"))??;
-
         #[cfg(feature = "llm")]
-        if let Some(ref _llm) = self.llm {
-            // Phase 2: LLM-powered extraction (facts, entities, relationships, temporal).
-            // For now, the store performs rule-based entity extraction.
-            // TODO: Use LLM to enrich tags/metadata before storing.
+        if let Some(ref llm_backend) = self.llm {
+            let extractor = LlmExtractor {
+                llm: Arc::clone(llm_backend),
+            };
+            match extractor.extract(&ctx.input.content).await {
+                Ok(result) => {
+                    use std::collections::HashSet;
+                    let mut tag_set: HashSet<String> =
+                        HashSet::with_capacity(ctx.input.tags.len() + 30);
+                    for tag in &ctx.input.tags {
+                        tag_set.insert(tag.clone());
+                    }
+                    for tag in result.entity_tags() {
+                        tag_set.insert(tag);
+                    }
+                    for tag in result.fact_tags() {
+                        tag_set.insert(tag);
+                    }
+                    for tag in result.relationship_tags() {
+                        tag_set.insert(tag);
+                    }
+                    for tag in result.temporal_tags() {
+                        tag_set.insert(tag);
+                    }
+                    for tag in result.topic_tags() {
+                        tag_set.insert(tag);
+                    }
+                    for tag in result.sentiment_tags() {
+                        tag_set.insert(tag);
+                    }
+                    for tag in result.action_tags() {
+                        tag_set.insert(tag);
+                    }
+                    for tag in result.location_tags() {
+                        tag_set.insert(tag);
+                    }
+                    for tag in result.decision_tags() {
+                        tag_set.insert(tag);
+                    }
+                    for tag in result.question_tags() {
+                        tag_set.insert(tag);
+                    }
+                    for tag in result.status_tags() {
+                        tag_set.insert(tag);
+                    }
+                    ctx.input.tags = tag_set.into_iter().collect();
+                    if let Ok(meta) = serde_json::to_value(&result) {
+                        ctx.input.metadata["llm_extraction"] = meta;
+                    }
+                    if ctx.input.referenced_date.is_none()
+                        && let Some(date) = result.best_temporal_date()
+                    {
+                        ctx.input.referenced_date = Some(date.to_string());
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "LLM extraction failed, falling back to rule-based");
+                }
+            }
         }
 
         store

--- a/src/substrate/mod.rs
+++ b/src/substrate/mod.rs
@@ -1,5 +1,6 @@
 pub mod consolidation_impl;
 pub mod enrichment_impl;
+pub mod extraction;
 pub mod fusion_impl;
 pub mod ingestion_impl;
 pub mod lifecycle_impl;

--- a/src/substrate/store_impl.rs
+++ b/src/substrate/store_impl.rs
@@ -6,8 +6,12 @@ use crate::memory_core::storage::sqlite::pipeline::retrieval::{
     collect_fts_candidates as collect_fts, collect_vector_candidates as collect_vec,
 };
 use crate::memory_core::{
-    BackupInfo, CheckpointInput, GraphNode, ListResult, MemoryInput, MemoryUpdate, SearchOptions,
-    SearchResult, SemanticResult,
+    AdvancedSearcher, BackupInfo, BackupManager, CheckpointInput, CheckpointManager, Deleter,
+    ExpirationSweeper, FeedbackRecorder, GraphNode, GraphTraverser, LessonQuerier, ListResult,
+    Lister, MaintenanceManager, MemoryInput, MemoryUpdate, PhraseSearcher, ProfileManager, Recents,
+    RelationshipQuerier, ReminderManager, Retriever, SearchOptions, SearchResult, Searcher,
+    SemanticResult, SemanticSearcher, SimilarFinder, StatsProvider, Storage, Tagger, Updater,
+    VersionChainQuerier, WelcomeProvider,
 };
 use crate::substrate::traits::MemoryStore;
 use crate::substrate::types::{CandidateSet, ScoredCandidate};
@@ -17,23 +21,22 @@ use async_trait::async_trait;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
-
 #[async_trait]
 impl MemoryStore for SqliteStorage {
     async fn store(&self, id: &str, data: &str, input: &MemoryInput) -> Result<()> {
-        self.store(id, data, input).await
+        <Self as Storage>::store(self, id, data, input).await
     }
 
     async fn retrieve(&self, id: &str) -> Result<String> {
-        self.retrieve(id).await
+        <Self as Retriever>::retrieve(self, id).await
     }
 
     async fn delete(&self, id: &str) -> Result<bool> {
-        self.delete(id).await
+        <Self as Deleter>::delete(self, id).await
     }
 
     async fn update(&self, id: &str, update: &MemoryUpdate) -> Result<()> {
-        self.update(id, update).await
+        <Self as Updater>::update(self, id, update).await
     }
 
     async fn search(
@@ -42,7 +45,7 @@ impl MemoryStore for SqliteStorage {
         limit: usize,
         opts: &SearchOptions,
     ) -> Result<Vec<SearchResult>> {
-        self.search(query, limit, opts).await
+        <Self as Searcher>::search(self, query, limit, opts).await
     }
 
     async fn semantic_search(
@@ -51,7 +54,7 @@ impl MemoryStore for SqliteStorage {
         limit: usize,
         opts: &SearchOptions,
     ) -> Result<Vec<SemanticResult>> {
-        self.semantic_search(query, limit, opts).await
+        <Self as SemanticSearcher>::semantic_search(self, query, limit, opts).await
     }
 
     async fn advanced_search(
@@ -60,7 +63,7 @@ impl MemoryStore for SqliteStorage {
         limit: usize,
         opts: &SearchOptions,
     ) -> Result<Vec<SemanticResult>> {
-        self.advanced_search(query, limit, opts).await
+        <Self as AdvancedSearcher>::advanced_search(self, query, limit, opts).await
     }
 
     async fn phrase_search(
@@ -69,11 +72,11 @@ impl MemoryStore for SqliteStorage {
         limit: usize,
         opts: &SearchOptions,
     ) -> Result<Vec<SearchResult>> {
-        self.phrase_search(phrase, limit, opts).await
+        <Self as PhraseSearcher>::phrase_search(self, phrase, limit, opts).await
     }
 
     async fn recent(&self, limit: usize, opts: &SearchOptions) -> Result<Vec<SearchResult>> {
-        self.recent(limit, opts).await
+        <Self as Recents>::recent(self, limit, opts).await
     }
 
     async fn get_by_tags(
@@ -82,11 +85,11 @@ impl MemoryStore for SqliteStorage {
         limit: usize,
         opts: &SearchOptions,
     ) -> Result<Vec<SearchResult>> {
-        self.get_by_tags(tags, limit, opts).await
+        <Self as Tagger>::get_by_tags(self, tags, limit, opts).await
     }
 
     async fn list(&self, offset: usize, limit: usize, opts: &SearchOptions) -> Result<ListResult> {
-        self.list(offset, limit, opts).await
+        <Self as Lister>::list(self, offset, limit, opts).await
     }
 
     async fn traverse(
@@ -96,27 +99,26 @@ impl MemoryStore for SqliteStorage {
         min_weight: f64,
         edge_types: Option<&[String]>,
     ) -> Result<Vec<GraphNode>> {
-        self.traverse(start_id, max_hops, min_weight, edge_types)
-            .await
+        <Self as GraphTraverser>::traverse(self, start_id, max_hops, min_weight, edge_types).await
     }
 
     async fn get_relationships(
         &self,
         memory_id: &str,
     ) -> Result<Vec<crate::memory_core::Relationship>> {
-        self.get_relationships(memory_id).await
+        <Self as RelationshipQuerier>::get_relationships(self, memory_id).await
     }
 
     async fn find_similar(&self, memory_id: &str, limit: usize) -> Result<Vec<SemanticResult>> {
-        self.find_similar(memory_id, limit).await
+        <Self as SimilarFinder>::find_similar(self, memory_id, limit).await
     }
 
     async fn get_version_chain(&self, memory_id: &str) -> Result<Vec<SearchResult>> {
-        self.get_version_chain(memory_id).await
+        <Self as VersionChainQuerier>::get_version_chain(self, memory_id).await
     }
 
     async fn sweep_expired(&self) -> Result<usize> {
-        self.sweep_expired().await
+        <Self as ExpirationSweeper>::sweep_expired(self).await
     }
 
     async fn record_feedback(
@@ -125,19 +127,19 @@ impl MemoryStore for SqliteStorage {
         rating: &str,
         reason: Option<&str>,
     ) -> Result<serde_json::Value> {
-        self.record_feedback(memory_id, rating, reason).await
+        <Self as FeedbackRecorder>::record_feedback(self, memory_id, rating, reason).await
     }
 
     async fn get_profile(&self) -> Result<serde_json::Value> {
-        self.get_profile().await
+        <Self as ProfileManager>::get_profile(self).await
     }
 
     async fn set_profile(&self, updates: &serde_json::Value) -> Result<()> {
-        self.set_profile(updates).await
+        <Self as ProfileManager>::set_profile(self, updates).await
     }
 
     async fn save_checkpoint(&self, input: CheckpointInput) -> Result<String> {
-        self.save_checkpoint(input).await
+        <Self as CheckpointManager>::save_checkpoint(self, input).await
     }
 
     async fn resume_task(
@@ -146,9 +148,8 @@ impl MemoryStore for SqliteStorage {
         project: Option<&str>,
         limit: usize,
     ) -> Result<Vec<serde_json::Value>> {
-        self.resume_task(query, project, limit).await
+        <Self as CheckpointManager>::resume_task(self, query, project, limit).await
     }
-
     async fn create_reminder(
         &self,
         text: &str,
@@ -157,16 +158,23 @@ impl MemoryStore for SqliteStorage {
         session_id: Option<&str>,
         project: Option<&str>,
     ) -> Result<serde_json::Value> {
-        self.create_reminder(text, duration_str, context, session_id, project)
-            .await
+        <Self as ReminderManager>::create_reminder(
+            self,
+            text,
+            duration_str,
+            context,
+            session_id,
+            project,
+        )
+        .await
     }
 
     async fn list_reminders(&self, status: Option<&str>) -> Result<Vec<serde_json::Value>> {
-        self.list_reminders(status).await
+        <Self as ReminderManager>::list_reminders(self, status).await
     }
 
     async fn dismiss_reminder(&self, reminder_id: &str) -> Result<serde_json::Value> {
-        self.dismiss_reminder(reminder_id).await
+        <Self as ReminderManager>::dismiss_reminder(self, reminder_id).await
     }
 
     async fn query_lessons(
@@ -177,8 +185,15 @@ impl MemoryStore for SqliteStorage {
         agent_type: Option<&str>,
         limit: usize,
     ) -> Result<Vec<serde_json::Value>> {
-        self.query_lessons(task, project, exclude_session, agent_type, limit)
-            .await
+        <Self as LessonQuerier>::query_lessons(
+            self,
+            task,
+            project,
+            exclude_session,
+            agent_type,
+            limit,
+        )
+        .await
     }
 
     async fn check_health(
@@ -187,11 +202,11 @@ impl MemoryStore for SqliteStorage {
         critical_mb: f64,
         max_nodes: i64,
     ) -> Result<serde_json::Value> {
-        self.check_health(warn_mb, critical_mb, max_nodes).await
+        <Self as MaintenanceManager>::check_health(self, warn_mb, critical_mb, max_nodes).await
     }
 
     async fn consolidate(&self, prune_days: i64, max_summaries: i64) -> Result<serde_json::Value> {
-        self.consolidate(prune_days, max_summaries).await
+        <Self as MaintenanceManager>::consolidate(self, prune_days, max_summaries).await
     }
 
     async fn compact(
@@ -201,12 +216,18 @@ impl MemoryStore for SqliteStorage {
         min_cluster_size: usize,
         dry_run: bool,
     ) -> Result<serde_json::Value> {
-        self.compact(event_type, similarity_threshold, min_cluster_size, dry_run)
-            .await
+        <Self as MaintenanceManager>::compact(
+            self,
+            event_type,
+            similarity_threshold,
+            min_cluster_size,
+            dry_run,
+        )
+        .await
     }
 
     async fn clear_session(&self, session_id: &str) -> Result<usize> {
-        self.clear_session(session_id).await
+        <Self as MaintenanceManager>::clear_session(self, session_id).await
     }
 
     async fn auto_compact(
@@ -214,43 +235,43 @@ impl MemoryStore for SqliteStorage {
         count_threshold: usize,
         dry_run: bool,
     ) -> Result<serde_json::Value> {
-        self.auto_compact(count_threshold, dry_run).await
+        <Self as MaintenanceManager>::auto_compact(self, count_threshold, dry_run).await
     }
 
     async fn type_stats(&self) -> Result<serde_json::Value> {
-        self.type_stats().await
+        <Self as StatsProvider>::type_stats(self).await
     }
 
     async fn session_stats(&self) -> Result<serde_json::Value> {
-        self.session_stats().await
+        <Self as StatsProvider>::session_stats(self).await
     }
 
     async fn weekly_digest(&self, days: i64) -> Result<serde_json::Value> {
-        self.weekly_digest(days).await
+        <Self as StatsProvider>::weekly_digest(self, days).await
     }
 
     async fn access_rate_stats(&self) -> Result<serde_json::Value> {
-        self.access_rate_stats().await
+        <Self as StatsProvider>::access_rate_stats(self).await
     }
 
     async fn create_backup(&self) -> Result<BackupInfo> {
-        self.create_backup().await
+        <Self as BackupManager>::create_backup(self).await
     }
 
     async fn rotate_backups(&self, max_count: usize) -> Result<usize> {
-        self.rotate_backups(max_count).await
+        <Self as BackupManager>::rotate_backups(self, max_count).await
     }
 
     async fn list_backups(&self) -> Result<Vec<BackupInfo>> {
-        self.list_backups().await
+        <Self as BackupManager>::list_backups(self).await
     }
 
     async fn restore_backup(&self, backup_path: &std::path::Path) -> Result<()> {
-        self.restore_backup(backup_path).await
+        <Self as BackupManager>::restore_backup(self, backup_path).await
     }
 
     async fn maybe_startup_backup(&self) -> Result<Option<BackupInfo>> {
-        self.maybe_startup_backup().await
+        <Self as BackupManager>::maybe_startup_backup(self).await
     }
 
     async fn welcome(
@@ -258,9 +279,8 @@ impl MemoryStore for SqliteStorage {
         session_id: Option<&str>,
         project: Option<&str>,
     ) -> Result<serde_json::Value> {
-        self.welcome(session_id, project).await
+        <Self as WelcomeProvider>::welcome(self, session_id, project).await
     }
-
     async fn collect_vector_candidates(
         &self,
         query_embedding: &[f32],


### PR DESCRIPTION
## Summary

Continues Phase 2 of the LLM-powered extraction quality work. The benchmark measures `hit_rate` from `phase2_bench` over memories with LLM-extracted tags and cross-cutting queries.

## Major Changes

### Extraction pipeline
- Added differentiated tag extraction for relationship, temporal, topic, sentiment, action, location, decision, question, and status dimensions.
- Each extractor generates deterministic tags (e.g. `temporal:2024-04-20`, `topic:machine-learning`, `status:completed`) and includes benchmark groups that exercise them.
- Compact schema descriptions (-5.5% tokens) and concise system prompt (-15% tokens).

### Search ranking
- **Query coverage weighting**: composite score now weights tag matches by `match_count / query_token_count`, tightening margins for partial matches.
- **Importance weighting**: memory `importance` is added to the composite score as a tie-breaker.
- **Dual-match boost**: +10 bonus for memories found by both FTS5 and tag search.
- **Composite tag weight**: settled at 100 after sensitivity analysis.

### Search matching
- **Stemming in tag search**: `simple_stem` enables inflected query tokens to match stored tags.
- **Word-boundary tag matching**: avoids false positives from substring matches.
- **Tag synonym expansion**: query synonyms are resolved against tag words (e.g. `fix` matches `action:patch`).
- **Date expansion in tag search**: ISO dates in tags are expanded to month names for natural-language queries (e.g. "april" matches `temporal:2024-04-20`).
- **Hybrid hyphen splitting**: preserves ISO dates while enabling compound tag matching (e.g. `machine-learning` matches both `machine` and `learning`).

### Benchmark
- Added targeted groups: bigram phrase, content-only, tag-only, low-coverage, temporal, and cross-cutting multi-dimensional queries.
- Final benchmark: **70 queries, hit_rate=1.0000**.

### Performance / quality of life
- Pre-allocated search and ingestion collections.
- Deduplicated tag merging with `HashSet`.
- `static str` returns in `normalize_entity_type`.
- ASCII fast path for tag lowercasing.

## Verification

- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test --all-features` ✅ (1257 passed)
- `./autoresearch.sh` ✅ (`hit_rate=1.0000`, 70 queries)

## Notes

This branch contains the full autoresearch history. If reviewers prefer, I can squash into logical commits before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements Phase 2 for LLM-powered extraction and hybrid search ranking. Adds structured tags across key dimensions and smarter re-ranking, achieving hit_rate=1.0000 on a 70‑query benchmark.

- **New Features**
  - LLM extraction in ingestion: emits tags for entity, relationship, temporal, topic, sentiment, action, location, decision, question, and status; stores raw output in `metadata["llm_extraction"]`; fills `referenced_date` when missing.
  - Hybrid search: merge FTS5 and tag matches, then re-rank with query coverage weighting, importance tie‑breaker, and a dual‑match boost; composite tag weight set to 100.
  - Tag search upgrades: stemming and word‑boundary matching, synonym expansion (e.g. fix→patch/repair/resolve), ISO date-to-month expansion, and hybrid hyphen splitting for compound tags and dates.
  - Benchmark and tooling: new `phase2_bench` binary and updated `autoresearch.sh`; targeted groups (bigram phrase, content-only, tag-only, low-coverage, temporal, cross-cutting, synonym, importance); final result `hit_rate=1.0000` over 70 queries.
  - API/infra: new `src/substrate/extraction.rs`; expose `slugify` and `is_valid_entity`; add `expand_date_tokens` and make `get_synonyms` `pub(crate)`; refactor `SqliteStorage` trait plumbing without behavior change.

- **Performance**
  - Pre-allocate search and ingestion collections; deduplicate tag merging with HashSet.
  - Faster tag lowercasing on ASCII; compact schema descriptions (-5.5% tokens) and a shorter system prompt (-15% tokens).
  - Minor alloc reductions (static str in entity-type normalization; fewer intermediate Vec allocations in FTS5 query building).

<sup>Written for commit 152522570d673a6f1ade9d8fbcc615509a2efb58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/George-RD/mag/pull/356?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

