### PR TITLE
docs(agents): make repository context progressive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,353 +1,116 @@
-# Repository Guidelines
-<!-- Last verified: 2026-05-20 | Valid for: v0.1.10-dev+ -->
+# MAG agent guide
 
-Universal agent guidance for AI coding assistants working on this repository.
-Vendor-neutral — applies to Claude Code, Cursor, Windsurf, Copilot, and any AI tool.
+MAG is a local-first Rust memory server for AI agents. This file is a routing
+layer: load only the context required for the current task.
 
----
+## Authority and context discipline
 
-## Project Overview
+- The user's request is primary.
+- Accepted Cairn decisions and contracts bind the architecture nodes they name.
+- This file and any nearer scoped `AGENTS.md` define working conventions.
+- Surface conflicts rather than silently choosing one source.
+- Do not preload `map.md`, `map.json`, full roadmaps, `docs/strongholds/`, or
+  `conductor/`. Query the smallest connected Cairn slice instead.
 
-**MAG** (`mag-memory`) is a local MCP (Model Context Protocol) memory server written in Rust. It persists memories in SQLite with ONNX embeddings (`bge-small-en-v1.5`, 384-dim by default) for semantic search. No external services are required at runtime.
+## Start every task with the smallest useful query
 
-It exposes **19 MCP tools** via stdio protocol and supports multiple AI coding tool integrations (Claude Code, Cursor, Windsurf, Cline, OpenCode, Claude Desktop) via an interactive `mag setup` wizard.
+| Starting point | First query |
+|---|---|
+| A planned item or named todo | `cairn brief todo.<slug>` |
+| A named symbol | `cairn locate <symbol>`, then `cairn bundle <node>` |
+| A known architecture area | `cairn context --scope <node>` |
+| A broad or unfamiliar request | `cairn context`, choose the owning node, then `cairn bundle <node>` |
+| Current project priorities | `cairn status` and `cairn next` |
+| Why a boundary exists | `cairn rationale <node>` |
+| Connected work or evidence | `cairn neighbourhood <node>` with only the needed `--include-*` flags |
 
----
+Identify the owning node, contract, binding decisions, and relevant todo before
+reading a large source surface. Use `--json` when structured output is easier to
+consume.
 
-## Architecture & Data Flow
+## Task routing
 
-Single binary, single SQLite file, hybrid retrieval.
+The Cairn router is `.claude/skills/cairn-dev/SKILL.md`. Read only the reference
+matching the task:
 
-```
-CLI (clap) ──► MCP Server (stdio) ──► Pipeline ──► SQLiteStorage
-                                          │
-                              ┌───────────┼───────────┐
-                              ▼           ▼           ▼
-                         Vector KNN   FTS5 BM25   Graph Edges
-                              │           │           │
-                              └──────► RRF Fusion ◄───┘
-                                          │
-                              ┌───────────┼───────────┐
-                              ▼           ▼           ▼
-                         Cross-Encoder  Scoring    Abstention
-                         Reranker       Refinement   Gate
-```
+| Task | Reference |
+|---|---|
+| Bug investigation | `.claude/skills/cairn-dev/references/task-bug-investigation.md` |
+| Feature implementation | `.claude/skills/cairn-dev/references/task-feature-implementation.md` |
+| Behaviour-preserving refactor | `.claude/skills/cairn-dev/references/task-refactoring.md` |
+| Architecture or dead-code investigation | `.claude/skills/cairn-dev/references/task-architecture-discovery.md` |
+| Cairn artefacts or blueprint edits | `.claude/skills/cairn-dev/references/artefact-schemas.md` or `blueprint-syntax.md` |
+| Clean VM, model, MCP, or retrieval evaluation work | `skills/mag-development/SKILL.md` |
 
-### Storage Pipeline (store)
+Clients without skill support may read the referenced file directly. Do not load
+all references.
 
-1. **Dedup** — SHA-256 canonical hash + cosine similarity check (skip embedding if duplicate)
-2. **Embedding** — ONNX embedder (bge-small-en-v1.5 int8, 384-dim); `PlaceholderEmbedder` when `real-embeddings` is off
-3. **Supersession** — Mark older similar memories as superseded (cosine >= 0.70)
-4. **Relationship linking** — Auto-create `RELATED` edges for near-duplicates
-5. **Entity extraction** — Rule-based: people, tools, projects → tags like `entity:people:alice`
-6. **Persist** — `memories` table + FTS5 index + `relationships` graph table
+## Current architecture constraint
 
-### Retrieval Pipeline (advanced search)
+`memory_core::Pipeline` and `substrate` are competing composition paths. Until the
+active architecture audit and composition decision are complete:
 
