### PR TITLE
fix(search): self-heal FTS5 on open + substrate hardening (#343)

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -211,6 +211,8 @@ Run diagnostic health check.
 | critical_mb | number | no | 800.0 | Critical threshold in MB |
 | max_nodes | integer | no | 10000 | Maximum node count threshold |
 
+Output includes `fts5_indexed` (rows in the FTS index) and `fts5_in_sync` (whether the index matches the `memories` table); a diverged index adds a warning and raises status to at least `warning`.
+
 #### Action: `consolidate`
 
 Prune stale data.
@@ -239,6 +241,10 @@ Embedding-based automatic deduplication.
 |-----------|------|----------|---------|-------------|
 | count_threshold | integer | no | 500 | Memory count threshold to trigger compaction |
 | dry_run | boolean | no | false | Preview without applying changes |
+
+#### Action: `fts_rebuild`
+
+Rebuild the full-text search index from the `memories` table by dropping and re-inserting every row. Use when `health` reports `fts5_in_sync: false`, or to recover from content-level index drift that the automatic on-open repair does not detect. Returns `fts_rows_before`, `fts_rows_after`, and `memories_count`. No additional parameters.
 
 #### Action: `clear_session`
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -289,7 +289,7 @@ pub enum Commands {
         #[arg(long, default_value_t = 5)]
         limit: usize,
     },
-    /// System maintenance: health check, consolidate, compact, clear-session, backup, backup-list, backup-restore.
+    /// System maintenance: health check, consolidate, compact, fts-rebuild, clear-session, backup, backup-list, backup-restore.
     Maintain {
         #[arg(long)]
         action: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -860,6 +860,11 @@ async fn main() -> anyhow::Result<()> {
                     <SqliteStorage as MaintenanceManager>::clear_session(&mcp_storage, sid).await?;
                 println!("{}", json!({"session_id": sid, "removed": removed}));
             }
+            "fts-rebuild" | "fts_rebuild" => {
+                let result =
+                    <SqliteStorage as MaintenanceManager>::rebuild_fts(&mcp_storage).await?;
+                println!("{result}");
+            }
             "backup" => {
                 let info = <SqliteStorage as BackupManager>::create_backup(&mcp_storage).await?;
                 <SqliteStorage as BackupManager>::rotate_backups(&mcp_storage, 5).await?;
@@ -902,7 +907,7 @@ async fn main() -> anyhow::Result<()> {
                 );
             }
             other => anyhow::bail!(
-                "invalid maintain action: {other} (expected health|consolidate|compact|clear-session|backup|backup-list|backup-restore)"
+                "invalid maintain action: {other} (expected health|consolidate|compact|fts-rebuild|clear-session|backup|backup-list|backup-restore)"
             ),
         },
         Commands::Welcome {

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -176,7 +176,7 @@ pub const TOOL_REGISTRY: &[ToolMeta] = &[
     },
     ToolMeta {
         name: "memory_lifecycle",
-        summary: "System maintenance (action: sweep|health|consolidate|compact|auto_compact|clear_session)",
+        summary: "System maintenance (action: sweep|health|consolidate|compact|auto_compact|fts_rebuild|clear_session)",
         category: "Lifecycle & Feedback",
     },
     // Cross-Session
@@ -452,7 +452,7 @@ impl McpMemoryServer {
 
     #[tool(
         name = "memory_lifecycle",
-        description = "System maintenance. Actions: 'sweep' (default, expire TTL-based memories), 'health' (diagnostic with thresholds), 'consolidate' (prune stale data), 'compact' (merge near-duplicates), 'auto_compact' (embedding-based dedup), 'clear_session' (remove session data), 'backup' (create binary backup), 'backup_list' (list available backups)."
+        description = "System maintenance. Actions: 'sweep' (default, expire TTL-based memories), 'health' (diagnostic with thresholds, incl. FTS5 sync status), 'consolidate' (prune stale data), 'compact' (merge near-duplicates), 'auto_compact' (embedding-based dedup), 'fts_rebuild' (rebuild the full-text index from source), 'clear_session' (remove session data), 'backup' (create binary backup), 'backup_list' (list available backups)."
     )]
     async fn memory_lifecycle(
         &self,
@@ -526,7 +526,7 @@ impl McpMemoryServer {
 
     #[tool(
         name = "memory_manage",
-        description = "Unified manage facade (Wave 2). Routes to update/feedback/relations/lifecycle based on `action` field (default: \"update\"). Sub-actions: relations_action (list|add|traverse|version_chain), lifecycle_action (sweep|health|consolidate|compact|auto_compact|clear_session|backup|backup_list)."
+        description = "Unified manage facade (Wave 2). Routes to update/feedback/relations/lifecycle based on `action` field (default: \"update\"). Sub-actions: relations_action (list|add|traverse|version_chain), lifecycle_action (sweep|health|consolidate|compact|auto_compact|fts_rebuild|clear_session|backup|backup_list)."
     )]
     async fn memory_manage(
         &self,

--- a/src/mcp/request_types.rs
+++ b/src/mcp/request_types.rs
@@ -128,7 +128,7 @@ pub(crate) struct FeedbackRequest {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub(crate) struct LifecycleRequest {
-    /// Action: "sweep" (default, TTL expiration), "health", "consolidate", "compact", "auto_compact", "clear_session".
+    /// Action: "sweep" (default, TTL expiration), "health", "consolidate", "compact", "auto_compact", "fts_rebuild", "clear_session".
     pub action: Option<String>,
     pub warn_mb: Option<f64>,
     pub critical_mb: Option<f64>,
@@ -255,7 +255,7 @@ pub(crate) struct MemoryManageRequest {
     pub max_hops: Option<usize>,
     pub min_weight: Option<f64>,
     // ── lifecycle fields ──
-    /// Sub-action for action=lifecycle: "sweep" (default), "health", "consolidate", "compact", "auto_compact", "clear_session", "backup", "backup_list".
+    /// Sub-action for action=lifecycle: "sweep" (default), "health", "consolidate", "compact", "auto_compact", "fts_rebuild", "clear_session", "backup", "backup_list".
     pub lifecycle_action: Option<String>,
     pub warn_mb: Option<f64>,
     pub critical_mb: Option<f64>,

--- a/src/mcp/tools/facades.rs
+++ b/src/mcp/tools/facades.rs
@@ -341,6 +341,14 @@ pub(crate) async fn memory_manage(
                         json!({"session_id": sid, "removed": removed}).to_string(),
                     )]))
                 }
+                "fts_rebuild" => {
+                    let result = storage.rebuild_fts().await.map_err(|e| {
+                        McpError::internal_error(format!("fts_rebuild failed: {e}"), None)
+                    })?;
+                    Ok(CallToolResult::success(vec![Content::text(
+                        result.to_string(),
+                    )]))
+                }
                 "backup" => {
                     let info = <SqliteStorage as BackupManager>::create_backup(storage)
                         .await
@@ -379,7 +387,7 @@ pub(crate) async fn memory_manage(
                 }
                 other => Err(McpError::invalid_params(
                     format!(
-                        "unknown lifecycle_action: {other} (expected sweep|health|consolidate|compact|auto_compact|clear_session|backup|backup_list)"
+                        "unknown lifecycle_action: {other} (expected sweep|health|consolidate|compact|auto_compact|fts_rebuild|clear_session|backup|backup_list)"
                     ),
                     None,
                 )),

--- a/src/mcp/tools/lifecycle.rs
+++ b/src/mcp/tools/lifecycle.rs
@@ -180,6 +180,15 @@ pub(crate) async fn memory_lifecycle(
                 json!({"session_id": sid, "removed": removed}).to_string(),
             )]))
         }
+        "fts_rebuild" => {
+            let result = storage
+                .rebuild_fts()
+                .await
+                .map_err(|e| McpError::internal_error(format!("fts_rebuild failed: {e}"), None))?;
+            Ok(CallToolResult::success(vec![Content::text(
+                result.to_string(),
+            )]))
+        }
         "backup" => {
             let info = <SqliteStorage as BackupManager>::create_backup(storage)
                 .await
@@ -214,7 +223,7 @@ pub(crate) async fn memory_lifecycle(
         }
         other => Err(McpError::invalid_params(
             format!(
-                "unknown lifecycle action: {other} (expected sweep|health|consolidate|compact|auto_compact|clear_session|backup|backup_list)"
+                "unknown lifecycle action: {other} (expected sweep|health|consolidate|compact|auto_compact|fts_rebuild|clear_session|backup|backup_list)"
             ),
             None,
         )),

--- a/src/memory_core/domain.rs
+++ b/src/memory_core/domain.rs
@@ -486,10 +486,12 @@ pub fn parse_duration(text: &str) -> Result<chrono::Duration> {
         }
     }
 
-    let total = chrono::Duration::weeks(weeks)
-        + chrono::Duration::days(days)
-        + chrono::Duration::hours(hours)
-        + chrono::Duration::minutes(minutes);
+    let overflow = || anyhow::anyhow!("duration out of range: {text}");
+    let total = chrono::Duration::try_weeks(weeks)
+        .and_then(|t| t.checked_add(&chrono::Duration::try_days(days)?))
+        .and_then(|t| t.checked_add(&chrono::Duration::try_hours(hours)?))
+        .and_then(|t| t.checked_add(&chrono::Duration::try_minutes(minutes)?))
+        .ok_or_else(overflow)?;
 
     if total.num_seconds() <= 0 {
         return Err(anyhow::anyhow!("duration must be greater than zero"));

--- a/src/memory_core/storage/sqlite/admin/maintenance.rs
+++ b/src/memory_core/storage/sqlite/admin/maintenance.rs
@@ -24,6 +24,10 @@ impl MaintenanceManager for SqliteStorage {
                 .query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))
                 .context("failed to count memories")?;
 
+            let fts_count: i64 = conn
+                .query_row("SELECT COUNT(*) FROM memories_fts", [], |row| row.get(0))
+                .context("failed to count FTS5 rows")?;
+
             let integrity: String = conn
                 .query_row("PRAGMA integrity_check", [], |row| row.get(0))
                 .unwrap_or_else(|_| "error".to_string());
@@ -41,7 +45,7 @@ impl MaintenanceManager for SqliteStorage {
             let db_size_mb = db_size_bytes as f64 / (1024.0 * 1024.0);
 
             let mut warnings: Vec<String> = Vec::new();
-            let status;
+            let mut status;
 
             if !integrity_ok {
                 status = "critical";
@@ -65,12 +69,24 @@ impl MaintenanceManager for SqliteStorage {
                 status = "healthy";
             }
 
+            let fts5_in_sync = fts_count == node_count;
+            if !fts5_in_sync {
+                warnings.push(format!(
+                    "FTS5 index out of sync: {fts_count} indexed vs {node_count} memories (run `mag maintain --action fts-rebuild`)"
+                ));
+                if status == "healthy" {
+                    status = "warning";
+                }
+            }
+
             Ok::<_, anyhow::Error>(serde_json::json!({
                 "status": status,
                 "db_size_mb": (db_size_mb * 100.0).round() / 100.0,
                 "node_count": node_count,
                 "max_nodes": max_nodes,
                 "integrity_ok": integrity_ok,
+                "fts5_indexed": fts_count,
+                "fts5_in_sync": fts5_in_sync,
                 "warnings": warnings,
             }))
         })
@@ -578,5 +594,49 @@ impl MaintenanceManager for SqliteStorage {
         }
 
         Ok(deleted)
+    }
+
+    async fn rebuild_fts(&self) -> Result<serde_json::Value> {
+        let pool = Arc::clone(&self.pool);
+
+        let result = tokio::task::spawn_blocking(move || {
+            let conn = pool.writer()?;
+
+            let before: i64 = conn
+                .query_row("SELECT COUNT(*) FROM memories_fts", [], |row| row.get(0))
+                .context("failed to count FTS5 rows")?;
+            let memories: i64 = conn
+                .query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))
+                .context("failed to count memory rows")?;
+
+            let tx = retry_on_lock(|| conn.unchecked_transaction())
+                .context("failed to start FTS rebuild transaction")?;
+            tx.execute("DELETE FROM memories_fts", [])
+                .context("failed to clear FTS5 index during rebuild")?;
+            tx.execute(
+                "INSERT INTO memories_fts(id, content) SELECT id, content FROM memories",
+                [],
+            )
+            .context("failed to repopulate FTS5 index during rebuild")?;
+            tx.commit().context("failed to commit FTS rebuild")?;
+
+            let after: i64 = conn
+                .query_row("SELECT COUNT(*) FROM memories_fts", [], |row| row.get(0))
+                .context("failed to count FTS5 rows after rebuild")?;
+
+            tracing::info!(before, after, memories, "rebuilt FTS5 index");
+            Ok::<_, anyhow::Error>(serde_json::json!({
+                "fts_rows_before": before,
+                "fts_rows_after": after,
+                "memories_count": memories,
+            }))
+        })
+        .await
+        .context("spawn_blocking join error")??;
+
+        // The index changed underneath any cached results.
+        self.invalidate_query_cache();
+
+        Ok(result)
     }
 }

--- a/src/memory_core/storage/sqlite/admin/maintenance.rs
+++ b/src/memory_core/storage/sqlite/admin/maintenance.rs
@@ -24,9 +24,8 @@ impl MaintenanceManager for SqliteStorage {
                 .query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))
                 .context("failed to count memories")?;
 
-            let fts_count: i64 = conn
-                .query_row("SELECT COUNT(*) FROM memories_fts", [], |row| row.get(0))
-                .context("failed to count FTS5 rows")?;
+            let fts = super::super::schema::fts_diagnostic(&conn);
+            let fts_count = fts.indexed_count.unwrap_or(0);
 
             let integrity: String = conn
                 .query_row("PRAGMA integrity_check", [], |row| row.get(0))
@@ -69,17 +68,13 @@ impl MaintenanceManager for SqliteStorage {
                 status = "healthy";
             }
 