-1. **Intent classification** — Keyword / Factual / Conceptual / General
-2. **Query embedding** — Skip for Keyword queries
-3. **Retrieval** — Vector KNN + FTS5 BM25 (parallel)
-4. **Fusion** — RRF with dual-match boost
-5. **Rerank** — Optional cross-encoder (`ms-marco-MiniLM-L-6-v2`)
-6. **Scoring refinement** — `type × time_decay × priority × word_overlap × importance × feedback × query_coverage`
-7. **Graph enrichment** — Neighbor boost (factor 0.1) via `relationships` table
-8. **Abstention gate** — Dedup + threshold filter + hot-cache merge
-9. **Query decomposition** — Multi-topic queries split into sub-queries, merged results
+- do not wire new production behaviour into both;
+- trace current callers, features, tests, and benchmarks before deleting either;
+- use `cairn brief todo.audit-current-architecture-and-dead-code` for the current
+  work unit.
 
-### Key Modules
+## Repository invariants
 
-| Module | Responsibility |
-|--------|--------------|
-| `src/main.rs` | CLI entry point, clap subcommands, `mag doctor` |
-| `src/lib.rs` | Public API surface, feature-gated re-exports |
-| `src/memory_core/mod.rs` | `Pipeline` orchestrator, trait re-exports |
-| `src/memory_core/domain.rs` | Core types: `EventType`, `MemoryKind`, `MemoryInput`, `SearchOptions`, `SearchResult`, TTL constants |
-| `src/memory_core/traits.rs` | 27+ async traits (`Ingestor`, `Storage`, `Searcher`, `AdvancedSearcher`, `GraphTraverser`, `MaintenanceManager`, …) |
-| `src/memory_core/embedder.rs` | `OnnxEmbedder` (real) and `PlaceholderEmbedder` (SHA256 fallback) |
-| `src/memory_core/scoring.rs` | `ScoringParams`, type weights, word overlap, Jaccard |
-| `src/memory_core/storage/sqlite/` | Full SQLite backend: schema, CRUD, search, graph, entities, lifecycle, session, admin, pipeline |
-| `src/mcp/mod.rs` | MCP stdio server, `TOOL_REGISTRY`, `#[tool_router]` delegation |
-| `src/mcp/tools/` | Tool handlers: `storage.rs`, `search.rs`, `relations.rs`, `lifecycle.rs`, `session.rs`, `facades.rs` |
-| `src/setup.rs` | Interactive `mag setup` wizard, connector content installation |
-| `src/uninstall.rs` | `mag uninstall` — config removal, cleanup |
-| `src/cli.rs` | CLI argument definitions (clap derive) |
-| `src/app_paths.rs` | XDG path resolution (`~/.mag/`) |
+- Core memory quality must work locally without cloud credentials. Hosted mode is
+  an optional deployment and synchronization adapter over the same semantics.
+- MCP stdio reserves stdout for protocol messages; runtime logs go to stderr.
+- Run synchronous SQLite work from async paths through `spawn_blocking`.
+- Schema evolution is additive unless an accepted migration decision says otherwise.
+- Derived facts, relationships, clusters, and summaries retain source provenance
+  and never overwrite raw memories.
+- Changes to retrieval, scoring, reranking, or the SQLite query pipeline are
+  benchmark-gated.
 
-### Feature Flags
+## Keep Cairn current
 
-| Flag | Default | Purpose |
-|------|---------|---------|
-| `real-embeddings` | **ON** | ONNX runtime, tokenizers, model download |
-| `mimalloc` | OFF | Alternative allocator |
-| `sqlite-vec` | OFF | Vector search acceleration |
-| `daemon-http` | OFF | HTTP daemon mode |
-| `test-helpers` | OFF | Expose `with_temp_home` to integration tests |
+Update the graph as part of the same change when you:
 
----
+- add or move source files across node ownership;
+- introduce a cross-node dependency;
+- change a public interface or module obligation;
+- settle an architectural decision;
+- start, block, or complete a tracked todo.
 
-## Key Directories
+Todo status lives in `meta/todos/`, not roadmap checkboxes:
 
-```
-src/                             Rust source — core + MCP + CLI
-src/memory_core/                 Pipeline, traits, domain types, embedder, scoring
-src/memory_core/storage/sqlite/  SQLite backend (schema, CRUD, search, graph, pipeline phases)
-src/mcp/                         MCP protocol server and tool handlers
-src/mcp/tools/                   Individual tool implementations
-tests/                           Integration tests, conformance suite, MCP smoke tests
-benches/                         Benchmark binaries (longmemeval, locomo, scale, onnx_profile)
-python/                          Python harnesses and MCP client for active strategy research
-scripts/                         Shell scripts: bench.sh, smoke-test.sh, bump-version.sh
-connectors/                      IDE/agent integration content (cursor, windsurf, opencode, shared)
-docs/                            Architecture docs, benchmark logs, MCP tool reference, setup guides
-```
-
----
-
-## Repository Skill Routing
-
-Compatible coding agents commonly load this root `AGENTS.md` automatically. Skill
-folder discovery varies by client, so this file explicitly routes environment work:
-
-- Before clean VM/container setup, first-run model debugging, local LLM work, or
-  benchmark execution, read `skills/mag-development/SKILL.md`.
-- Treat that skill as the operational supplement to this architecture guide; do
-  not duplicate the full repository overview into the skill.
-
----
-
-## Development Commands
-
-### Build
 ```bash
-cargo build --release                          # Release binary
-cargo build --bin mag                          # Default binary
-cargo build --features real-embeddings         # Explicit default feature
+cairn todo set <slug> <open|in_progress|done|blocked>
 ```
 