-            let (fts_orphaned, fts_missing) = super::super::schema::fts_divergence(&conn)?;
-            let fts5_in_sync = fts_orphaned == 0 && fts_missing == 0;
-            if !fts5_in_sync {
-                warnings.push(format!(
-                    "FTS5 index out of sync: {fts_orphaned} orphaned index rows, {fts_missing} unindexed memories (run `mag maintain --action fts-rebuild`)"
-                ));
+            let fts5_in_sync = fts.in_sync();
+            if let Some(w) = fts.warning() {
+                warnings.push(w);
                 if status == "healthy" {
                     status = "warning";
                 }
             }
-
             Ok::<_, anyhow::Error>(serde_json::json!({
                 "status": status,
                 "db_size_mb": (db_size_mb * 100.0).round() / 100.0,

--- a/src/memory_core/storage/sqlite/admin/maintenance.rs
+++ b/src/memory_core/storage/sqlite/admin/maintenance.rs
@@ -598,23 +598,21 @@ impl MaintenanceManager for SqliteStorage {
         let result = tokio::task::spawn_blocking(move || {
             let conn = pool.writer()?;
 
+            // A structurally corrupt index can make the pre-rebuild count fail;
+            // tolerate that and report what we can rather than aborting the repair.
             let before: i64 = conn
                 .query_row("SELECT COUNT(*) FROM memories_fts", [], |row| row.get(0))
-                .context("failed to count FTS5 rows")?;
+                .unwrap_or(0);
             let memories: i64 = conn
                 .query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))
                 .context("failed to count memory rows")?;
 
-            let tx = retry_on_lock(|| conn.unchecked_transaction())
-                .context("failed to start FTS rebuild transaction")?;
-            tx.execute("DELETE FROM memories_fts", [])
-                .context("failed to clear FTS5 index during rebuild")?;
-            tx.execute(
-                "INSERT INTO memories_fts(id, content) SELECT id, content FROM memories",
-                [],
-            )
-            .context("failed to repopulate FTS5 index during rebuild")?;
-            tx.commit().context("failed to commit FTS rebuild")?;
+            // Full DROP + recreate + repopulate from `memories`. A surgical
+            // DELETE + re-INSERT leaves residual shadow-table damage on a
+            // structurally corrupt index, so the safe path rebuilds the virtual
+            // table from scratch (issue #343).
+            let reindexed = super::super::schema::rebuild_fts_from_source(&conn)
+                .context("failed to rebuild FTS5 index from source")?;
 
             let after: i64 = conn
                 .query_row("SELECT COUNT(*) FROM memories_fts", [], |row| row.get(0))
@@ -625,6 +623,7 @@ impl MaintenanceManager for SqliteStorage {
                 "fts_rows_before": before,
                 "fts_rows_after": after,
                 "memories_count": memories,
+                "reindexed": reindexed,
             }))
         })
         .await

--- a/src/memory_core/storage/sqlite/admin/maintenance.rs
+++ b/src/memory_core/storage/sqlite/admin/maintenance.rs
@@ -69,10 +69,11 @@ impl MaintenanceManager for SqliteStorage {
                 status = "healthy";
             }
 
-            let fts5_in_sync = fts_count == node_count;
+            let (fts_orphaned, fts_missing) = super::super::schema::fts_divergence(&conn)?;
+            let fts5_in_sync = fts_orphaned == 0 && fts_missing == 0;
             if !fts5_in_sync {
                 warnings.push(format!(
-                    "FTS5 index out of sync: {fts_count} indexed vs {node_count} memories (run `mag maintain --action fts-rebuild`)"
+                    "FTS5 index out of sync: {fts_orphaned} orphaned index rows, {fts_missing} unindexed memories (run `mag maintain --action fts-rebuild`)"
                 ));
                 if status == "healthy" {
                     status = "warning";

--- a/src/memory_core/storage/sqlite/conn_pool.rs
+++ b/src/memory_core/storage/sqlite/conn_pool.rs
@@ -125,6 +125,14 @@ impl ConnPool {
             tracing::debug!("startup WAL checkpoint skipped: {e}");
         }
 
+        // Self-heal a diverged FTS5 index from a reused database (issue #343).
+        // Non-fatal: a repair failure must not block opening the DB.
+        match super::schema::ensure_fts_sync(&writer) {
+            Ok(0) => {}
+            Ok(repaired) => tracing::warn!(repaired, "repaired out-of-sync FTS5 index on open"),
+            Err(e) => tracing::warn!("FTS5 sync check failed (continuing): {e}"),
+        }
+
         let mut readers = Vec::with_capacity(DEFAULT_READER_COUNT);
         for _ in 0..DEFAULT_READER_COUNT {
             let reader = open_connection(path)?;

--- a/src/memory_core/storage/sqlite/crud.rs
+++ b/src/memory_core/storage/sqlite/crud.rs
@@ -4,6 +4,331 @@ use crate::memory_core::storage::sqlite::pipeline::scoring::bump_token_cache_gen
 #[async_trait]
 impl Storage for SqliteStorage {
     async fn store(&self, id: &str, data: &str, input: &MemoryInput) -> Result<()> {
+        self.store_internal(id, data, input, None).await
+    }
+}
+
+#[async_trait]
+impl Retriever for SqliteStorage {
+    async fn retrieve(&self, id: &str) -> Result<String> {
+        let pool = Arc::clone(&self.pool);
+        let id = id.to_string();
+
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.writer()?;
+            let tx = retry_on_lock(|| conn.unchecked_transaction())
+                .context("failed to start sqlite transaction")?;
+
+            let content: Option<String> = tx
+                .query_row(
+                    "SELECT content FROM memories WHERE id = ?1",
+                    params![id],
+                    |row| row.get(0),
+                )
+                .optional()
+                .context("failed to query memory content")?;
+
+            let content = content.ok_or_else(|| anyhow!("memory not found for id={id}"))?;
+
+            tx.execute(
+                "UPDATE memories
+                 SET
+                     last_accessed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+                     access_count = access_count + 1
+                 WHERE id = ?1",
+                params![id],
+            )
+            .context("failed to update last_accessed_at")?;
+
+            tx.commit().context("failed to commit sqlite transaction")?;
+            Ok::<_, anyhow::Error>(content)
+        })
+        .await
+        .context("spawn_blocking join error")?
+    }
+}
+
+#[async_trait]
+impl Deleter for SqliteStorage {
+    async fn delete(&self, id: &str) -> Result<bool> {
+        let pool = Arc::clone(&self.pool);
+        let id = id.to_string();
+
+        let deleted = tokio::task::spawn_blocking(move || {
+            let conn = pool.writer()?;
+            let tx = retry_on_lock(|| conn.unchecked_transaction())
+                .context("failed to start delete transaction")?;
+            tx.execute("DELETE FROM memories_fts WHERE id = ?1", params![id])
+                .context("failed to delete memory from FTS index")?;
+
+            #[cfg(feature = "sqlite-vec")]
+            vec_delete(&tx, &id)?;
+
+            let changes = tx
+                .execute("DELETE FROM memories WHERE id = ?1", params![id])
+                .context("failed to delete memory")?;
+            tx.commit().context("failed to commit delete transaction")?;
+            drop(conn); // Release writer Mutex before note_write to avoid deadlock
+            pool.note_write();
+            Ok::<_, anyhow::Error>(changes > 0)
+        })
+        .await
+        .context("spawn_blocking join error")??;
+        bump_token_cache_gen();
+        self.invalidate_query_cache();
+        self.refresh_hot_cache_best_effort();
+        Ok(deleted)
+    }
+}
+
+#[async_trait]
+impl Updater for SqliteStorage {
+    async fn update(&self, id: &str, input: &MemoryUpdate) -> Result<()> {
+        if input.content.is_none()
+            && input.tags.is_none()
+            && input.importance.is_none()
+            && input.metadata.is_none()
+            && input.event_type.is_none()
+            && input.priority.is_none()
+        {
+            return Err(anyhow!(
+                "at least one of content, tags, importance, metadata, event_type, or priority must be provided"
+            ));
+        }
+
+        let tags_json = input
+            .tags
+            .as_ref()
+            .map(|tags| serde_json::to_string(tags).context("failed to serialize tags"))
+            .transpose()?;
+        let metadata_json = input
+            .metadata
+            .as_ref()
+            .map(|metadata| serde_json::to_string(metadata).context("failed to serialize metadata"))
+            .transpose()?;
+        let event_type = event_type_to_sql(&input.event_type);
+        let priority = input.priority;
+        let importance = input.importance;
+        let content = input.content.clone();
+
+        let pool = Arc::clone(&self.pool);
+        let embedder = Arc::clone(&self.embedder);
+        let id = id.to_string();
+
+        tokio::task::spawn_blocking(move || {
+            let content_fields = match content.as_deref() {
+                Some(new_content) => {
+                    let hash = content_hash(new_content);
+                    let canonical = canonical_hash(new_content);
+                    let emb = encode_embedding(&embedder.embed(new_content)?);
+                    Some((new_content.to_string(), hash, canonical, emb))
+                }
+                None => None,
+            };
+            use rusqlite::types::Value as SqlValue;
+
+            let conn = pool.writer()?;
+
+            let mut set_clauses = Vec::new();
+            let mut values: Vec<SqlValue> = Vec::new();
+            let mut next_param_index = 2;
+
+            if let Some((new_content, hash, canonical, embedding)) = &content_fields {
+                set_clauses.push(format!("content = ?{next_param_index}"));
+                values.push(SqlValue::Text(new_content.clone()));
+                next_param_index += 1;
+
+                set_clauses.push(format!("content_hash = ?{next_param_index}"));
+                values.push(SqlValue::Text(hash.clone()));
+                next_param_index += 1;
+
+                set_clauses.push(format!("embedding = ?{next_param_index}"));
+                values.push(SqlValue::Blob(embedding.clone()));
+                next_param_index += 1;
+
+                set_clauses.push(format!("canonical_hash = ?{next_param_index}"));
+                values.push(SqlValue::Text(canonical.clone()));
+                next_param_index += 1;
+            }
+
+            if let Some(new_tags) = &tags_json {
+                set_clauses.push(format!("tags = ?{next_param_index}"));
+                values.push(SqlValue::Text(new_tags.clone()));
+                next_param_index += 1;
+            }
+
+            if let Some(new_importance) = importance {
+                set_clauses.push(format!("importance = ?{next_param_index}"));
+                values.push(SqlValue::Real(new_importance));
+                next_param_index += 1;
+            }
+
+            if let Some(new_metadata) = &metadata_json {
+                set_clauses.push(format!("metadata = ?{next_param_index}"));
+                values.push(SqlValue::Text(new_metadata.clone()));
+                next_param_index += 1;
+            }
+
+            if let Some(new_event_type) = &event_type {
+                set_clauses.push(format!("event_type = ?{next_param_index}"));
+                values.push(SqlValue::Text(new_event_type.clone()));
+                next_param_index += 1;
+            }
+
+            if let Some(new_priority) = priority {
+                set_clauses.push(format!("priority = ?{next_param_index}"));
+                values.push(SqlValue::Integer(i64::from(new_priority)));
+            }
+
+            let sql = format!(
+                "UPDATE memories SET {},
+                 last_accessed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+                 WHERE id = ?1",
+                set_clauses.join(", ")
+            );
+
+            let mut params: Vec<&dyn rusqlite::types::ToSql> = Vec::with_capacity(values.len() + 1);
+            params.push(&id);
+            for value in &values {
+                params.push(value);
+            }
+
+            let tx = retry_on_lock(|| conn.unchecked_transaction())
+                .context("failed to start update transaction")?;
+
+            let changes = tx
+                .execute(&sql, params.as_slice())
+                .context("failed to update memory")?;
+
+            if changes == 0 {
+                return Err(anyhow!("memory not found for id={id}"));
+            }
+
+            if let Some((new_content, _, _, ref _embedding)) = content_fields {
+                tx.execute("DELETE FROM memories_fts WHERE id = ?1", params![id])
+                    .context("failed to delete existing FTS row during update")?;
+                tx.execute(
+                    "INSERT INTO memories_fts(id, content) VALUES (?1, ?2)",
+                    params![id, new_content],
+                )
+                .context("failed to insert FTS row during update")?;
+
+                #[cfg(feature = "sqlite-vec")]
+                vec_upsert(&tx, &id, _embedding)?;
+            }
+
+            tx.commit().context("failed to commit update transaction")?;
+            drop(conn); // Release writer Mutex before note_write to avoid deadlock
+            pool.note_write();
+
+            Ok::<_, anyhow::Error>(())
+        })
+        .await
+        .context("spawn_blocking join error")??;
+        bump_token_cache_gen();
+        self.invalidate_query_cache();
+        self.refresh_hot_cache_best_effort();
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Tagger for SqliteStorage {
+    async fn get_by_tags(
+        &self,
+        tags: &[String],
+        limit: usize,
+        opts: &SearchOptions,
+    ) -> Result<Vec<SearchResult>> {
+        if tags.is_empty() || limit == 0 {
+            return Ok(Vec::new());
+        }
+
+        let pool = Arc::clone(&self.pool);
+        let tags = tags.to_vec();
+        let effective_limit = i64::try_from(limit).context("tag search limit exceeds i64")?;
+        let opts = opts.clone();
+
+        tokio::task::spawn_blocking(move || {
+            let conn = pool.reader()?;
+
+            // Build dynamic WHERE clause with dual-read support:
+            // - JSON tags: json_valid + json_each
+            // - Legacy CSV tags: instr-based comma-delimited matching
+            let mut json_conditions = Vec::new();
+            let mut csv_conditions = Vec::new();
+            let mut param_values: Vec<String> = Vec::new();
+            for (i, tag) in tags.iter().enumerate() {
+                let p = i + 1;
+                json_conditions.push(format!(
+                    "EXISTS (SELECT 1 FROM json_each(memories.tags) WHERE value = ?{p})"
+                ));
+                csv_conditions.push(format!(
+                    "instr(',' || memories.tags || ',', ',' || ?{p} || ',') > 0"
+                ));
+                param_values.push(tag.clone());
+            }
+            let json_clause = json_conditions.join(" AND ");
+            let csv_clause = csv_conditions.join(" AND ");
+            let mut sql = format!(
+                "SELECT id, content, tags, importance, metadata, event_type, session_id, project, entity_id, agent_type FROM memories \
+                 WHERE ((json_valid(memories.tags) AND {json_clause}) \
+                         OR (NOT json_valid(memories.tags) AND memories.tags != '' AND {csv_clause})) \
+                 "
+            );
+
+            let mut next_idx = param_values.len();
+            if let Some(ref event_type) = opts.event_type {
+                next_idx += 1;
+                sql.push_str(&format!(" AND event_type = ?{next_idx}"));
+                param_values.push(event_type.to_string());
+            }
+            if let Some(project) = opts.project.clone() {
+                next_idx += 1;
+                sql.push_str(&format!(" AND project = ?{next_idx}"));
+                param_values.push(project);
+            }
+            if let Some(session_id) = opts.session_id.clone() {
+                next_idx += 1;
+                sql.push_str(&format!(" AND session_id = ?{next_idx}"));
+                param_values.push(session_id);
+            }
+            next_idx += 1;
+            sql.push_str(&format!(" ORDER BY last_accessed_at DESC LIMIT ?{next_idx}"));
+
+            let mut stmt = conn
+                .prepare(&sql)
+                .context("failed to prepare tag search query")?;
+
+            let mut param_refs: Vec<&dyn rusqlite::types::ToSql> = Vec::new();
+            for v in &param_values {
+                param_refs.push(v);
+            }
+            param_refs.push(&effective_limit);
+
+            let rows = stmt
+                .query_map(param_refs.as_slice(), search_result_from_row)
+                .context("failed to execute tag search query")?;
+
+            let mut results = Vec::new();
+            for row in rows {
+                results.push(row.context("failed to decode tag search row")?);
+            }
+            Ok::<_, anyhow::Error>(results)
+        })
+        .await
+        .context("spawn_blocking join error")?
+    }
+}
+
+impl SqliteStorage {
+    pub(crate) async fn store_internal(
+        &self,
+        id: &str,
+        data: &str,
+        input: &MemoryInput,
+        precomputed_embedding: Option<Vec<f32>>,
+    ) -> Result<()> {
         let tags_json =
             serde_json::to_string(&input.tags).context("failed to serialize tags to JSON")?;
         let metadata_json = serde_json::to_string(&input.metadata)
@@ -31,6 +356,7 @@ impl Storage for SqliteStorage {
         let source_type = input.source_type.clone();
         let id_for_store = id.clone();
 
+        let precomputed_embedding = precomputed_embedding;
         let (outcome, superseded_ids, final_tags) = tokio::task::spawn_blocking(move || {
             let c_hash = content_hash(&data);
             let normalized_hash = canonical_hash(&data);
@@ -142,7 +468,10 @@ impl Storage for SqliteStorage {
             }
 
             // ── Phase 2: Embedding (the real bottleneck, ~8ms) ──
-            let embedding_vec = embedder.embed(&data)?;
+            let embedding_vec = match precomputed_embedding {
+                Some(vec) => vec,
+                None => embedder.embed(&data)?,
+            };
             let embedding = encode_embedding(&embedding_vec);
 
             // ── Phase 3: Supersession detection ──
@@ -477,322 +806,7 @@ impl Storage for SqliteStorage {
         bump_token_cache_gen();
         Ok(())
     }
-}
 
-#[async_trait]
-impl Retriever for SqliteStorage {
-    async fn retrieve(&self, id: &str) -> Result<String> {
-        let pool = Arc::clone(&self.pool);
-        let id = id.to_string();
-
-        tokio::task::spawn_blocking(move || {
-            let conn = pool.writer()?;
-            let tx = retry_on_lock(|| conn.unchecked_transaction())
-                .context("failed to start sqlite transaction")?;
-
-            let content: Option<String> = tx
-                .query_row(
-                    "SELECT content FROM memories WHERE id = ?1",
-                    params![id],
-                    |row| row.get(0),
-                )
-                .optional()
-                .context("failed to query memory content")?;
-
-            let content = content.ok_or_else(|| anyhow!("memory not found for id={id}"))?;
-
-            tx.execute(
-                "UPDATE memories
-                 SET
-                     last_accessed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
-                     access_count = access_count + 1
-                 WHERE id = ?1",
-                params![id],
-            )
-            .context("failed to update last_accessed_at")?;
-
-            tx.commit().context("failed to commit sqlite transaction")?;
-            Ok::<_, anyhow::Error>(content)
-        })
-        .await
-        .context("spawn_blocking join error")?
-    }
-}
-
-#[async_trait]
-impl Deleter for SqliteStorage {
-    async fn delete(&self, id: &str) -> Result<bool> {
-        let pool = Arc::clone(&self.pool);
-        let id = id.to_string();
-
-        let deleted = tokio::task::spawn_blocking(move || {
-            let conn = pool.writer()?;
-            let tx = retry_on_lock(|| conn.unchecked_transaction())
-                .context("failed to start delete transaction")?;
-            tx.execute("DELETE FROM memories_fts WHERE id = ?1", params![id])
-                .context("failed to delete memory from FTS index")?;
-
-            #[cfg(feature = "sqlite-vec")]
-            vec_delete(&tx, &id)?;
-
-            let changes = tx
-                .execute("DELETE FROM memories WHERE id = ?1", params![id])
-                .context("failed to delete memory")?;
-            tx.commit().context("failed to commit delete transaction")?;
-            drop(conn); // Release writer Mutex before note_write to avoid deadlock
-            pool.note_write();
-            Ok::<_, anyhow::Error>(changes > 0)
-        })
-        .await
-        .context("spawn_blocking join error")??;
-        bump_token_cache_gen();
-        self.invalidate_query_cache();
-        self.refresh_hot_cache_best_effort();
-        Ok(deleted)
-    }
-}
-
-#[async_trait]
-impl Updater for SqliteStorage {
-    async fn update(&self, id: &str, input: &MemoryUpdate) -> Result<()> {
-        if input.content.is_none()
-            && input.tags.is_none()
-            && input.importance.is_none()
-            && input.metadata.is_none()
-            && input.event_type.is_none()
-            && input.priority.is_none()
-        {
-            return Err(anyhow!(
-                "at least one of content, tags, importance, metadata, event_type, or priority must be provided"
-            ));
-        }
-
-        let tags_json = input
-            .tags
-            .as_ref()
-            .map(|tags| serde_json::to_string(tags).context("failed to serialize tags"))
-            .transpose()?;
-        let metadata_json = input
-            .metadata
-            .as_ref()
-            .map(|metadata| serde_json::to_string(metadata).context("failed to serialize metadata"))
-            .transpose()?;
-        let event_type = event_type_to_sql(&input.event_type);
-        let priority = input.priority;
-        let importance = input.importance;
-        let content = input.content.clone();
-
-        let pool = Arc::clone(&self.pool);
-        let embedder = Arc::clone(&self.embedder);
-        let id = id.to_string();
-
-        tokio::task::spawn_blocking(move || {
-            let content_fields = match content.as_deref() {
-                Some(new_content) => {
-                    let hash = content_hash(new_content);
-                    let canonical = canonical_hash(new_content);
-                    let emb = encode_embedding(&embedder.embed(new_content)?);
-                    Some((new_content.to_string(), hash, canonical, emb))
-                }
-                None => None,
-            };
-            use rusqlite::types::Value as SqlValue;
-
-            let conn = pool.writer()?;
-
-            let mut set_clauses = Vec::new();
-            let mut values: Vec<SqlValue> = Vec::new();
-            let mut next_param_index = 2;
-
-            if let Some((new_content, hash, canonical, embedding)) = &content_fields {
-                set_clauses.push(format!("content = ?{next_param_index}"));
-                values.push(SqlValue::Text(new_content.clone()));
-                next_param_index += 1;
-
-                set_clauses.push(format!("content_hash = ?{next_param_index}"));
-                values.push(SqlValue::Text(hash.clone()));
-                next_param_index += 1;
-
-                set_clauses.push(format!("embedding = ?{next_param_index}"));
-                values.push(SqlValue::Blob(embedding.clone()));
-                next_param_index += 1;
-
-                set_clauses.push(format!("canonical_hash = ?{next_param_index}"));
-                values.push(SqlValue::Text(canonical.clone()));
-                next_param_index += 1;
-            }
-
-            if let Some(new_tags) = &tags_json {
-                set_clauses.push(format!("tags = ?{next_param_index}"));
-                values.push(SqlValue::Text(new_tags.clone()));
-                next_param_index += 1;
-            }
-
-            if let Some(new_importance) = importance {
-                set_clauses.push(format!("importance = ?{next_param_index}"));
-                values.push(SqlValue::Real(new_importance));
-                next_param_index += 1;
-            }
-
-            if let Some(new_metadata) = &metadata_json {
-                set_clauses.push(format!("metadata = ?{next_param_index}"));
-                values.push(SqlValue::Text(new_metadata.clone()));
-                next_param_index += 1;
-            }
-
-            if let Some(new_event_type) = &event_type {
-                set_clauses.push(format!("event_type = ?{next_param_index}"));
-                values.push(SqlValue::Text(new_event_type.clone()));
-                next_param_index += 1;
-            }
-
-            if let Some(new_priority) = priority {
-                set_clauses.push(format!("priority = ?{next_param_index}"));
-                values.push(SqlValue::Integer(i64::from(new_priority)));
-            }
-
-            let sql = format!(
-                "UPDATE memories SET {},
-                 last_accessed_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
-                 WHERE id = ?1",
-                set_clauses.join(", ")
-            );
-
-            let mut params: Vec<&dyn rusqlite::types::ToSql> = Vec::with_capacity(values.len() + 1);
-            params.push(&id);
-            for value in &values {
-                params.push(value);
-            }
-
-            let tx = retry_on_lock(|| conn.unchecked_transaction())
-                .context("failed to start update transaction")?;
-
-            let changes = tx
-                .execute(&sql, params.as_slice())
-                .context("failed to update memory")?;
-
-            if changes == 0 {
-                return Err(anyhow!("memory not found for id={id}"));
-            }
-
-            if let Some((new_content, _, _, ref _embedding)) = content_fields {
-                tx.execute("DELETE FROM memories_fts WHERE id = ?1", params![id])
-                    .context("failed to delete existing FTS row during update")?;
-                tx.execute(
-                    "INSERT INTO memories_fts(id, content) VALUES (?1, ?2)",
-                    params![id, new_content],
-                )
-                .context("failed to insert FTS row during update")?;
-
-                #[cfg(feature = "sqlite-vec")]
-                vec_upsert(&tx, &id, _embedding)?;
-            }
-
-            tx.commit().context("failed to commit update transaction")?;
-            drop(conn); // Release writer Mutex before note_write to avoid deadlock
-            pool.note_write();
-
-            Ok::<_, anyhow::Error>(())
-        })
-        .await
-        .context("spawn_blocking join error")??;
-        bump_token_cache_gen();
-        self.invalidate_query_cache();
-        self.refresh_hot_cache_best_effort();
-        Ok(())
-    }
-}
-
-#[async_trait]
-impl Tagger for SqliteStorage {
-    async fn get_by_tags(
-        &self,
-        tags: &[String],
-        limit: usize,
-        opts: &SearchOptions,
-    ) -> Result<Vec<SearchResult>> {
-        if tags.is_empty() || limit == 0 {
-            return Ok(Vec::new());
-        }
-
-        let pool = Arc::clone(&self.pool);
-        let tags = tags.to_vec();
-        let effective_limit = i64::try_from(limit).context("tag search limit exceeds i64")?;
-        let opts = opts.clone();
-
-        tokio::task::spawn_blocking(move || {
-            let conn = pool.reader()?;
-
-            // Build dynamic WHERE clause with dual-read support:
-            // - JSON tags: json_valid + json_each
-            // - Legacy CSV tags: instr-based comma-delimited matching
-            let mut json_conditions = Vec::new();
-            let mut csv_conditions = Vec::new();
-            let mut param_values: Vec<String> = Vec::new();
-            for (i, tag) in tags.iter().enumerate() {
-                let p = i + 1;
-                json_conditions.push(format!(
-                    "EXISTS (SELECT 1 FROM json_each(memories.tags) WHERE value = ?{p})"
-                ));
-                csv_conditions.push(format!(
-                    "instr(',' || memories.tags || ',', ',' || ?{p} || ',') > 0"
-                ));
-                param_values.push(tag.clone());
-            }
-            let json_clause = json_conditions.join(" AND ");
-            let csv_clause = csv_conditions.join(" AND ");
-            let mut sql = format!(
-                "SELECT id, content, tags, importance, metadata, event_type, session_id, project, entity_id, agent_type FROM memories \
-                 WHERE ((json_valid(memories.tags) AND {json_clause}) \
-                         OR (NOT json_valid(memories.tags) AND memories.tags != '' AND {csv_clause})) \
-                 "
-            );
-
-            let mut next_idx = param_values.len();
-            if let Some(ref event_type) = opts.event_type {
-                next_idx += 1;
-                sql.push_str(&format!(" AND event_type = ?{next_idx}"));
-                param_values.push(event_type.to_string());
-            }
-            if let Some(project) = opts.project.clone() {
-                next_idx += 1;
-                sql.push_str(&format!(" AND project = ?{next_idx}"));
-                param_values.push(project);
-            }
-            if let Some(session_id) = opts.session_id.clone() {
-                next_idx += 1;
-                sql.push_str(&format!(" AND session_id = ?{next_idx}"));
-                param_values.push(session_id);
-            }
-            next_idx += 1;
-            sql.push_str(&format!(" ORDER BY last_accessed_at DESC LIMIT ?{next_idx}"));
-
-            let mut stmt = conn
-                .prepare(&sql)
-                .context("failed to prepare tag search query")?;
-
-            let mut param_refs: Vec<&dyn rusqlite::types::ToSql> = Vec::new();
-            for v in &param_values {
-                param_refs.push(v);
-            }
-            param_refs.push(&effective_limit);
-
-            let rows = stmt
-                .query_map(param_refs.as_slice(), search_result_from_row)
-                .context("failed to execute tag search query")?;
-
-            let mut results = Vec::new();
-            for row in rows {
-                results.push(row.context("failed to decode tag search row")?);
-            }
-            Ok::<_, anyhow::Error>(results)
-        })
-        .await
-        .context("spawn_blocking join error")?
-    }
-}
-
-impl SqliteStorage {
     /// Batch store multiple memories with optimized embedding computation.
     ///
     /// Pre-warms the embedding LRU cache with a single `embed_batch()` call,

--- a/src/memory_core/storage/sqlite/crud.rs
+++ b/src/memory_core/storage/sqlite/crud.rs
@@ -356,7 +356,6 @@ impl SqliteStorage {
         let source_type = input.source_type.clone();
         let id_for_store = id.clone();
 
-        let precomputed_embedding = precomputed_embedding;
         let (outcome, superseded_ids, final_tags) = tokio::task::spawn_blocking(move || {
             let c_hash = content_hash(&data);
             let normalized_hash = canonical_hash(&data);

--- a/src/memory_core/storage/sqlite/io.rs
+++ b/src/memory_core/storage/sqlite/io.rs
@@ -40,19 +40,21 @@ impl super::SqliteStorage {
                 )
                 .context("failed to get total access count")?;
 
-            let fts_count: i64 = conn
-                .query_row("SELECT COUNT(*) FROM memories_fts", [], |row| row.get(0))
-                .context("failed to count FTS5 entries")?;
+            let fts = super::schema::fts_diagnostic(&conn);
 
-            Ok::<_, anyhow::Error>(serde_json::json!({
+            let mut value = serde_json::json!({
                 "total_memories": total_memories,
                 "total_relationships": total_relationships,
                 "average_importance": avg_importance,
                 "total_access_count": total_access,
-                "fts5_indexed": fts_count,
-                "fts5_in_sync": super::schema::fts_divergence(&conn)? == (0, 0),
+                "fts5_indexed": fts.indexed_count.unwrap_or(0),
+                "fts5_in_sync": fts.in_sync(),
                 "paths": build_stats_paths_json(&db_path),
-            }))
+            });
+            if let Some(ref err) = fts.corruption_error {
+                value["fts5_error"] = serde_json::Value::String(err.clone());
+            }
+            Ok::<_, anyhow::Error>(value)
         })
         .await
         .context("spawn_blocking join error")?

--- a/src/memory_core/storage/sqlite/io.rs
+++ b/src/memory_core/storage/sqlite/io.rs
@@ -50,7 +50,7 @@ impl super::SqliteStorage {
                 "average_importance": avg_importance,
                 "total_access_count": total_access,
                 "fts5_indexed": fts_count,
-                "fts5_in_sync": fts_count == total_memories,
+                "fts5_in_sync": super::schema::fts_divergence(&conn)? == (0, 0),
                 "paths": build_stats_paths_json(&db_path),
             }))
         })

--- a/src/memory_core/storage/sqlite/schema.rs
+++ b/src/memory_core/storage/sqlite/schema.rs
@@ -458,6 +458,61 @@ pub(super) fn fts_divergence(conn: &Connection) -> Result<(i64, i64)> {
         .context("failed to count unindexed memory rows")?;
     Ok((orphaned, missing))
 }
+/// Read-only diagnostic snapshot of the FTS5 index.
+///
+/// Tolerates a structurally corrupt `memories_fts` virtual table so that
+/// diagnostics paths can report degradation instead of returning an opaque
+/// error.
+pub(super) struct FtsDiagnostic {
+    pub indexed_count: Option<i64>,
+    pub divergence: Option<(i64, i64)>,
+    /// `Some` when the FTS5 virtual table or its shadow tables could not be
+    /// queried, indicating corruption or severe unreadability.
+    pub corruption_error: Option<String>,
+}
+
+impl FtsDiagnostic {
+    pub fn in_sync(&self) -> bool {
+        self.corruption_error.is_none() && self.divergence == Some((0, 0))
+    }
+
+    pub fn warning(&self) -> Option<String> {
+        if let Some(ref err) = self.corruption_error {
+            Some(format!(
+                "FTS5 index corrupt or unreadable: {err} (run `mag maintain --action fts-rebuild`)"
+            ))
+        } else if let Some((orphaned, missing)) = self.divergence {
+            if orphaned != 0 || missing != 0 {
+                Some(format!(
+                    "FTS5 index out of sync: {orphaned} orphaned index rows, {missing} unindexed memories (run `mag maintain --action fts-rebuild`)"
+                ))
+            } else {
+                None
+            }
+        } else {
+            None
+        }
+    }
+}
+
+/// Returns a read-only diagnostic snapshot of the FTS5 index, catching a
+/// structurally corrupt index instead of propagating the error.
+pub(super) fn fts_diagnostic(conn: &Connection) -> FtsDiagnostic {
+    let indexed_count = conn.query_row("SELECT COUNT(*) FROM memories_fts", [], |row| row.get(0));
+    let divergence = fts_divergence(conn);
+
+    let corruption_error = indexed_count
+        .as_ref()
+        .err()
+        .map(|e| e.to_string())
+        .or_else(|| divergence.as_ref().err().map(|e| e.to_string()));
+
+    FtsDiagnostic {
+        indexed_count: indexed_count.ok(),
+        divergence: divergence.ok(),
+        corruption_error,
+    }
+}
 
 /// Detects and repairs divergence between the `memories` table and the
 /// `memories_fts` full-text index, returning the number of FTS rows changed.

--- a/src/memory_core/storage/sqlite/schema.rs
+++ b/src/memory_core/storage/sqlite/schema.rs
@@ -35,6 +35,15 @@ fn current_schema_version(conn: &Connection) -> Result<i64> {
     .map_err(|e| anyhow!("Failed to read schema version: {e}"))
 }
 
+/// Canonical DDL for the `memories_fts` full-text index, shared by schema
+/// initialization, the porter-tokenizer migration, and corruption recovery so
+/// every path recreates the index with an identical definition.
+const FTS5_TABLE_DDL: &str = "CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
+    id UNINDEXED,
+    content,
+    tokenize='porter unicode61'
+);";
+
 /// Creates the `memories` and `relationships` tables if they don't exist and enables foreign keys.
 pub(super) fn initialize_schema(conn: &Connection, embedding_dim: usize) -> Result<()> {
     conn.execute_batch("PRAGMA foreign_keys = ON;")
@@ -113,15 +122,12 @@ pub(super) fn initialize_schema(conn: &Connection, embedding_dim: usize) -> Resu
             key TEXT NOT NULL PRIMARY KEY,
             value TEXT NOT NULL,
             updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
-        );
-
-        CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
-            id UNINDEXED,
-            content,
-            tokenize='porter unicode61'
         );",
     )
     .context("failed to initialize sqlite schema")?;
+
+    conn.execute_batch(FTS5_TABLE_DDL)
+        .context("failed to create FTS5 index")?;
 
     if current < 1 {
         conn.execute(
@@ -397,14 +403,8 @@ fn migrate_fts_to_porter(conn: &Connection) -> Result<()> {
     conn.execute_batch("DROP TABLE IF EXISTS memories_fts;")
         .context("failed to drop old FTS5 table during porter migration")?;
 
-    conn.execute_batch(
-        "CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
-            id UNINDEXED,
-            content,
-            tokenize='porter unicode61'
-        );",
-    )
-    .context("failed to recreate FTS5 table with porter tokenizer")?;
+    conn.execute_batch(FTS5_TABLE_DDL)
+        .context("failed to recreate FTS5 table with porter tokenizer")?;
 
     // Repopulate from existing memories (rebuild_fts_index will also check, but we do it
     // here so the migration is self-contained).
@@ -474,11 +474,28 @@ pub(super) fn fts_divergence(conn: &Connection) -> Result<(i64, i64)> {
 /// equal-count id mismatch (one row dropped, an unrelated one orphaned) also
 /// breaks search and must be caught. The repair is bidirectional — orphaned
 /// FTS rows (no backing memory) are deleted and unindexed memories are added.
+///
+/// A structurally corrupt index (e.g. a damaged `memories_fts_data` segment
+/// tree) makes the anti-join probe itself error; there is no surgical repair,
+/// so the whole index is rebuilt from `memories`.
 /// Content-level drift (matching ids, stale text) is not an id-set divergence
 /// and is out of scope here; `MaintenanceManager::rebuild_fts` is the
 /// full-rebuild escape hatch for that.
 pub(super) fn ensure_fts_sync(conn: &Connection) -> Result<usize> {
-    let (orphaned, missing) = fts_divergence(conn)?;
+    let (orphaned, missing) = match fts_divergence(conn) {
+        Ok(counts) => counts,
+        // An unreadable index — e.g. a corrupt `memories_fts_data` segment tree
+        // left by an interrupted write — makes the divergence probe itself
+        // error. A corrupt segment tree has no surgical repair, so rebuild the
+        // whole index from the `memories` source of truth.
+        Err(e) => {
+            tracing::warn!(
+                error = %e,
+                "FTS5 index unreadable (corrupt); rebuilding from memories table"
+            );
+            return rebuild_fts_from_source(conn);
+        }
+    };
 
     if orphaned == 0 && missing == 0 {
         return Ok(0);
@@ -506,6 +523,29 @@ pub(super) fn ensure_fts_sync(conn: &Connection) -> Result<usize> {
         .context("failed to backfill missing FTS5 rows")?;
 
     Ok(deleted + inserted)
+}
+
+/// Rebuilds the `memories_fts` index from the `memories` table — the recovery
+/// path for a structurally corrupt index, where a `DELETE`+re-`INSERT` would
+/// leave residual shadow-table damage that still fails `integrity-check`. The
+/// full `DROP`+recreate+repopulate restores a clean, internally consistent
+/// index. Returns the number of rows reindexed.
+fn rebuild_fts_from_source(conn: &Connection) -> Result<usize> {
+    // Atomic so a crash mid-rebuild can never leave a half-populated index
+    // visible: either the whole DROP+recreate+repopulate lands or none of it.
+    let tx = retry_on_lock(|| conn.unchecked_transaction())
+        .context("failed to start FTS rebuild transaction")?;
+    tx.execute_batch("DROP TABLE IF EXISTS memories_fts;")
+        .context("failed to drop corrupt FTS5 index during rebuild")?;
+    tx.execute_batch(FTS5_TABLE_DDL)
+        .context("failed to recreate FTS5 index during rebuild")?;
+    tx.execute_batch("INSERT INTO memories_fts(id, content) SELECT id, content FROM memories;")
+        .context("failed to repopulate FTS5 index from memories table")?;
+    let reindexed: i64 = tx
+        .query_row("SELECT COUNT(*) FROM memories", [], |row| row.get(0))
+        .context("failed to count memories after FTS rebuild")?;
+    tx.commit().context("failed to commit FTS rebuild")?;
+    Ok(usize::try_from(reindexed).unwrap_or(0))
 }
 
 /// Resolves the default database path: `$HOME/.mag/memory.db`.

--- a/src/memory_core/storage/sqlite/schema.rs
+++ b/src/memory_core/storage/sqlite/schema.rs
@@ -585,7 +585,7 @@ pub(super) fn ensure_fts_sync(conn: &Connection) -> Result<usize> {
 /// leave residual shadow-table damage that still fails `integrity-check`. The
 /// full `DROP`+recreate+repopulate restores a clean, internally consistent
 /// index. Returns the number of rows reindexed.
-fn rebuild_fts_from_source(conn: &Connection) -> Result<usize> {
+pub(super) fn rebuild_fts_from_source(conn: &Connection) -> Result<usize> {
     // Atomic so a crash mid-rebuild can never leave a half-populated index
     // visible: either the whole DROP+recreate+repopulate lands or none of it.
     let tx = retry_on_lock(|| conn.unchecked_transaction())

--- a/src/memory_core/storage/sqlite/schema.rs
+++ b/src/memory_core/storage/sqlite/schema.rs
@@ -432,6 +432,68 @@ pub(super) fn rebuild_fts_index(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+/// Detects and repairs divergence between the `memories` table and the
+/// `memories_fts` full-text index, returning the number of FTS rows changed.
+///
+/// The index is maintained inline within each write transaction, so a healthy
+/// database keeps the two row sets identical. Divergence can still arise from
+/// interrupted writes (e.g. a `kill -9`'d process), concurrent writers, or
+/// historical bugs — and once diverged, search silently returns nothing for the
+/// affected rows with no recovery path short of deleting the database
+/// (issue #343). Running this on every file-backed open lets a reused `~/.mag`
+/// self-heal.
+///
+/// Divergence is gated on set membership (two anti-joins), not row counts: an
+/// equal-count id mismatch (one row dropped, an unrelated one orphaned) also
+/// breaks search and must be caught. The repair is bidirectional — orphaned
+/// FTS rows (no backing memory) are deleted and unindexed memories are added.
+/// Content-level drift (matching ids, stale text) is not an id-set divergence
+/// and is out of scope here; `MaintenanceManager::rebuild_fts` is the
+/// full-rebuild escape hatch for that.
+pub(super) fn ensure_fts_sync(conn: &Connection) -> Result<usize> {
+    let orphaned: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM memories_fts WHERE id NOT IN (SELECT id FROM memories)",
+            [],
+            |row| row.get(0),
+        )
+        .context("failed to count orphaned FTS5 rows")?;
+    let missing: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE id NOT IN (SELECT id FROM memories_fts)",
+            [],
+            |row| row.get(0),
+        )
+        .context("failed to count unindexed memory rows")?;
+
+    if orphaned == 0 && missing == 0 {
+        return Ok(0);
+    }
+
+    tracing::warn!(
+        orphaned,
+        missing,
+        "FTS5 index out of sync with memories table; repairing"
+    );
+
+    let deleted = conn
+        .execute(
+            "DELETE FROM memories_fts WHERE id NOT IN (SELECT id FROM memories)",
+            [],
+        )
+        .context("failed to delete orphaned FTS5 rows")?;
+    let inserted = conn
+        .execute(
+            "INSERT INTO memories_fts(id, content) \
+             SELECT id, content FROM memories \
+             WHERE id NOT IN (SELECT id FROM memories_fts)",
+            [],
+        )
+        .context("failed to backfill missing FTS5 rows")?;
+
+    Ok(deleted + inserted)
+}
+
 /// Resolves the default database path: `$HOME/.mag/memory.db`.
 pub(super) fn default_db_path() -> Result<PathBuf> {
     app_paths::resolve_app_paths().map(|paths| paths.database_path)

--- a/src/memory_core/storage/sqlite/schema.rs
+++ b/src/memory_core/storage/sqlite/schema.rs
@@ -432,6 +432,33 @@ pub(super) fn rebuild_fts_index(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
+/// Counts FTS5 index divergence from the `memories` table as
+/// `(orphaned, missing)`: `orphaned` is FTS rows with no backing memory and
+/// `missing` is memories absent from the index. Both zero ⇒ the id sets are
+/// identical (in sync).
+///
+/// This is the set-membership signal — two anti-joins — that distinguishes a
+/// truly synced index from an equal-count id mismatch that row counts alone
+/// cannot detect. Shared by `ensure_fts_sync` (repair) and the `fts5_in_sync`
+/// health/stats reports so all three agree on what "in sync" means.
+pub(super) fn fts_divergence(conn: &Connection) -> Result<(i64, i64)> {
+    let orphaned: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM memories_fts WHERE id NOT IN (SELECT id FROM memories)",
+            [],
+            |row| row.get(0),
+        )
+        .context("failed to count orphaned FTS5 rows")?;
+    let missing: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM memories WHERE id NOT IN (SELECT id FROM memories_fts)",
+            [],
+            |row| row.get(0),
+        )
+        .context("failed to count unindexed memory rows")?;
+    Ok((orphaned, missing))
+}
+
 /// Detects and repairs divergence between the `memories` table and the
 /// `memories_fts` full-text index, returning the number of FTS rows changed.
 ///
@@ -451,20 +478,7 @@ pub(super) fn rebuild_fts_index(conn: &Connection) -> Result<()> {
 /// and is out of scope here; `MaintenanceManager::rebuild_fts` is the
 /// full-rebuild escape hatch for that.
 pub(super) fn ensure_fts_sync(conn: &Connection) -> Result<usize> {
-    let orphaned: i64 = conn
-        .query_row(
-            "SELECT COUNT(*) FROM memories_fts WHERE id NOT IN (SELECT id FROM memories)",
-            [],
-            |row| row.get(0),
-        )
-        .context("failed to count orphaned FTS5 rows")?;
-    let missing: i64 = conn
-        .query_row(
-            "SELECT COUNT(*) FROM memories WHERE id NOT IN (SELECT id FROM memories_fts)",
-            [],
-            |row| row.get(0),
-        )
-        .context("failed to count unindexed memory rows")?;
+    let (orphaned, missing) = fts_divergence(conn)?;
 
     if orphaned == 0 && missing == 0 {
         return Ok(0);

--- a/src/memory_core/storage/sqlite/tests.rs
+++ b/src/memory_core/storage/sqlite/tests.rs
@@ -7891,20 +7891,14 @@ async fn test_rebuild_fts_recovers_content_drift() {
 #[tokio::test]
 async fn test_rebuild_fts_repairs_structural_corruption() {
     let storage = SqliteStorage::new_in_memory().unwrap();
-    <SqliteStorage as Storage>::store(
-        &storage,
-        "struct-1",
-        "happy cat",
-        &MemoryInput::default(),
-    )
-    .await
-    .unwrap();
+    <SqliteStorage as Storage>::store(&storage, "struct-1", "happy cat", &MemoryInput::default())
+        .await
+        .unwrap();
 
     // Damage the FTS5 segment tree so the index is structurally unreadable.
     {
         let conn = storage.test_conn().unwrap();
-        conn.execute("DELETE FROM memories_fts_data", [])
-            .unwrap();
+        conn.execute("DELETE FROM memories_fts_data", []).unwrap();
     }
 
     // A manual full rebuild should succeed despite the corruption.
@@ -7915,14 +7909,20 @@ async fn test_rebuild_fts_repairs_structural_corruption() {
     assert_eq!(report["memories_count"], 1);
 
     // Searchability is restored.
-    let results = storage.search("cats", 10, &SearchOptions::default()).await.unwrap();
+    let results = storage
+        .search("cats", 10, &SearchOptions::default())
+        .await
+        .unwrap();
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].id, "struct-1");
 
     // The rebuilt index is internally consistent.
     let conn = storage.test_conn().unwrap();
-    conn.execute("INSERT INTO memories_fts(memories_fts) VALUES('integrity-check')", [])
-        .expect("rebuilt FTS5 index must pass integrity-check");
+    conn.execute(
+        "INSERT INTO memories_fts(memories_fts) VALUES('integrity-check')",
+        [],
+    )
+    .expect("rebuilt FTS5 index must pass integrity-check");
 }
 
 /// `check_health` surfaces FTS divergence: `fts5_in_sync` flips to false and a

--- a/src/memory_core/storage/sqlite/tests.rs
+++ b/src/memory_core/storage/sqlite/tests.rs
@@ -7871,7 +7871,10 @@ async fn test_check_health_detects_equal_count_fts_divergence() {
         <SqliteStorage as MaintenanceManager>::check_health(&storage, 1000.0, 2000.0, 100_000)
             .await
             .unwrap();
-    assert_eq!(report["fts5_indexed"], 2, "row counts are deliberately equal");
+    assert_eq!(
+        report["fts5_indexed"], 2,
+        "row counts are deliberately equal"
+    );
     assert_eq!(
         report["fts5_in_sync"], false,
         "equal-count id divergence must still report out of sync"
@@ -7909,7 +7912,10 @@ async fn test_stats_detects_equal_count_fts_divergence() {
     }
 
     let stats = storage.stats().await.unwrap();
-    assert_eq!(stats["fts5_indexed"], 2, "row counts are deliberately equal");
+    assert_eq!(
+        stats["fts5_indexed"], 2,
+        "row counts are deliberately equal"
+    );
     assert_eq!(
         stats["fts5_in_sync"], false,
         "equal-count id divergence must still report out of sync"

--- a/src/memory_core/storage/sqlite/tests.rs
+++ b/src/memory_core/storage/sqlite/tests.rs
@@ -7775,6 +7775,70 @@ async fn test_reopen_repairs_partial_fts_divergence_and_orphans() {
     let _ = fs::remove_dir_all(base);
 }
 
+/// A structurally corrupt FTS5 index — a damaged segment b-tree
+/// (`memories_fts_data`) left by an interrupted write or `kill -9` — makes
+/// *every* index read raise "fts5: corruption found reading blob …", so the
+/// id-set divergence probe itself errors and the prior self-heal gave up,
+/// leaving search permanently broken for a reused database. Reopening must
+/// detect the unreadable index and rebuild it from the `memories` source of
+/// truth. A surgical DELETE+reinsert leaves residual shadow-table damage that
+/// still fails `integrity-check`, so recovery must be a full DROP+repopulate.
+#[tokio::test]
+async fn test_reopen_rebuilds_structurally_corrupt_fts() {
+    let base = std::env::temp_dir().join(format!("mag-fts-corrupt-test-{}", Uuid::new_v4()));
+    let db_path = base.join("memory.db");
+
+    {
+        let storage = SqliteStorage::new_with_path(
+            db_path.clone(),
+            std::sync::Arc::new(crate::memory_core::PlaceholderEmbedder),
+        )
+        .unwrap();
+        <SqliteStorage as Storage>::store(&storage, "corrupt-1", "happy cat", &MemoryInput::default())
+            .await
+            .unwrap();
+        // Wipe the fts5 segment b-tree to simulate post-crash corruption: the
+        // index becomes unreadable while the `memories` table stays intact.
+        {
+            let conn = storage.test_conn().unwrap();
+            conn.execute("DELETE FROM memories_fts_data", []).unwrap();
+        }
+    } // drop storage → close pool → persist the corrupt index to disk
+
+    let reopened = SqliteStorage::new_with_path(
+        db_path.clone(),
+        std::sync::Arc::new(crate::memory_core::PlaceholderEmbedder),
+    )
+    .unwrap();
+
+    // `"cats"` is a porter-stemmed match for stored `"happy cat"` but not a
+    // substring, so the `LIKE` fallback cannot satisfy it — only a rebuilt FTS
+    // index can return the row.
+    let results = reopened
+        .search("cats", 10, &SearchOptions::default())
+        .await
+        .unwrap();
+    assert_eq!(
+        results.len(),
+        1,
+        "structurally corrupt FTS must be rebuilt on open so stored content is findable"
+    );
+    assert_eq!(results[0].id, "corrupt-1");
+    assert_eq!(fts_match_count(&reopened, "cats"), 1);
+
+    // The rebuilt index is internally consistent.
+    {
+        let conn = reopened.test_conn().unwrap();
+        conn.execute(
+            "INSERT INTO memories_fts(memories_fts) VALUES('integrity-check')",
+            [],
+        )
+        .expect("rebuilt FTS index must pass fts5 integrity-check");
+    }
+
+    let _ = fs::remove_dir_all(base);
+}
+
 /// `rebuild_fts` recovers content-level drift (matching ids, stale indexed
 /// text) — a divergence `ensure_fts_sync`'s id anti-joins intentionally do not
 /// detect, so the manual full rebuild is the escape hatch.

--- a/src/memory_core/storage/sqlite/tests.rs
+++ b/src/memory_core/storage/sqlite/tests.rs
@@ -7611,3 +7611,146 @@ async fn test_entity_edges_no_self_loops() {
         "should not create self-referential RELATES_TO edge"
     );
 }
+
+// ── FTS5 self-heal on open (issue #343) ─────────────────────────────
+
+/// Counts FTS5 rows matching `query` on the writer connection — the exact
+/// text-search primitive the retrieval pipeline relies on. Used alongside the
+/// behaviour-level `search()` assertions to pin the repair at the index layer.
+fn fts_match_count(storage: &SqliteStorage, query: &str) -> i64 {
+    let conn = storage.test_conn().unwrap();
+    conn.query_row(
+        "SELECT COUNT(*) FROM memories_fts WHERE memories_fts MATCH ?1",
+        params![query],
+        |r| r.get(0),
+    )
+    .unwrap()
+}
+
+/// Reproduces #343: a reused `~/.mag` whose FTS5 index has diverged from the
+/// `memories` table returns 0 search results for content that is still stored.
+/// Reopening the database must auto-repair the index.
+///
+/// The query (`"cats"` against stored `"happy cat"`) is a porter-stemmed match
+/// that is *not* a literal substring, so `search()`'s `LIKE '%cats%'` fallback
+/// cannot satisfy it — only the FTS index can. That makes the missing-FTS case
+/// a deterministic 0-results repro at the public `search()` boundary, not just
+/// at the raw index.
+#[tokio::test]
+async fn test_reused_db_with_desynced_fts_self_heals_on_open() {
+    let base = std::env::temp_dir().join(format!("mag-fts-heal-test-{}", Uuid::new_v4()));
+    let db_path = base.join("memory.db");
+
+    {
+        let storage = SqliteStorage::new_with_path(
+            db_path.clone(),
+            std::sync::Arc::new(crate::memory_core::PlaceholderEmbedder),
+        )
+        .unwrap();
+        <SqliteStorage as Storage>::store(&storage, "heal-1", "happy cat", &MemoryInput::default())
+            .await
+            .unwrap();
+        // Sanity: the porter-stemmed query resolves via FTS before corruption.
+        let before = storage
+            .search("cats", 10, &SearchOptions::default())
+            .await
+            .unwrap();
+        assert_eq!(
+            before.len(),
+            1,
+            "porter FTS should match 'cats' → 'happy cat'"
+        );
+        assert_eq!(fts_match_count(&storage, "cats"), 1);
+
+        // Simulate FTS divergence: the memory row stays, its FTS entry is lost.
+        {
+            let conn = storage.test_conn().unwrap();
+            conn.execute("DELETE FROM memories_fts", []).unwrap();
+        }
+    } // drop storage → close pool → persist desynced state to disk
+
+    // Reopen the same path — open must self-heal the FTS index.
+    let reopened = SqliteStorage::new_with_path(
+        db_path.clone(),
+        std::sync::Arc::new(crate::memory_core::PlaceholderEmbedder),
+    )
+    .unwrap();
+    let after = reopened
+        .search("cats", 10, &SearchOptions::default())
+        .await
+        .unwrap();
+    assert_eq!(
+        after.len(),
+        1,
+        "search must find the stored memory after reopening a desynced DB"
+    );
+    assert_eq!(after[0].id, "heal-1");
+    assert_eq!(fts_match_count(&reopened, "cats"), 1);
+
+    let _ = fs::remove_dir_all(base);
+}
+
+/// Partial divergence: one memory missing from FTS plus one orphaned FTS row.
+/// Reopen must backfill the missing row and drop the orphan so counts match.
+#[tokio::test]
+async fn test_reopen_repairs_partial_fts_divergence_and_orphans() {
+    let base = std::env::temp_dir().join(format!("mag-fts-partial-test-{}", Uuid::new_v4()));
+    let db_path = base.join("memory.db");
+
+    {
+        let storage = SqliteStorage::new_with_path(
+            db_path.clone(),
+            std::sync::Arc::new(crate::memory_core::PlaceholderEmbedder),
+        )
+        .unwrap();
+        for (id, content) in [("p-1", "alpha keeper note"), ("p-2", "beta keeper note")] {
+            <SqliteStorage as Storage>::store(&storage, id, content, &MemoryInput::default())
+                .await
+                .unwrap();
+        }
+        // Drop one FTS entry (missing) and add an orphan FTS row (no backing memory).
+        {
+            let conn = storage.test_conn().unwrap();
+            conn.execute("DELETE FROM memories_fts WHERE id = ?1", params!["p-2"])
+                .unwrap();
+            conn.execute(
+                "INSERT INTO memories_fts(id, content) VALUES (?1, ?2)",
+                params!["ghost", "orphaned ghost row"],
+            )
+            .unwrap();
+        }
+    }
+
+    let reopened = SqliteStorage::new_with_path(
+        db_path.clone(),
+        std::sync::Arc::new(crate::memory_core::PlaceholderEmbedder),
+    )
+    .unwrap();
+
+    // Backfilled row is matchable again; orphan no longer matches.
+    assert_eq!(
+        fts_match_count(&reopened, "beta"),
+        1,
+        "missing FTS row must be backfilled on reopen"
+    );
+    assert_eq!(
+        fts_match_count(&reopened, "orphaned"),
+        0,
+        "orphaned FTS row must no longer match"
+    );
+
+    // FTS count equals memories count after reconciliation.
+    {
+        let conn = reopened.test_conn().unwrap();
+        let mem_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM memories", [], |r| r.get(0))
+            .unwrap();
+        let fts_count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM memories_fts", [], |r| r.get(0))
+            .unwrap();
+        assert_eq!(mem_count, 2);
+        assert_eq!(fts_count, 2, "FTS and memories counts must reconcile");
+    }
+
+    let _ = fs::remove_dir_all(base);
+}

--- a/src/memory_core/storage/sqlite/tests.rs
+++ b/src/memory_core/storage/sqlite/tests.rs
@@ -7884,6 +7884,46 @@ async fn test_rebuild_fts_recovers_content_drift() {
     assert_eq!(fts_match_count(&storage, "original"), 1);
     assert_eq!(fts_match_count(&storage, "garbage"), 0);
 }
+/// `rebuild_fts` repairs a structurally corrupt FTS5 index: a damaged
+/// `memories_fts_data` segment tree makes ordinary reads fail, so the manual
+/// rebuild must drop and recreate the virtual table from the `memories`
+/// source of truth.
+#[tokio::test]
+async fn test_rebuild_fts_repairs_structural_corruption() {
+    let storage = SqliteStorage::new_in_memory().unwrap();
+    <SqliteStorage as Storage>::store(
+        &storage,
+        "struct-1",
+        "happy cat",
+        &MemoryInput::default(),
+    )
+    .await
+    .unwrap();
+
+    // Damage the FTS5 segment tree so the index is structurally unreadable.
+    {
+        let conn = storage.test_conn().unwrap();
+        conn.execute("DELETE FROM memories_fts_data", [])
+            .unwrap();
+    }
+
+    // A manual full rebuild should succeed despite the corruption.
+    let report = <SqliteStorage as MaintenanceManager>::rebuild_fts(&storage)
+        .await
+        .expect("rebuild_fts must repair a structurally corrupt FTS5 index");
+    assert_eq!(report["fts_rows_after"], 1);
+    assert_eq!(report["memories_count"], 1);
+
+    // Searchability is restored.
+    let results = storage.search("cats", 10, &SearchOptions::default()).await.unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].id, "struct-1");
+
+    // The rebuilt index is internally consistent.
+    let conn = storage.test_conn().unwrap();
+    conn.execute("INSERT INTO memories_fts(memories_fts) VALUES('integrity-check')", [])
+        .expect("rebuilt FTS5 index must pass integrity-check");
+}
 
 /// `check_health` surfaces FTS divergence: `fts5_in_sync` flips to false and a
 /// warning is emitted (status is at least "warning") when the index drifts.

--- a/src/memory_core/storage/sqlite/tests.rs
+++ b/src/memory_core/storage/sqlite/tests.rs
@@ -7839,3 +7839,79 @@ async fn test_check_health_reports_fts_out_of_sync() {
         "health warnings should flag the FTS desync, got: {warnings:?}"
     );
 }
+
+/// Regression: equal-count id divergence must still report `fts5_in_sync:
+/// false`. `check_health` previously compared only row counts, so a DB where
+/// one memory is dropped from the index and an unrelated orphan FTS row is added
+/// (counts equal, id sets disjoint) was falsely reported in sync — masking
+/// exactly the divergence class `ensure_fts_sync` exists to repair.
+#[tokio::test]
+async fn test_check_health_detects_equal_count_fts_divergence() {
+    let storage = SqliteStorage::new_in_memory().unwrap();
+    for (id, content) in [("eq-1", "alpha note"), ("eq-2", "beta note")] {
+        <SqliteStorage as Storage>::store(&storage, id, content, &MemoryInput::default())
+            .await
+            .unwrap();
+    }
+
+    // Drop one indexed row and add an unrelated orphan: counts stay 2 == 2 but
+    // the id sets diverge (eq-2 unindexed, "ghost" orphaned).
+    {
+        let conn = storage.test_conn().unwrap();
+        conn.execute("DELETE FROM memories_fts WHERE id = ?1", params!["eq-2"])
+            .unwrap();
+        conn.execute(
+            "INSERT INTO memories_fts(id, content) VALUES (?1, ?2)",
+            params!["ghost", "orphaned ghost row"],
+        )
+        .unwrap();
+    }
+
+    let report =
+        <SqliteStorage as MaintenanceManager>::check_health(&storage, 1000.0, 2000.0, 100_000)
+            .await
+            .unwrap();
+    assert_eq!(report["fts5_indexed"], 2, "row counts are deliberately equal");
+    assert_eq!(
+        report["fts5_in_sync"], false,
+        "equal-count id divergence must still report out of sync"
+    );
+    assert_eq!(report["status"], "warning");
+    let warnings = report["warnings"].as_array().unwrap();
+    assert!(
+        warnings
+            .iter()
+            .any(|w| w.as_str().unwrap_or("").contains("FTS5 index out of sync")),
+        "health warnings should flag the FTS desync, got: {warnings:?}"
+    );
+}
+
+/// `stats()` shares the same `fts5_in_sync` contract as `check_health` and must
+/// likewise detect equal-count id divergence rather than trusting row counts.
+#[tokio::test]
+async fn test_stats_detects_equal_count_fts_divergence() {
+    let storage = SqliteStorage::new_in_memory().unwrap();
+    for (id, content) in [("eq-1", "alpha note"), ("eq-2", "beta note")] {
+        <SqliteStorage as Storage>::store(&storage, id, content, &MemoryInput::default())
+            .await
+            .unwrap();
+    }
+
+    {
+        let conn = storage.test_conn().unwrap();
+        conn.execute("DELETE FROM memories_fts WHERE id = ?1", params!["eq-2"])
+            .unwrap();
+        conn.execute(
+            "INSERT INTO memories_fts(id, content) VALUES (?1, ?2)",
+            params!["ghost", "orphaned ghost row"],
+        )
+        .unwrap();
+    }
+
+    let stats = storage.stats().await.unwrap();
+    assert_eq!(stats["fts5_indexed"], 2, "row counts are deliberately equal");
+    assert_eq!(
+        stats["fts5_in_sync"], false,
+        "equal-count id divergence must still report out of sync"
+    );
+}

--- a/src/memory_core/storage/sqlite/tests.rs
+++ b/src/memory_core/storage/sqlite/tests.rs
@@ -7754,3 +7754,88 @@ async fn test_reopen_repairs_partial_fts_divergence_and_orphans() {
 
     let _ = fs::remove_dir_all(base);
 }
+
+/// `rebuild_fts` recovers content-level drift (matching ids, stale indexed
+/// text) — a divergence `ensure_fts_sync`'s id anti-joins intentionally do not
+/// detect, so the manual full rebuild is the escape hatch.
+#[tokio::test]
+async fn test_rebuild_fts_recovers_content_drift() {
+    let storage = SqliteStorage::new_in_memory().unwrap();
+    <SqliteStorage as Storage>::store(
+        &storage,
+        "r1",
+        "original keeper text",
+        &MemoryInput::default(),
+    )
+    .await
+    .unwrap();
+
+    // Drift the FTS content while keeping the id (counts stay equal, ids match).
+    {
+        let conn = storage.test_conn().unwrap();
+        conn.execute("DELETE FROM memories_fts WHERE id = ?1", params!["r1"])
+            .unwrap();
+        conn.execute(
+            "INSERT INTO memories_fts(id, content) VALUES (?1, ?2)",
+            params!["r1", "stale drifted garbage"],
+        )
+        .unwrap();
+    }
+    // The drifted index matches the wrong terms and misses the real ones.
+    assert_eq!(fts_match_count(&storage, "original"), 0);
+    assert_eq!(fts_match_count(&storage, "garbage"), 1);
+
+    let report = <SqliteStorage as MaintenanceManager>::rebuild_fts(&storage)
+        .await
+        .unwrap();
+    assert_eq!(report["fts_rows_after"], 1);
+    assert_eq!(report["memories_count"], 1);
+
+    // After a full rebuild the index reflects the source content again.
+    assert_eq!(fts_match_count(&storage, "original"), 1);
+    assert_eq!(fts_match_count(&storage, "garbage"), 0);
+}
+
+/// `check_health` surfaces FTS divergence: `fts5_in_sync` flips to false and a
+/// warning is emitted (status is at least "warning") when the index drifts.
+#[tokio::test]
+async fn test_check_health_reports_fts_out_of_sync() {
+    let storage = SqliteStorage::new_in_memory().unwrap();
+    <SqliteStorage as Storage>::store(
+        &storage,
+        "h1",
+        "health probe content",
+        &MemoryInput::default(),
+    )
+    .await
+    .unwrap();
+
+    let healthy =
+        <SqliteStorage as MaintenanceManager>::check_health(&storage, 1000.0, 2000.0, 100_000)
+            .await
+            .unwrap();
+    assert_eq!(healthy["fts5_in_sync"], true);
+    assert_eq!(healthy["fts5_indexed"], 1);
+    assert_eq!(healthy["status"], "healthy");
+
+    // Lose the FTS row → memories(1) vs fts(0).
+    {
+        let conn = storage.test_conn().unwrap();
+        conn.execute("DELETE FROM memories_fts", []).unwrap();
+    }
+
+    let degraded =
+        <SqliteStorage as MaintenanceManager>::check_health(&storage, 1000.0, 2000.0, 100_000)
+            .await
+            .unwrap();
+    assert_eq!(degraded["fts5_in_sync"], false);
+    assert_eq!(degraded["fts5_indexed"], 0);
+    assert_eq!(degraded["status"], "warning");
+    let warnings = degraded["warnings"].as_array().unwrap();
+    assert!(
+        warnings
+            .iter()
+            .any(|w| w.as_str().unwrap_or("").contains("FTS5 index out of sync")),
+        "health warnings should flag the FTS desync, got: {warnings:?}"
+    );
+}

--- a/src/memory_core/storage/sqlite/tests.rs
+++ b/src/memory_core/storage/sqlite/tests.rs
@@ -7794,9 +7794,14 @@ async fn test_reopen_rebuilds_structurally_corrupt_fts() {
             std::sync::Arc::new(crate::memory_core::PlaceholderEmbedder),
         )
         .unwrap();
-        <SqliteStorage as Storage>::store(&storage, "corrupt-1", "happy cat", &MemoryInput::default())
-            .await
-            .unwrap();
+        <SqliteStorage as Storage>::store(
+            &storage,
+            "corrupt-1",
+            "happy cat",
+            &MemoryInput::default(),
+        )
+        .await
+        .unwrap();
         // Wipe the fts5 segment b-tree to simulate post-crash corruption: the
         // index becomes unreadable while the `memories` table stays intact.
         {

--- a/src/memory_core/storage/sqlite/tests.rs
+++ b/src/memory_core/storage/sqlite/tests.rs
@@ -8010,3 +8010,93 @@ async fn test_stats_detects_equal_count_fts_divergence() {
         "equal-count id divergence must still report out of sync"
     );
 }
+
+/// Structurally corrupt FTS indexes (e.g. a damaged `memories_fts_data` segment
+/// tree) can make `fts_divergence()` itself fail while the `memories` table
+/// remains readable. Maintenance diagnostics must stay callable and report the
+/// FTS problem explicitly instead of returning an opaque error.
+#[tokio::test]
+async fn test_check_health_reports_structurally_corrupt_fts() {
+    let storage = SqliteStorage::new_in_memory().unwrap();
+    <SqliteStorage as Storage>::store(
+        &storage,
+        "corrupt-diag-1",
+        "happy cat",
+        &MemoryInput::default(),
+    )
+    .await
+    .unwrap();
+
+    {
+        let conn = storage.test_conn().unwrap();
+        conn.execute("DELETE FROM memories_fts_data", []).unwrap();
+    }
+
+    let report =
+        <SqliteStorage as MaintenanceManager>::check_health(&storage, 1000.0, 2000.0, 100_000)
+            .await
+            .expect("check_health must remain callable when the FTS index is structurally corrupt");
+
+    assert!(
+        report["status"] == "warning" || report["status"] == "critical",
+        "structurally corrupt FTS must degrade the health status"
+    );
+    // NOTE: we do NOT assert `integrity_ok == true` here.  PRAGMA integrity_check
+    // validates the entire database, including FTS5 shadow tables.  Since we
+    // deliberately corrupted the FTS index by deleting from memories_fts_data, the
+    // check may correctly report integrity_ok=false even though the core memories
+    // table is intact.  The actual regression contract (call succeeds, status
+    // degraded, warning flags FTS) is covered by the assertions above and below.
+    let warnings = report["warnings"].as_array().expect("warnings array");
+    assert!(
+        warnings.iter().any(|w| {
+            let s = w.as_str().unwrap_or("");
+            s.contains("FTS") && (s.contains("corrupt") || s.contains("out of sync"))
+        }),
+        "warning must explicitly flag the FTS problem; got {:?}",
+        warnings
+    );
+}
+
+/// `stats()` must likewise tolerate a structurally corrupt FTS index and surface
+/// a degraded `fts5_in_sync` report rather than erroring.
+#[tokio::test]
+async fn test_stats_reports_structurally_corrupt_fts() {
+    let storage = SqliteStorage::new_in_memory().unwrap();
+    <SqliteStorage as Storage>::store(
+        &storage,
+        "corrupt-diag-2",
+        "happy cat",
+        &MemoryInput::default(),
+    )
+    .await
+    .unwrap();
+
+    {
+        let conn = storage.test_conn().unwrap();
+        conn.execute("DELETE FROM memories_fts_data", []).unwrap();
+    }
+
+    let stats = storage
+        .stats()
+        .await
+        .expect("stats must remain callable when the FTS index is structurally corrupt");
+
+    assert_eq!(
+        stats["fts5_in_sync"], false,
+        "structurally corrupt FTS must report fts5_in_sync=false"
+    );
+    assert!(
+        stats.get("fts5_error").is_some()
+            || stats
+                .get("warnings")
+                .and_then(|w| w.as_array())
+                .map(|arr| arr.iter().any(|w| {
+                    let s = w.as_str().unwrap_or("");
+                    s.contains("FTS") && (s.contains("corrupt") || s.contains("out of sync"))
+                }))
+                .unwrap_or(false),
+        "stats must surface a degraded FTS report; got {:?}",
+        stats
+    );
+}

--- a/src/memory_core/storage/sqlite/tests.rs
+++ b/src/memory_core/storage/sqlite/tests.rs
@@ -3615,6 +3615,26 @@ fn test_reminder_invalid_duration() {
     }
 }
 
+#[test]
+fn test_reminder_duration_overflow_is_err() {
+    // Values that fit in i64 but overflow chrono::Duration must yield an Err,
+    // not panic. Reachable from user-supplied session-expiry strings.
+    for input in [
+        "999999999999999999w",
+        "999999999999999999d",
+        "999999999999999999h",
+        "999999999999999999m",
+    ] {
+        assert!(
+            parse_duration(input).is_err(),
+            "expected Err for overflowing duration {input:?}"
+        );
+    }
+    // Components individually valid but summing past the i64-second range
+    // must also error rather than panic.
+    assert!(parse_duration("10000000000000w50000000000000d").is_err());
+}
+
 #[tokio::test]
 async fn test_lessons_query_basic() {
     let storage = SqliteStorage::new_in_memory().unwrap();

--- a/src/memory_core/traits.rs
+++ b/src/memory_core/traits.rs
@@ -231,6 +231,11 @@ pub trait MaintenanceManager: Send + Sync {
         count_threshold: usize,
         dry_run: bool,
     ) -> Result<serde_json::Value>;
+    /// Fully rebuild the FTS5 index from the `memories` table: drop every
+    /// indexed row and re-insert from source. Recovers from any divergence,
+    /// including content-level drift that the on-open `ensure_fts_sync` does
+    /// not detect. Returns `{fts_rows_before, fts_rows_after, memories_count}`.
+    async fn rebuild_fts(&self) -> Result<serde_json::Value>;
 }
 
 /// Session startup briefing provider.

--- a/src/substrate/enrichment_impl.rs
+++ b/src/substrate/enrichment_impl.rs
@@ -1,8 +1,8 @@
 use crate::substrate::traits::Scorer;
 use crate::substrate::types::{QueryContext, ScoredCandidate};
-use anyhow::Result;
 #[cfg(feature = "real-embeddings")]
 use anyhow::Context;
+use anyhow::Result;
 use async_trait::async_trait;
 use std::collections::HashMap;
 #[cfg(feature = "real-embeddings")]

--- a/src/substrate/enrichment_impl.rs
+++ b/src/substrate/enrichment_impl.rs
@@ -1,8 +1,11 @@
 use crate::substrate::traits::Scorer;
 use crate::substrate::types::{QueryContext, ScoredCandidate};
-use anyhow::{Context, Result};
+use anyhow::Result;
+#[cfg(feature = "real-embeddings")]
+use anyhow::Context;
 use async_trait::async_trait;
 use std::collections::HashMap;
+#[cfg(feature = "real-embeddings")]
 use std::sync::Arc;
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -85,6 +88,32 @@ impl Scorer for crate::substrate::traits::EntityExpansionScorer {
 // CrossEncoderScorer
 // ═══════════════════════════════════════════════════════════════════════════════
 
+/// Applies cross-encoder scores to the candidate map, pairing each requested
+/// ID with the score at the same position.
+///
+/// Extracted into a pure helper so the ID↔score pairing contract can be
+/// unit-tested without loading an ONNX model.
+pub(crate) fn apply_cross_encoder_scores(
+    candidates: &mut HashMap<String, ScoredCandidate>,
+    ids: &[String],
+    ce_scores: &[f32],
+    alpha: f64,
+) -> Result<()> {
+    if ids.len() != ce_scores.len() {
+        anyhow::bail!(
+            "cross-encoder score count mismatch: ids={} ce_scores={}",
+            ids.len(),
+            ce_scores.len()
+        );
+    }
+    for (id, ce_score) in ids.iter().zip(ce_scores.iter()) {
+        if let Some(candidate) = candidates.get_mut(id) {
+            candidate.score = alpha * candidate.score + (1.0 - alpha) * f64::from(*ce_score);
+        }
+    }
+    Ok(())
+}
+
 #[cfg(feature = "real-embeddings")]
 #[async_trait]
 impl Scorer for crate::substrate::traits::CrossEncoderScorer {
@@ -127,11 +156,7 @@ impl Scorer for crate::substrate::traits::CrossEncoderScorer {
         .await
         .context("spawn_blocking join error")??;
 
-        for (id, ce_score) in ids.iter().zip(ce_scores.iter()) {
-            if let Some(candidate) = candidates.get_mut(id) {
-                candidate.score = alpha * candidate.score + (1.0 - alpha) * f64::from(*ce_score);
-            }
-        }
+        apply_cross_encoder_scores(candidates, &ids, &ce_scores, alpha)?;
 
         Ok(())
     }

--- a/src/substrate/fusion_impl.rs
+++ b/src/substrate/fusion_impl.rs
@@ -30,10 +30,10 @@ impl FusionStrategy for super::traits::RrfFusion {
                 }
                 match output.entry(id) {
                     std::collections::hash_map::Entry::Occupied(mut e) => {
-                        e.get_mut().score += candidate.score * rrf_score;
+                        e.get_mut().score += rrf_score;
                     }
                     std::collections::hash_map::Entry::Vacant(e) => {
-                        candidate.score *= rrf_score;
+                        candidate.score = rrf_score;
                         e.insert(candidate);
                     }
                 }

--- a/src/substrate/ingestion_impl.rs
+++ b/src/substrate/ingestion_impl.rs
@@ -43,12 +43,15 @@ impl IngestionPipeline for EmbedAndExtractPipeline {
             ctx.assigned_id
         };
 
-        let content = ctx.input.content.clone();
-        let embedder = Arc::clone(&self.embedder);
-
-        let embedding = tokio::task::spawn_blocking(move || embedder.embed(&content))
-            .await
-            .map_err(|e| anyhow::anyhow!("spawn_blocking join error: {e:?}"))??;
+        let embedding = if let Some(embedding) = ctx.embedding.take() {
+            embedding
+        } else {
+            let content = ctx.input.content.clone();
+            let embedder = Arc::clone(&self.embedder);
+            tokio::task::spawn_blocking(move || embedder.embed(&content))
+                .await
+                .map_err(|e| anyhow::anyhow!("spawn_blocking join error: {e:?}"))??
+        };
         #[cfg(feature = "llm")]
         if let Some(ref llm_backend) = self.llm {
             let extractor = LlmExtractor {

--- a/src/substrate/lifecycle_impl.rs
+++ b/src/substrate/lifecycle_impl.rs
@@ -19,13 +19,13 @@ impl LifecyclePolicy for crate::substrate::traits::TtlExpirationPolicy {
         let expires_at = match candidate.result.metadata.get("expires_at") {
             Some(v) => match v.as_str() {
                 Some(s) => s,
-                None => return true,
+                None => return false,
             },
             None => return true,
         };
         let expires = match DateTime::parse_from_rfc3339(expires_at) {
             Ok(dt) => dt.with_timezone(&Utc),
-            Err(_) => return true,
+            Err(_) => return false,
         };
         expires >= Utc::now()
     }

--- a/src/substrate/orchestrators.rs
+++ b/src/substrate/orchestrators.rs
@@ -129,7 +129,7 @@ impl SearchPipeline {
                         if let Some(ref explain) = candidate.explain
                             && let Some(obj) = meta.as_object_mut()
                         {
-                            obj.insert("explain".to_string(), explain.clone());
+                            obj.insert("_explain".to_string(), explain.clone());
                         }
                         meta
                     };

--- a/src/substrate/orchestrators.rs
+++ b/src/substrate/orchestrators.rs
@@ -78,6 +78,12 @@ impl SearchPipeline {
             .map(|c| (c.result.id.clone(), c))
             .collect();
 
+        // Populate query_tokens lazily before scorers, per the QueryContext contract.
+        let mut ctx = ctx;
+        if ctx.query_tokens.is_none() {
+            ctx.query_tokens = Some(crate::memory_core::scoring::token_set(&ctx.query, 3));
+        }
+
         // Step 4: Apply each scorer in order.
         for scorer in &self.scorers {
             scorer.score_batch(&mut candidates, &ctx).await?;

--- a/src/substrate/store_impl.rs
+++ b/src/substrate/store_impl.rs
@@ -27,6 +27,16 @@ impl MemoryStore for SqliteStorage {
         <Self as Storage>::store(self, id, data, input).await
     }
 
+    async fn store_with_embedding(
+        &self,
+        id: &str,
+        data: &str,
+        input: &MemoryInput,
+        embedding: Vec<f32>,
+    ) -> Result<()> {
+        self.store_internal(id, data, input, Some(embedding)).await
+    }
+
     async fn retrieve(&self, id: &str) -> Result<String> {
         <Self as Retriever>::retrieve(self, id).await
     }

--- a/src/substrate/tests.rs
+++ b/src/substrate/tests.rs
@@ -163,6 +163,14 @@ fn ttl_policy_dead_when_expires_at_non_string() {
     assert!(!policy.is_alive(&candidate));
 }
 
+#[test]
+fn ttl_policy_alive_with_metadata_but_no_expires_at() {
+    let policy = TtlExpirationPolicy;
+    let mut candidate = make_candidate("x", 1.0);
+    candidate.result.metadata = serde_json::json!({"retention": "permanent"});
+    assert!(policy.is_alive(&candidate));
+}
+
 #[tokio::test]
 async fn multi_factor_scorer_does_not_panic() {
     let scorer = MultiFactorScorer;

--- a/src/substrate/tests.rs
+++ b/src/substrate/tests.rs
@@ -188,3 +188,46 @@ async fn multi_factor_scorer_does_not_panic() {
     scorer.score_batch(&mut candidates, &ctx).await.unwrap();
     assert!(!candidates.is_empty());
 }
+
+#[test]
+fn cross_encoder_rejects_mismatched_ids_and_scores() {
+    // Regression: CrossEncoderScorer::score_batch zips requested IDs with the
+    // cross-encoder score vector without checking they have the same length.
+    // A truncated or extra score must be rejected rather than silently ignored.
+    use crate::substrate::enrichment_impl::apply_cross_encoder_scores;
+
+    let mut candidates = HashMap::new();
+    candidates.insert("a".to_string(), make_candidate("a", 0.5));
+    candidates.insert("b".to_string(), make_candidate("b", 0.5));
+
+    let original_scores: HashMap<String, f64> = candidates
+        .iter()
+        .map(|(id, c)| (id.clone(), c.score))
+        .collect();
+
+    let ids = vec!["a".to_string(), "b".to_string()];
+    let ce_scores = vec![0.8f32]; // fewer scores than IDs
+
+    let result = apply_cross_encoder_scores(&mut candidates, &ids, &ce_scores, 0.5);
+    assert!(
+        result.is_err(),
+        "expected mismatched id/score lengths to be rejected"
+    );
+    let msg = result.unwrap_err().to_string();
+    assert!(
+        msg.contains("2"),
+        "expected error message to mention id count, got: {msg}"
+    );
+    assert!(
+        msg.contains("1"),
+        "expected error message to mention score count, got: {msg}"
+    );
+
+    for (id, original) in original_scores {
+        assert_eq!(
+            candidates.get(&id).unwrap().score,
+            original,
+            "candidate {id} must not be mutated when id/score lengths mismatch"
+        );
+    }
+}

--- a/src/substrate/tests.rs
+++ b/src/substrate/tests.rs
@@ -335,3 +335,102 @@ async fn search_pipeline_populates_query_tokens_for_scorer() {
         "SearchPipeline must populate QueryContext.query_tokens before calling scorers"
     );
 }
+
+#[tokio::test]
+async fn search_pipeline_explain_mode_uses_documented_metadata_key() {
+    use crate::substrate::SearchPipeline;
+    use async_trait::async_trait;
+
+    struct FakeRetrieval;
+
+    #[async_trait]
+    impl RetrievalStrategy for FakeRetrieval {
+        fn name(&self) -> &str {
+            "fake"
+        }
+
+        async fn collect(&self, _ctx: &QueryContext) -> anyhow::Result<CandidateSet> {
+            let mut candidate = make_candidate("a", 1.0);
+            candidate.explain = Some(serde_json::json!({
+                "strategy": "fake",
+                "raw_score": 1.0,
+            }));
+            Ok(vec![("a".to_string(), 1.0, candidate)])
+        }
+    }
+
+    struct FakeFusion;
+
+    impl FusionStrategy for FakeFusion {
+        fn fuse(
+            &self,
+            candidates: HashMap<&str, CandidateSet>,
+            _scoring_params: &ScoringParams,
+        ) -> Vec<ScoredCandidate> {
+            candidates
+                .into_values()
+                .flat_map(|set| set.into_iter().map(|(_, _, candidate)| candidate))
+                .collect()
+        }
+    }
+
+    struct PassThroughScorer;
+
+    #[async_trait]
+    impl Scorer for PassThroughScorer {
+        fn name(&self) -> &str {
+            "pass_through"
+        }
+
+        async fn score_batch(
+            &self,
+            candidates: &mut HashMap<String, ScoredCandidate>,
+            _ctx: &QueryContext,
+        ) -> anyhow::Result<()> {
+            for candidate in candidates.values_mut() {
+                candidate.text_overlap = 1.0;
+            }
+            Ok(())
+        }
+    }
+
+    let pipeline = SearchPipeline {
+        retrieval: vec![Box::new(FakeRetrieval)],
+        fusion: Box::new(FakeFusion),
+        scorers: vec![Box::new(PassThroughScorer)],
+        lifecycle: None,
+        abstention_min_text: 0.15,
+    };
+
+    let results = pipeline
+        .search(QueryContext {
+            query: "rust memory search".to_string(),
+            limit: 1,
+            opts: SearchOptions {
+                explain: Some(true),
+                ..SearchOptions::default()
+            },
+            scoring_params: ScoringParams::default(),
+            query_embedding: None,
+            query_tokens: None,
+            include_superseded: false,
+        })
+        .await
+        .expect("search should succeed");
+
+    assert_eq!(results.len(), 1, "expected a single explain-mode result");
+
+    let metadata = results[0]
+        .metadata
+        .as_object()
+        .expect("search results should carry object metadata");
+    let explain = metadata
+        .get("_explain")
+        .expect("explain-mode results must expose explanation metadata under _explain");
+    assert_eq!(explain["strategy"], serde_json::json!("fake"));
+    assert_eq!(explain["raw_score"], serde_json::json!(1.0));
+    assert!(
+        !metadata.contains_key("explain"),
+        "legacy explain metadata key must not be present"
+    );
+}

--- a/src/substrate/tests.rs
+++ b/src/substrate/tests.rs
@@ -55,6 +55,84 @@ fn rrf_fusion_ranks_candidates() {
 }
 
 #[test]
+fn rrf_fusion_pure_rank_ignores_raw_score() {
+    // Regression: the current implementation incorrectly multiplies the
+    // candidate's raw per-strategy score into the RRF term.  The documented
+    // contract is `rrf_score(rank) = weight / (k + rank + 1)`; raw scores
+    // should influence the result only through their rank position.
+    let fusion = RrfFusion;
+    let mut sets = HashMap::new();
+    // Vector order: low raw score is ranked first, huge raw score is second.
+    // A pure rank-based fusion must still prefer the first-ranked candidate.
+    sets.insert(
+        "vector",
+        vec![
+            (
+                "low_raw_first".to_string(),
+                0.01,
+                make_candidate("low_raw_first", 0.01),
+            ),
+            (
+                "high_raw_second".to_string(),
+                100.0,
+                make_candidate("high_raw_second", 100.0),
+            ),
+            ("dual".to_string(), 0.5, make_candidate("dual", 0.5)),
+        ],
+    );
+    // FTS order: the dual-match candidate is ranked first with a huge raw score.
+    // Its dual-match boost should not hide the fact that RRF itself is rank-only.
+    sets.insert(
+        "fts",
+        vec![("dual".to_string(), 999.0, make_candidate("dual", 999.0))],
+    );
+
+    let result = fusion.fuse(sets, &ScoringParams::default());
+    assert_eq!(result.len(), 3);
+    let by_id: HashMap<String, f64> = result
+        .iter()
+        .map(|c| (c.result.id.clone(), c.score))
+        .collect();
+
+    let k = ScoringParams::default().rrf_k;
+    let vec_rank_0 = 1.0 / (k + 0.0 + 1.0); // low_raw_first
+    let vec_rank_1 = 1.0 / (k + 1.0 + 1.0); // high_raw_second
+    let vec_rank_2 = 1.0 / (k + 2.0 + 1.0); // dual (vector arm)
+    let fts_rank_0 = 1.0 / (k + 0.0 + 1.0); // dual (fts arm)
+    let dual_boost = 1.5 + (1.0 / (1.0 + 0.0)) * 0.5;
+
+    let expected_low_raw_first = vec_rank_0;
+    let expected_high_raw_second = vec_rank_1;
+    let expected_dual = (vec_rank_2 + fts_rank_0) * dual_boost;
+
+    let eps = 1e-12;
+    assert!(
+        (by_id["low_raw_first"] - expected_low_raw_first).abs() < eps,
+        "low_raw_first score {} != expected {}",
+        by_id["low_raw_first"],
+        expected_low_raw_first
+    );
+    assert!(
+        (by_id["high_raw_second"] - expected_high_raw_second).abs() < eps,
+        "high_raw_second score {} != expected {}",
+        by_id["high_raw_second"],
+        expected_high_raw_second
+    );
+    assert!(
+        (by_id["dual"] - expected_dual).abs() < eps,
+        "dual score {} != expected {}",
+        by_id["dual"],
+        expected_dual
+    );
+
+    // Rank-based ordering: dual match wins, and the first-ranked vector-only
+    // candidate beats the second-ranked vector-only candidate even though its
+    // raw score is much smaller.
+    let ids: Vec<&str> = result.iter().map(|c| c.result.id.as_str()).collect();
+    assert_eq!(ids, vec!["dual", "low_raw_first", "high_raw_second"]);
+}
+
+#[test]
 fn ttl_policy_alive_by_default() {
     let policy = TtlExpirationPolicy;
     let candidate = make_candidate("x", 1.0);

--- a/src/substrate/tests.rs
+++ b/src/substrate/tests.rs
@@ -147,6 +147,22 @@ fn ttl_policy_dead_when_expired() {
     assert!(!policy.is_alive(&candidate));
 }
 
+#[test]
+fn ttl_policy_dead_when_expires_at_invalid_string() {
+    let policy = TtlExpirationPolicy;
+    let mut candidate = make_candidate("x", 1.0);
+    candidate.result.metadata = serde_json::json!({"expires_at": "not-an-rfc3339-timestamp"});
+    assert!(!policy.is_alive(&candidate));
+}
+
+#[test]
+fn ttl_policy_dead_when_expires_at_non_string() {
+    let policy = TtlExpirationPolicy;
+    let mut candidate = make_candidate("x", 1.0);
+    candidate.result.metadata = serde_json::json!({"expires_at": 12345});
+    assert!(!policy.is_alive(&candidate));
+}
+
 #[tokio::test]
 async fn multi_factor_scorer_does_not_panic() {
     let scorer = MultiFactorScorer;

--- a/src/substrate/tests.rs
+++ b/src/substrate/tests.rs
@@ -1,9 +1,11 @@
 use crate::memory_core::{ScoringParams, SearchOptions, SemanticResult};
 use crate::substrate::traits::{
-    FusionStrategy, LifecyclePolicy, MultiFactorScorer, RrfFusion, Scorer, TtlExpirationPolicy,
+    FusionStrategy, LifecyclePolicy, MultiFactorScorer, RetrievalStrategy, RrfFusion, Scorer,
+    TtlExpirationPolicy,
 };
-use crate::substrate::types::{QueryContext, ScoredCandidate};
-use std::collections::HashMap;
+use crate::substrate::types::{CandidateSet, QueryContext, ScoredCandidate};
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
 
 fn make_candidate(id: &str, score: f64) -> ScoredCandidate {
     ScoredCandidate {
@@ -230,4 +232,106 @@ fn cross_encoder_rejects_mismatched_ids_and_scores() {
             "candidate {id} must not be mutated when id/score lengths mismatch"
         );
     }
+}
+#[tokio::test]
+async fn search_pipeline_populates_query_tokens_for_scorer() {
+    // Regression: SearchPipeline must lazily populate QueryContext.query_tokens
+    // before invoking scorers. Without this, scorers that rely on the token set
+    // have to re-derive it or silently operate without word-overlap signals.
+    use crate::memory_core::scoring::token_set;
+    use crate::substrate::SearchPipeline;
+    use async_trait::async_trait;
+
+    struct FakeRetrieval;
+
+    #[async_trait]
+    impl RetrievalStrategy for FakeRetrieval {
+        fn name(&self) -> &str {
+            "fake"
+        }
+
+        async fn collect(&self, _ctx: &QueryContext) -> anyhow::Result<CandidateSet> {
+            Ok(vec![("a".to_string(), 1.0, make_candidate("a", 1.0))])
+        }
+    }
+
+    struct FakeFusion;
+
+    impl FusionStrategy for FakeFusion {
+        fn fuse(
+            &self,
+            candidates: HashMap<&str, CandidateSet>,
+            _scoring_params: &ScoringParams,
+        ) -> Vec<ScoredCandidate> {
+            candidates
+                .into_values()
+                .flat_map(|set| set.into_iter().map(|(_, _, candidate)| candidate))
+                .collect()
+        }
+    }
+
+    struct TokenSpy {
+        tokens: Arc<Mutex<Option<HashSet<String>>>>,
+    }
+
+    #[async_trait]
+    impl Scorer for TokenSpy {
+        fn name(&self) -> &str {
+            "token_spy"
+        }
+
+        async fn score_batch(
+            &self,
+            candidates: &mut HashMap<String, ScoredCandidate>,
+            ctx: &QueryContext,
+        ) -> anyhow::Result<()> {
+            *self.tokens.lock().unwrap() = ctx.query_tokens.clone();
+            // Drive text_overlap above the abstention gate so the assertion below
+            // is about the scorer's input, not an empty result from abstention.
+            for candidate in candidates.values_mut() {
+                candidate.text_overlap = 1.0;
+            }
+            Ok(())
+        }
+    }
+
+    let observed: Arc<Mutex<Option<HashSet<String>>>> = Arc::new(Mutex::new(None));
+    let pipeline = SearchPipeline {
+        retrieval: vec![Box::new(FakeRetrieval)],
+        fusion: Box::new(FakeFusion),
+        scorers: vec![Box::new(TokenSpy {
+            tokens: observed.clone(),
+        })],
+        lifecycle: None,
+        abstention_min_text: 0.15,
+    };
+
+    let query = "rust memory search";
+    let ctx = QueryContext {
+        query: query.to_string(),
+        limit: 10,
+        opts: SearchOptions::default(),
+        scoring_params: ScoringParams::default(),
+        query_embedding: None,
+        query_tokens: None,
+        include_superseded: false,
+    };
+
+    let results = pipeline.search(ctx).await.expect("search should succeed");
+    assert!(
+        !results.is_empty(),
+        "expected results after scorer ran; abstention gate may have hidden the scorer input"
+    );
+
+    let observed_tokens = observed.lock().unwrap().take();
+    assert!(
+        observed_tokens.is_some(),
+        "scorer observed QueryContext.query_tokens = None, but SearchPipeline must populate it"
+    );
+    let observed_tokens = observed_tokens.unwrap();
+    let expected_tokens = token_set(query, 3);
+    assert_eq!(
+        observed_tokens, expected_tokens,
+        "SearchPipeline must populate QueryContext.query_tokens before calling scorers"
+    );
 }

--- a/tests/mcp_smoke.rs
+++ b/tests/mcp_smoke.rs
@@ -716,6 +716,32 @@ async fn mcp_stdio_lists_tools_and_calls_health() -> Result<(), Box<dyn std::err
         "expected lifecycle health to return non-empty response"
     );
 
+    // ─── memory_lifecycle (action=fts_rebuild) ───
+    let lifecycle_fts_rebuild_result = timeout(
+        Duration::from_secs(20),
+        service.call_tool(CallToolRequestParams {
+            meta: None,
+            name: "memory_lifecycle".into(),
+            arguments: Some(
+                serde_json::json!({ "action": "fts_rebuild" })
+                    .as_object()
+                    .cloned()
+                    .unwrap_or_default(),
+            ),
+            task: None,
+        }),
+    )
+    .await??;
+
+    assert!(
+        lifecycle_fts_rebuild_result.content.iter().any(|c| c
+            .as_text()
+            .is_some_and(
+                |text| text.text.contains("fts_rows_after") && text.text.contains("memories_count")
+            )),
+        "expected fts_rebuild to return fts_rows_after and memories_count"
+    );
+
     // ─── memory_checkpoint (save + resume) ───
     let checkpoint_save_result = timeout(
         Duration::from_secs(20),

--- a/tests/substrate_pipeline.rs
+++ b/tests/substrate_pipeline.rs
@@ -68,11 +68,11 @@ async fn substrate_fts_pipeline_returns_results() {
 #[tokio::test]
 async fn substrate_embed_and_extract_reuses_precomputed_embedding() {
     #[derive(Clone)]
-    struct CountingEmbedder {
+    struct RecordingEmbedder {
         counter: Arc<AtomicUsize>,
     }
 
-    impl Embedder for CountingEmbedder {
+    impl Embedder for RecordingEmbedder {
         fn dimension(&self) -> usize {
             32
         }
@@ -84,30 +84,31 @@ async fn substrate_embed_and_extract_reuses_precomputed_embedding() {
     }
 
     let counter = Arc::new(AtomicUsize::new(0));
-    let embedder: Arc<dyn Embedder> = Arc::new(CountingEmbedder {
+    let embedder: Arc<dyn Embedder> = Arc::new(RecordingEmbedder {
         counter: Arc::clone(&counter),
     });
     let storage =
         SqliteStorage::new_with_path(PathBuf::from(":memory:"), Arc::clone(&embedder)).unwrap();
     let store: Arc<dyn MemoryStore> = Arc::new(storage);
-
     let pipeline = EmbedAndExtractPipeline::new(Arc::clone(&embedder));
 
+    let precomputed_embedding = vec![0.25_f32; 32];
     let ctx = WriteContext {
         input: MemoryInput {
             content: "rust programming language".to_string(),
             ..Default::default()
         },
         assigned_id: "mem-1".to_string(),
-        embedding: None,
+        embedding: Some(precomputed_embedding),
     };
 
     let id = pipeline.ingest(ctx, store.as_ref()).await.unwrap();
     assert_eq!(id, "mem-1");
+    assert_eq!(store.retrieve(&id).await.unwrap(), "rust programming language");
 
     let count = counter.load(Ordering::SeqCst);
     assert_eq!(
-        count, 1,
-        "embedder should be invoked exactly once for a single ingest with a precomputed embedding, got {count}"
+        count, 0,
+        "embedder should not be invoked when WriteContext supplies a precomputed embedding, got {count}"
     );
 }

--- a/tests/substrate_pipeline.rs
+++ b/tests/substrate_pipeline.rs
@@ -1,12 +1,14 @@
-use mag::memory_core::embedder::PlaceholderEmbedder;
+use mag::memory_core::embedder::{Embedder, PlaceholderEmbedder};
 use mag::memory_core::{MemoryInput, ScoringParams, SearchOptions, storage::SqliteStorage};
 use mag::substrate::orchestrators::SearchPipeline;
-use mag::substrate::types::QueryContext;
+use mag::substrate::types::{QueryContext, WriteContext};
 use mag::substrate::{
-    FullTextSearch, MemoryStore, MultiFactorScorer, RrfFusion, TtlExpirationPolicy,
+    EmbedAndExtractPipeline, FullTextSearch, IngestionPipeline, MemoryStore, MultiFactorScorer,
+    RrfFusion, TtlExpirationPolicy,
 };
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 #[tokio::test]
 async fn substrate_fts_pipeline_returns_results() {
@@ -61,4 +63,51 @@ async fn substrate_fts_pipeline_returns_results() {
 
     let results = pipeline.search(ctx).await.unwrap();
     assert!(!results.is_empty(), "pipeline should return results");
+}
+
+#[tokio::test]
+async fn substrate_embed_and_extract_reuses_precomputed_embedding() {
+    #[derive(Clone)]
+    struct CountingEmbedder {
+        counter: Arc<AtomicUsize>,
+    }
+
+    impl Embedder for CountingEmbedder {
+        fn dimension(&self) -> usize {
+            32
+        }
+
+        fn embed(&self, _text: &str) -> anyhow::Result<Vec<f32>> {
+            self.counter.fetch_add(1, Ordering::SeqCst);
+            Ok(vec![1.0_f32; self.dimension()])
+        }
+    }
+
+    let counter = Arc::new(AtomicUsize::new(0));
+    let embedder: Arc<dyn Embedder> = Arc::new(CountingEmbedder {
+        counter: Arc::clone(&counter),
+    });
+    let storage =
+        SqliteStorage::new_with_path(PathBuf::from(":memory:"), Arc::clone(&embedder)).unwrap();
+    let store: Arc<dyn MemoryStore> = Arc::new(storage);
+
+    let pipeline = EmbedAndExtractPipeline::new(Arc::clone(&embedder));
+
+    let ctx = WriteContext {
+        input: MemoryInput {
+            content: "rust programming language".to_string(),
+            ..Default::default()
+        },
+        assigned_id: "mem-1".to_string(),
+        embedding: None,
+    };
+
+    let id = pipeline.ingest(ctx, store.as_ref()).await.unwrap();
+    assert_eq!(id, "mem-1");
+
+    let count = counter.load(Ordering::SeqCst);
+    assert_eq!(
+        count, 1,
+        "embedder should be invoked exactly once for a single ingest with a precomputed embedding, got {count}"
+    );
 }

--- a/tests/substrate_pipeline.rs
+++ b/tests/substrate_pipeline.rs
@@ -104,7 +104,10 @@ async fn substrate_embed_and_extract_reuses_precomputed_embedding() {
 
     let id = pipeline.ingest(ctx, store.as_ref()).await.unwrap();
     assert_eq!(id, "mem-1");
-    assert_eq!(store.retrieve(&id).await.unwrap(), "rust programming language");
+    assert_eq!(
+        store.retrieve(&id).await.unwrap(),
+        "rust programming language"
+    );
 
     let count = counter.load(Ordering::SeqCst);
     assert_eq!(


### PR DESCRIPTION
## Summary

Fixes #343 — reusing the default `~/.mag` home across sessions/benchmark runs returned **0 results** for known-stored content because the `memories_fts` FTS5 index could silently diverge from the `memories` table with no recovery path short of deleting the DB. Bundles substrate-pipeline correctness fixes surfaced during the same hardening pass.

### Issue #343 — FTS5 desync self-heal
- `ensure_fts_sync` runs on every file-backed DB open (`conn_pool::open_file`): detects id-set divergence via **two anti-joins** (not row counts, so an equal-count id mismatch is still caught) and repairs bidirectionally — orphaned FTS rows deleted, unindexed memories backfilled. Non-fatal: a repair failure logs and continues, never blocks open.
- A **structurally corrupt** index (damaged `memories_fts_data` segment tree) makes the probe itself error; that path drops + recreates + repopulates the index from `memories` inside a transaction.
- New `mag maintain --action fts-rebuild` (CLI) and `rebuild_fts` on the `MaintenanceManager` trait (MCP) for an explicit full rebuild.
- `check_health`/stats report `fts5_in_sync` via id-set membership and surface a corruption/desync warning pointing at `fts-rebuild`.
- FTS diagnostics tolerate a corrupt virtual table instead of returning an opaque error.

### Substrate pipeline hardening
- Pure rank-based RRF fusion.
- Honor precomputed write/ingest embeddings (skip redundant re-embed).
- Reject malformed TTL metadata and missing expiry field instead of silently mis-parsing.
- Reject cross-encoder score/id length mismatch before mutating candidates.
- Populate query tokens before scoring.
- Honor the `explain` metadata key.

### Misc
- `parse_duration` rejects overflowing durations (chrono checked constructors) instead of panicking on large session-expiry inputs.

## Testing
- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets --all-features -- -D warnings` — no issues
- `cargo test --all-features` — **1287 passed**, 0 failed

Closes #343

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Self-heals the `memories_fts` FTS5 index on database open and adds an explicit rebuild path, fixing zero-result searches caused by index drift (fixes #343). Also hardens scoring/ingestion correctness and prevents duration overflow panics.

- **Bug Fixes**
  - On open, detect FTS5 id-set divergence via anti-joins and repair both ways; structural corruption triggers atomic drop+recreate+repopulate. Non-fatal if repair fails.
  - Health/stats now compute `fts5_in_sync` by id membership (not counts) and tolerate unreadable FTS tables.
  - Substrate correctness: pure rank-based RRF; reuse precomputed write embeddings; reject malformed TTL metadata and cross-encoder id/score length mismatches; populate query tokens before scoring; honor the `explain` metadata key.
  - `parse_duration` rejects overflowing inputs instead of panicking.

- **New Features**
  - Add `fts-rebuild` maintenance action: CLI `mag maintain --action fts-rebuild` and MCP `memory_lifecycle`/`memory_manage` with `fts_rebuild`. Returns `{fts_rows_before, fts_rows_after, memories_count}`.
  - Health output includes `fts5_indexed` and `fts5_in_sync`, and raises status with a warning when the index diverges.

<sup>Written for commit 4a25cecca2bad8fcb02be8cd8b5f34f6547f366c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/George-RD/mag/pull/357?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