-### Test
+Before handing work back:
+
 ```bash
-cargo test --all-features                      # Full test suite (500+ tests)
-cargo test --all-features <test_name>          # Single test
-cargo test --all-features -- --nocapture       # With output
+cairn scan
+cairn hook all
 ```
 
-### Lint / Format
+Record Cairn friction rather than working around it silently:
+
+```bash
+cairn feedback "what you expected, what happened instead"
+```
+
+## Engineering gates
+
+Run the smallest focused tests during development. Before merge:
+
 ```bash
 cargo fmt --all -- --check
 cargo clippy --all-targets --all-features -- -D warnings
+cargo test --all-features
 ```
 
-### Run
-```bash
-cargo run -- serve                             # Start MCP stdio server
-cargo run -- setup                             # Interactive setup wizard
-cargo run -- doctor                            # Health check + auto-fix
-```
+Additionally:
 
-### Benchmarks
-```bash
-# Preferred entry point (logs to docs/benchmarks/benchmark_log.csv)
-./scripts/bench.sh                             # bge-small, 2 samples, word-overlap
-./scripts/bench.sh --gate                      # PR gate: compare vs 10-sample baseline
-./scripts/bench.sh --samples 10                # Full validation run
-
-# Raw benchmark binaries
-cargo run --release --bin longmemeval_bench
-cargo run --release --bin locomo_bench -- --samples 2
-cargo run --release --bin locomo_bench -- --llm-judge  # needs OPENAI_API_KEY
-```
-
-### Quality Gate (all in one)
-```bash
-prek run                                       # fmt + clippy + test
-```
-
----
-
-## Code Conventions & Common Patterns
-
-### Commits
-Semantic commits: `<type>(<scope>): <description>`
-Examples: `feat(memory): add TTL sweep`, `fix(search): handle empty FTS5 result`
-
-### Error Handling
-- **No `unwrap()` / `expect()` in production** — use `anyhow::Context` or `?`
-- All DB I/O in `tokio::task::spawn_blocking` — never block the async executor
-- `anyhow::Result<()>` at CLI boundaries; structured errors inside MCP tools map to `McpError`
-
-### Async Patterns
-- `#[async_trait]` for trait-based async interfaces
-- `tokio::spawn_blocking(|| { conn.call(...) })` for SQLite operations
-- `Arc<SqliteStorage>` shared across tool handlers (cloned per request)
-
-### Trait-First Design
-- Add new capability via new trait + impl rather than modifying existing signatures
-- 27+ traits in `src/memory_core/traits.rs` define the pipeline contract
-- `Backend<'a>` struct bundles `&dyn Trait` references for generic test helpers
-
-### Struct-Based API
-- `MemoryInput` — store parameters (content, tags, event_type, session_id, …)
-- `MemoryUpdate` — update parameters (content, tags, metadata, …)
-- `SearchOptions` — search/filter configuration
-- Avoid positional arguments in internal APIs
-
-### Naming
-- `snake_case` for functions/variables, `PascalCase` for types/traits, `SCREAMING_SNAKE_CASE` for constants
-- Module files: `domain.rs`, `traits.rs`, `schema.rs`, `crud.rs`
-- Test modules: `mod tests { ... }` inline, or `tests/<name>.rs` for integration
-
-### State Management
-- SQLite is the single source of truth; no in-memory caches for durability-critical data
-- Selective cache invalidation on `store()`, full clear on bulk ops (import/sweep/compact)
-- Connection pooling with reader/writer separation in `conn_pool.rs`
-
-### Schema Migrations
-- **Additive only** — never drop/rename columns
-- Use `ALTER TABLE ADD COLUMN` with error ignoring for idempotency
-- Schema version tracked in `schema_migrations` table
-
-### SQLite Concurrency
-- `retry_on_lock()` with bounded backoff: initial + 5 retries, 10-160ms + jitter
-- `rusqlite` with `bundled` feature
-
----
-
-## Important Files
-
-| File | Purpose |
-|------|---------|
-| `src/main.rs` | Binary entry point, CLI dispatch, doctor checks |
-| `src/lib.rs` | Library exports, `#[cfg]` re-exports |
-| `Cargo.toml` | Package config, features, dependencies, bin targets, lints |
-| `src/memory_core/mod.rs` | `Pipeline` struct, trait re-exports |
-| `src/memory_core/traits.rs` | 27+ trait definitions (contract for all backends) |
-| `src/memory_core/domain.rs` | Core data types and constants |
-| `src/memory_core/embedder.rs` | `OnnxEmbedder` / `PlaceholderEmbedder` |
-| `src/memory_core/scoring.rs` | Scoring parameters and algorithms |
-| `src/mcp/mod.rs` | MCP server, `TOOL_REGISTRY`, `#[tool_router]` |
-| `src/mcp/request_types.rs` | All MCP request/response structs |
-| `src/mcp/validation.rs` | `require_finite`, `MAX_RESULT_LIMIT`, `MAX_BATCH_SIZE` |
-| `src/setup.rs` | `mag setup` wizard and connector installation |
-| `src/uninstall.rs` | `mag uninstall` cleanup |
-| `src/app_paths.rs` | XDG paths (`~/.mag/memory.db`, `~/.mag/models/`) |
-| `scripts/bench.sh` | Standardized benchmark runner + gate |
-| `docs/architecture.md` | Deep-dive on storage/retrieval pipelines |
-| `docs/mcp-tools.md` | Full MCP tool reference |
-| `docs/configuration.md` | Runtime configuration options |
-| `connectors/shared/AGENTS.md` | Template for IDE AGENTS.md injection |
-
----
-
-## Runtime/Tooling Preferences
-
-### Required Toolchain
-- **Rust** (edition 2024) — `cargo` is the only build tool
-- **No Node/Bun** required — this is a pure Rust project
-- Optional: Python 3 for `python/` benchmark harnesses and active strategy research
-
-### Dependencies
-- `tokio` (full) — async runtime
-- `rusqlite` (bundled) — SQLite
-- `ort` + `tokenizers` + `ndarray` — ONNX embedding (gated by `real-embeddings`)
-- `rmcp` — MCP protocol server/client
-- `clap` — CLI parsing
-- `serde` + `serde_json` — serialization
-- `chrono` — date/time handling
-- `tracing` + `tracing-subscriber` — structured logging
-
-### Model Files
-- ~134 MB of ONNX models auto-download on first use
-- Cached under `~/.mag/models/`
-- Default: `bge-small-en-v1.5` (int8, 384-dim)
-- Optional: `voyage-4-nano` (int8/fp16/fp32, 512/1024/2048-dim Matryoshka)
-
-### Environment
-- `.env.local` contains `OPENAI_API_KEY` — in `.gitignore`, loaded by `dotenvy`
-- `HOME` / `USERPROFILE` hermetic isolation in MCP smoke tests
-- No stdout in MCP server mode — stdout is the protocol channel; logs to stderr via `tracing`
-
----
-
-## Testing & QA
-
-### Test Infrastructure
-- **500+ unit and integration tests**
-- All storage tests use **in-memory SQLite** (`:memory:`) for hermeticity
-- `serial_test` crate for tests that touch filesystem state
-- `tempfile` crate for temporary directories
-
-### Key Test Files
-- `tests/storage_conformance.rs` — Generic async conformance suite run against both `SqliteStorage` and `MemoryStorage`
-- `tests/mcp_smoke.rs` — End-to-end MCP stdio protocol tests with hermetic HOME/USERPROFILE isolation
-- `tests/schema_migration.rs` — Forward/backward migration compatibility
-- `tests/cli_output_smoke.rs` — CLI output snapshot tests
-- `tests/setup_model_download.rs` — Setup wizard model download logic
-- `tests/longmemeval_regression.rs` — Benchmark regression guard
-- `tests/python/` — Python-side tests for benchmark runners
-
-### Test Patterns
-- `conformance_tests!` macro generates a test module per backend
-- `Backend<'a>` trait-object bundle for generic test helpers
-- `PlaceholderEmbedder` used when `real-embeddings` is disabled (deterministic SHA256 hashes)
-- MCP smoke tests spawn the binary as a child process and speak JSON-RPC over stdio
-
-### Running Tests
-```bash
-cargo test --all-features                          # Everything
-cargo test --all-features mcp_stdio                # MCP smoke tests only
-cargo test --all-features sqlite_conformance       # SQLite conformance only
-cargo test --all-features memory_conformance       # In-memory backend only
-```
-
-### Quality Gates (must pass before pushing)
-1. **Format**: `cargo fmt --all -- --check`
-2. **Lint**: `cargo clippy --all-targets --all-features -- -D warnings`
-3. **Tests**: `cargo test --all-features`
-4. **Benchmark gate** (if touching scoring/search/storage): `./scripts/bench.sh --gate`
-   - Runs 2-sample, compares against 10-sample baseline
-   - Warns at >2pp delta, fails at >5pp regression
-5. **Full validation** (before merge if gate warned): `./scripts/bench.sh --samples 10`
-
-Run `prek run` for gates 1-3. Always use `bench.sh` (not raw `cargo run`) so results are logged to `docs/benchmarks/benchmark_log.csv`.
-
-### Post-Implementation Checklist
-- [ ] Quality gates pass (`prek run`)
-- [ ] Benchmark shows no regression (if applicable); append row to `docs/benchmarks/benchmark_log.csv`
-- [ ] New public APIs have tests
-- [ ] Code simplification review — check for unnecessary complexity, duplication
-- [ ] Update `AGENTS.md` if architecture or conventions changed
-
----
-
-## Gotchas
-
-- `benches/locomo/` is a modular 10-file benchmark suite, not a single-file bench
-- LoCoMo-10 IS the reduced dataset (original had 50 conversations); `--samples 2` is fast iteration mode
-- LoCoMo categories: cat 1=single-hop, 2=temporal, 3=multi-hop, 4=open-domain, 5=adversarial
-- `conductor/` is a legacy Gemini CLI artifact — not actively maintained
-- `GRAPH_NEIGHBOR_FACTOR=0.1` — graph enrichment Phase 5 re-enabled at conservative factor; guarded by `if > 0.0`
-- Tags stored as JSON arrays, queried via `json_each()`
-- `SearchOptions::default()` used everywhere for search parameter construction
-- Changing default `ScoringParams` affects benchmark baselines — always gate-check
-
----
-
-## Version Control
-
-- Standard git workflow (not Graphite)
-- Feature branches: `feat/...`, `fix/...`, `perf/...`, `refactor/...`
-- `git switch -c feat/my-feature` then `git push -u origin feat/my-feature`
-- Use `gh pr create` for PRs
-
----
-
-## Tool-Specific Notes
-
-### Claude Code
-- Use `/simplify` after completing implementation work to review for quality
-
-### Codex (OpenAI)
-<!-- Add Codex-specific guidance here as needed -->
+- retrieval/scoring/storage-pipeline changes: `./scripts/bench.sh --gate`;
+- CLI, MCP, installation, or model-startup changes: `bash scripts/smoke-test.sh`;
+- clean-environment or local-model work: follow `skills/mag-development/SKILL.md`.
 
 <!-- cairn:agent-guide-begin -->
 ## Cairn orientation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,8 @@
 # CLAUDE.md
 
-All agent guidance lives in [AGENTS.md](./AGENTS.md). Read that file for commands, conventions, architecture, quality gates, and gotchas.
+Start with [AGENTS.md](./AGENTS.md). It is a progressive-disclosure router: use
+the Cairn queries and task-specific references it names instead of preloading the
+repository, generated maps, or full planning documents.
 
-This file exists only because Claude Code looks for `CLAUDE.md` by convention.
-AGENTS.md is vendor-neutral and applies to all AI coding tools (Claude Code, Cursor, Windsurf, Copilot).
+This file exists because Claude Code looks for `CLAUDE.md` by convention. The
+root guidance is vendor-neutral and applies to all coding agents.

--- a/meta/sources/src.mag-agents-guide.md
+++ b/meta/sources/src.mag-agents-guide.md
@@ -1,10 +1,10 @@
 ---
 id: src.mag-agents-guide
 file: AGENTS.md
-sha256: 91f564faedbacfd383238bac9ff20ffaa3e0457f1d179ad7aa7da26c63b32239
+sha256: 633a680e4d980a3f0a4d0c26af39964d4ef38ba07bfce92d4ff3f89dbf4b96d7
 verification: verified
 type: repository-guide
 date: 2026-07-28
 ---
 
-Current repository architecture, commands, and coding constraints.
+Progressive-disclosure repository router, invariants, and Cairn context entrypoints.

--- a/skills/mag-development/SKILL.md
+++ b/skills/mag-development/SKILL.md
@@ -9,8 +9,9 @@ metadata:
 
 # MAG development
 
-Read the root `AGENTS.md` first. It is the architecture and coding guide; this
-skill contains the operational details that were easy to misread in a clean VM.
+Read the root `AGENTS.md` first. It is the progressive-disclosure router and
+repository-invariant guide. This skill contains operational details for clean
+environments, model startup, MCP testing, and retrieval validation.
 
 ## Clean-environment baseline
 

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,77 +1,38 @@
-# SOURCE MAP
+# `src/` scoped agent guide
 
-## OVERVIEW
-`src/` contains executable runtime paths: CLI dispatch, MCP server, and trait-driven memory core.
+The root `AGENTS.md` and accepted Cairn decisions remain authoritative. This file
+contains only runtime-specific reminders; use Cairn for the live architecture.
 
-## STRUCTURE
-```text
-src/
-├── main.rs               # Process entrypoint and command dispatch
-├── cli.rs                # Clap command surface
-├── mcp/                  # MCP stdio server + tool handlers
-│   ├── mod.rs            # Server struct, #[tool_router] delegation, TOOL_REGISTRY
-│   ├── request_types.rs  # All request/response structs
-│   ├── validation.rs     # Validation constants + require_finite
-│   └── tools/            # Tool handler implementations by concern
-│       ├── storage.rs    # store/retrieve/delete + memory facade
-│       ├── search.rs     # search, list
-│       ├── relations.rs  # relations (list/add/traverse/version_chain)
-│       ├── lifecycle.rs  # update, feedback, lifecycle
-│       ├── session.rs    # checkpoint/remind/lessons/profile/session_info
-│       └── facades.rs    # memory_manage, memory_session, memory_admin
-└── memory_core/
-    ├── mod.rs            # Core traits + Pipeline orchestration
-    ├── embedder.rs       # Embedder trait + PlaceholderEmbedder + OnnxEmbedder
-    ├── scoring.rs        # Search scoring: type weights, priority factors, time decay, word overlap, Jaccard
-    └── storage/
-        ├── mod.rs        # Storage exports
-        └── sqlite.rs     # SQLite implementation
+## Orient to the owning node
+
+```bash
+cairn locate <symbol>
+cairn context --scope <node>
+cairn bundle <node>
 ```
 
-## WHERE TO LOOK
-| Task | File | Notes |
-|---|---|---|
-| Add CLI command | `src/cli.rs` + `src/main.rs` | Keep parser and runtime match in sync |
-| Add MCP tool | `src/mcp/mod.rs` + `src/mcp/tools/*.rs` | Add handler in `tools/`, register via `#[tool]` in `mod.rs` `#[tool_router]` block |
-| Change storage behavior | `src/memory_core/storage/sqlite.rs` | Ensure async-safe DB access |
-| Introduce new core stage | `src/memory_core/mod.rs` | Implement trait, then wire Pipeline |
-| Embedding behavior | `src/memory_core/embedder.rs` | `Embedder` trait, `OnnxEmbedder` (feature-gated), `PlaceholderEmbedder` |
-| New operations via SqliteStorage | `src/main.rs` | New CLI ops use `mcp_storage` directly (not Pipeline) |
+Common nodes:
 
-## FEATURE SURFACE
+| Area | Cairn node |
+|---|---|
+| CLI, crate surface, process assembly, doctor dispatch | `mag.runtime.entrypoints` |
+| Setup, configuration, paths, uninstall | `mag.runtime.setup` |
+| MCP protocol and tools | `mag.runtime.mcp` |
+| Memory domain/models/retrieval/storage | `mag.runtime.memory` |
+| Candidate trait-composed orchestration | `mag.runtime.substrate` |
+| Optional HTTP deployment adapter | `mag.runtime.daemon` |
 
-### CLI Commands (30)
+Do not use this file as a source-tree map. The blueprint and node contracts are
+the maintained index.
 
-`ingest`, `process`, `retrieve`, `delete`, `update`, `list`, `relations`, `search`, `semantic-search`, `recent`, `stats`, `export`, `import`, `feedback`, `sweep`, `checkpoint`, `resume-task`, `profile`, `remind`, `lessons`, `download-model`, `advanced-search`, `similar`, `traverse`, `phrase-search`, `maintain`, `welcome`, `protocol`, `stats-extended`, `serve`
+## Runtime invariants
 
-### MCP Tools (19)
+- Keep Clap declarations and runtime dispatch aligned.
+- MCP stdio reserves stdout for JSON-RPC; send logs to stderr.
+- Public CLI or MCP changes require compatibility consideration and tests.
+- Synchronous SQLite work called from async code must use `spawn_blocking`.
+- Do not duplicate new production behaviour across `memory_core::Pipeline` and
+  `substrate` while the composition decision is unresolved.
+- New files and cross-node calls must be represented in Cairn.
 
-`memory_store`, `memory_store_batch`, `memory_retrieve`, `memory_delete`, `memory_update`, `memory_search`, `memory_list`, `memory_relations`, `memory_feedback`, `memory_lifecycle`, `memory_checkpoint`, `memory_remind`, `memory_lessons`, `memory_profile`, `memory_admin`, `memory_session_info`, `memory`, `memory_manage`, `memory_session`
-
-**Migration note (from pre-consolidation tool set):**
-Four tools were merged into the two consolidated tools above:
-- `memory_health` → `memory_admin` with `action=health` (+ optional `detail=basic|stats|types|sessions|digest|access_rate`)
-- `memory_export` → `memory_admin` with `action=export` or `action=import`
-- `memory_welcome` → `memory_session_info` with `mode=welcome`
-- `memory_protocol` → `memory_session_info` with `mode=protocol`
-
-All functionality is preserved; only the tool entry-points changed. Update any hardcoded tool calls in prompts or integrations to use the new names above.
-
-### Core Traits (26)
-
-`Ingestor`, `Processor`, `Storage`, `Retriever`, `Searcher`, `Recents`, `SemanticSearcher`, `Deleter`, `Updater`, `Tagger`, `Lister`, `RelationshipQuerier`, `Embedder`, `AdvancedSearcher`, `GraphTraverser`, `SimilarFinder`, `PhraseSearcher`, `FeedbackRecorder`, `ExpirationSweeper`, `ProfileManager`, `CheckpointManager`, `ReminderManager`, `LessonQuerier`, `MaintenanceManager`, `WelcomeProvider`, `StatsProvider`
-
-### Domain Structs
-
-`MemoryInput` (store params), `MemoryUpdate` (update params), `SearchOptions` (filter by event_type/project/session_id/importance_min/created_after/created_before/context_tags), `SearchResult`, `SemanticResult`, `Relationship`, `ListResult`, `GraphNode`
-
-## CONVENTIONS
-- `main.rs` initializes tracing to stderr; preserve this in server mode.
-- MCP tools must return stable payloads (`CallToolResult`) and clear error mapping.
-- Runtime logs should use metadata (ids, content lengths), not raw content dumps.
-- For DB operations called from async contexts, wrap sync SQLite work with `spawn_blocking`.
-
-## ANTI-PATTERNS
-- Do not perform direct `rusqlite` calls on async runtime threads.
-- Do not change command/tool names without migration rationale; integrations depend on them.
-- Do not add stdout logging in server path; protocol corruption risk.
+Finish with focused tests, then `cairn scan` and `cairn hook all`.

--- a/src/memory_core/AGENTS.md
+++ b/src/memory_core/AGENTS.md
@@ -1,62 +1,48 @@
-# MEMORY CORE MAP
+# `src/memory_core/` scoped agent guide
 
-## OVERVIEW
+Use the root `AGENTS.md` first. This file narrows work inside the memory system;
+Cairn remains the live architecture and decision index.
 
-`memory_core` defines the domain contracts and orchestration for ingest/process/store/retrieve.
-
-## STRUCTURE
-
-```text
-src/memory_core/
-├── mod.rs               # Traits + Pipeline orchestration
-├── embedder.rs          # Embedder trait + PlaceholderEmbedder + OnnxEmbedder
-├── scoring.rs           # Search scoring: type weights, priority factors, time decay, word overlap, Jaccard
-└── storage/
-    ├── mod.rs           # Export surface
-    └── sqlite.rs        # SQLite-backed storage + schema + tests
-```
-
-## WHERE TO LOOK
-
-| Task | File | Notes |
-|---|---|---|
-| Trait contract changes | `src/memory_core/mod.rs` | Update trait + Pipeline usage + tests together |
-| SQLite schema changes | `src/memory_core/storage/sqlite.rs` | Keep migration-safe additive table updates |
-| Retrieval semantics | `src/memory_core/storage/sqlite.rs` | `retrieve` updates `last_accessed_at` in one transaction |
-| Relationship behavior | `src/memory_core/storage/sqlite.rs` | FK enforcement + cascade behavior are required |
-| Event type parsing/defaults | `src/memory_core/mod.rs` | `EventType`, `is_valid_event_type()`, and `MemoryInput::apply_event_type_defaults()` |
-| Struct-based signatures | `src/memory_core/mod.rs` | `MemoryInput`, `MemoryUpdate`, `SearchOptions` replace positional params |
-| Embedding generation | `src/memory_core/embedder.rs` | `Embedder` trait with `OnnxEmbedder` (384-dim, feature-gated) and `PlaceholderEmbedder` (32-dim SHA256 fallback) |
-| Search scoring | `src/memory_core/scoring.rs` | Type weights, priority factors, time decay, word overlap, Jaccard similarity |
-| Advanced search | `src/memory_core/storage/sqlite.rs` | Multi-phase scoring: vector + FTS5 + type-weighting + time-decay + word-overlap + importance |
-| Graph traversal | `src/memory_core/storage/sqlite.rs` | BFS with max_hops (1-5), min_weight, edge type filtering |
-| Cross-session profile/checkpoint/reminder/lesson | `src/memory_core/mod.rs`, `src/memory_core/storage/sqlite.rs` | Traits: ProfileManager/CheckpointManager/ReminderManager/LessonQuerier; `user_profile` table |
-| TTL + dedup lifecycle | `src/memory_core/mod.rs`, `src/memory_core/storage/sqlite.rs` | Event-type TTL defaults, canonical hash dedup, Jaccard dedup |
-| Auto-relate + feedback + sweep | `src/memory_core/storage/sqlite.rs` | Best-effort related edges, feedback scoring flags, TTL expiration cleanup |
-| Maintenance + welcome + stats | `src/memory_core/mod.rs`, `src/memory_core/storage/sqlite.rs` | Traits: MaintenanceManager (health/consolidate/compact/clear_session), WelcomeProvider (session briefing), StatsProvider (type/session/digest/access_rate stats) |
-
-## CONVENTIONS
-
-- Keep Pipeline methods thin orchestration; heavy logic belongs in concrete implementations.
-- Preserve id defaulting (`Uuid::new_v4`) in pipeline paths when caller omits id.
-- Schema initialization must enable `PRAGMA foreign_keys = ON` before DDL.
-- SQLite tests should prefer `new_in_memory()` and explicit edge-case assertions.
-
-## ANTI-PATTERNS
-
-- Do not drop/rename existing columns in this phase; favor additive schema evolution.
-- Do not bypass transactional writes for coupled read/update flows.
-- Do not regress hermetic tests by coupling to user HOME paths.
-
-## COMMANDS
+## Select the smallest node
 
 ```bash
-# focused checks for this area
-cargo test memory_core:: --all-features
-cargo test sqlite:: --all-features
-
-# full parity gate
-cargo fmt --all -- --check
-cargo clippy --all-targets --all-features -- -D warnings
-cargo test --all-features
+cairn context --scope mag.runtime.memory
+cairn bundle mag.runtime.memory.<domain|models|retrieval>
+cairn bundle mag.runtime.memory.storage.<api|sqlite|memory>
+cairn rationale mag.runtime.memory
 ```
+
+Relevant nodes:
+
+- `mag.runtime.memory.domain` — types, traits, and legacy `Pipeline`;
+- `mag.runtime.memory.models` — embeddings, optional generation, model adapters;
+- `mag.runtime.memory.retrieval` — candidate retrieval, reranking, scoring, abstention;
+- `mag.runtime.memory.storage.sqlite` — production storage and query pipeline;
+- `mag.runtime.memory.storage.memory` — reference backend and parity target;
+- `mag.runtime.substrate` — candidate composition path, outside this directory.
+
+## Current constraint
+
+The production composition root is under active review. Do not add equivalent
+behaviour to both the legacy `Pipeline` path and `substrate`. Before changing
+or deleting either, use:
+
+```bash
+cairn brief todo.audit-current-architecture-and-dead-code
+```
+
+and trace current callers, feature flags, tests, benchmarks, and fallbacks.
+
+## Memory-system invariants
+
+- Preserve raw memories; generated facts, relations, clusters, and summaries are
+  derived records with source provenance.
+- Keep schema changes additive unless an accepted migration decision permits more.
+- Preserve parity between production SQLite and the reference backend where the
+  shared contract requires it.
+- Retrieval, scoring, reranking, or query-pipeline changes require
+  `./scripts/bench.sh --gate`.
+- Use hermetic storage and model paths in tests; never touch the user's MAG data.
+- Run synchronous SQLite work from async paths through `spawn_blocking`.
+
+After focused tests, run `cairn scan` and `cairn hook all`.


### PR DESCRIPTION
Reworks MAG's agent instructions around progressive disclosure rather than preloading a static repository map.

## Changes

- Replaces the ~360-line root `AGENTS.md` architecture dump with a compact context router.
- Routes planned work, symbols, architecture areas, rationale, and connected evidence through bounded Cairn queries.
- Adds task-to-skill routing for bugs, features, refactors, architecture work, Cairn artefacts, clean VMs, models, MCP, and retrieval evaluation.
- Keeps only cross-cutting invariants in the root file.
- Replaces stale `src/AGENTS.md` and `src/memory_core/AGENTS.md` source maps with scoped Cairn node guidance.
- Updates the MAG development skill and `CLAUDE.md` to follow the same disclosure model.
- Refreshes the verified Cairn source checksum for `AGENTS.md`.

## Intended behaviour

A fresh agent should identify the owning node, contract, decisions, and active todo before opening a broad source surface. Generated maps, historical strongholds, and full roadmaps are explicitly opt-in rather than startup context.

## Validation

- Cairn architecture/source gate
- Standard repository CI


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches MAG’s agent docs to progressive disclosure. Replaces the monolithic root AGENTS.md with a small router that drives task-focused Cairn queries and scoped guides to reduce preload and confusion.

- **Refactors**
  - Replace the ~360-line root AGENTS.md with a compact router that keeps only cross-cutting invariants and routes work via bounded Cairn queries.
  - Add task-to-skill routing for bugs, features, refactors, architecture, Cairn artefacts, clean VMs, models, MCP, and retrieval evaluation.
  - Replace stale `src/AGENTS.md` and `src/memory_core/AGENTS.md` with scoped runtime/memory guides that defer to Cairn.
  - Update `CLAUDE.md` to point to the router; align `skills/mag-development/SKILL.md`; refresh Cairn source checksum and meta description.
  - Document the current composition constraint: do not duplicate new production behavior across `memory_core::Pipeline` and `substrate` while the audit runs.

- **Migration**
  - Stop preloading repo maps/strongholds/roadmaps; start with small Cairn queries (e.g., `cairn context`, `cairn bundle <node>`, `cairn locate <symbol>`, `cairn brief todo.<slug>`).
  - Identify the owning node, contract, binding decisions, and active todo before reading broadly; use `skills/mag-development/SKILL.md` for environment/model/MCP tasks.
  - Validate with the Cairn architecture/source gate and standard CI; before handoff run `cairn scan` and `cairn hook all`.

<sup>Written for commit 671111eb0a910111cc637477001a8bcf8408ce64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/George-RD/mag/pull/366?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

