### PR TITLE
Redesign MAG landing page and README

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,43 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "site/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Assemble static site
+        run: |
+          mkdir -p _site
+          cat site/parts/*.html > _site/index.html
+          cat site/styles/*.css > _site/styles.css
+          cp site/app.js site/favicon.svg site/social-card.svg _site/
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+      - name: Upload site
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,85 @@
+# MAG design system
+
+## Surface mode
+
+The GitHub Pages landing page is a **Persuade** surface. The README is a **Read** surface that uses the same identity with less visual density.
+
+## Direction
+
+**Local context relay.**
+
+MAG should look like an engineering field log crossed with a compact control-room schematic. The signature image is a useful decision moving from one coding tool, through a local MAG store, into another tool. The design must make cross-tool continuity visible before it explains search architecture.
+
+The identity rejects the category defaults: glowing AI orbs, purple gradients, generic memory dashboards, repeated icon cards and vague “second brain” language.
+
+## Palette
+
+| Token | Value | Role |
+|---|---|---|
+| Paper | `#f5f7f2` | Main light surface |
+| White | `#ffffff` | High-contrast panels |
+| Ink | `#0d1b2a` | Text and dark sections |
+| Muted ink | `#53677a` | Secondary text |
+| Cobalt | `#2457ff` | Context route and primary action |
+| Signal orange | `#ff5a36` | Breaks, warnings and comparison |
+| Dark signal | `#a82c12` | Orange-family text on light surfaces |
+| Live green | `#ccff3d` | Active local state |
+| Route tint | `#dce4ff` | MAG comparison column and soft route surfaces |
+
+Use color as fields and signals, not as scattered decoration. Do not use gradients.
+
+## Type
+
+- Display: Archivo Black.
+- Body: Atkinson Hyperlegible.
+- Code and measurements: JetBrains Mono.
+- Safe fallbacks must keep the layout usable when web fonts fail.
+
+Headings are blunt and short. Body copy is plain English. Monospace is reserved for code, labels, measurements and machine state.
+
+## Layout
+
+- Maximum content width: 1180px.
+- Use hard rules, offset blocks and asymmetric two-column compositions.
+- Keep related content tight and separate major arguments generously.
+- Use purpose-built visuals for the relay, retrieval pipeline, benchmark, trade-offs and roadmap.
+- Do not make equal cards the page scaffold.
+
+## Components
+
+- **Relay stage:** the core product proof. One decision visibly passes through `~/.mag/memory.db` to another client.
+- **Evidence rail:** measured facts with a named benchmark context.
+- **Pipeline:** capture, store, recall and explain.
+- **Comparison table:** highlights fit rather than claiming universal superiority.
+- **Benchmark board:** MAG and AutoMem shown at the same scale with the recall caveat nearby.
+- **Roadmap rail:** issue-linked directions with no invented dates.
+- **Install terminal:** a real command and a visible copy action.
+
+## Motion
+
+One restrained relay-dot sequence is allowed. The page must remain complete before animation starts. Disable non-essential motion under `prefers-reduced-motion`.
+
+## Responsive behavior
+
+- At narrow widths, stack narrative and proof without changing their order.
+- The relay becomes a vertical route.
+- The comparison table remains horizontally scrollable inside a labelled, keyboard-focusable region.
+- Primary actions and issue links keep at least a 44px touch target.
+- The document itself must not create horizontal page scroll.
+
+## Accessibility and performance
+
+- Body text contrast must meet WCAG AA.
+- Keep a visible two-layer focus treatment on interactive controls.
+- Use semantic landmarks, one `h1`, ordered headings and a skip link.
+- The site remains static HTML, CSS and small vanilla JavaScript.
+- No framework or runtime dependency.
+- Social and README visuals must include meaningful titles, descriptions or alt text.
+
+## README visuals
+
+README SVGs use fixed GitHub-safe colors and system fonts. They show the same relay mechanism without scripts, external assets or motion. Copy remains primary; visuals orient the reader and explain the mechanism.
+
+## Change rule
+
+Product claims come from `PRODUCT.md` and repository evidence. Visual changes should preserve the context-relay idea unless the positioning changes. A clean detector result does not justify generic design, and a bold visual does not justify an unsupported claim.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,57 @@
+# MAG product context
+
+## Product
+
+MAG is a local memory layer for coding agents. It stores useful decisions, bug fixes, work rules and session handoffs in one SQLite database, then makes that context available to MCP clients. Claude Code also has a native plugin and lifecycle hooks.
+
+## Audience
+
+Primary:
+
+- Developers who move between two or more coding agents.
+- Developers working with client, private or regulated context that should remain on their machine.
+- Technical users who prefer inspectable local data over another hosted account.
+
+Wrong fit:
+
+- Teams that need managed cloud sync now.
+- Users who need application-level database encryption.
+- Users who want a browser-only service with no local model or setup.
+- Users who expect useful long-term memory with no capture rules or cleanup.
+
+## Job to be done
+
+When I switch coding tools or resume work later, bring back the small amount of prior context that changes the next decision, without sending my memory store to a third party by default.
+
+## Primary action
+
+Install MAG, let `mag setup` configure known clients, store one real decision, then recall it with different wording.
+
+## Product truth
+
+- The default setup uses one local SQLite database for memories.
+- Embeddings and search run locally by default.
+- First use downloads local ONNX models.
+- Optional API embedding providers can send data outside the machine when explicitly configured.
+- The SQLite database is plaintext. Users should not store secrets and should use full-disk encryption when needed.
+- MAG is a 0.1.x project. Interfaces and setup may still change.
+- The published 90.1% LoCoMo result is retrieval-oriented word-overlap recall, not a general score for agent quality.
+- Team-wide cloud sync is not built in today.
+
+## Position
+
+MAG competes on cross-tool continuity, local ownership and inspectability. It is not positioned as a universal replacement for project documentation, built-in memory, or managed team-memory services.
+
+## Voice
+
+Direct, technical and bounded by evidence. Explain the mechanism. State limitations without hiding them in footnotes. Avoid generic AI language, inflated claims and false certainty.
+
+## Sources of truth
+
+- `docs/architecture.md`
+- `docs/benchmarks/methodology.md`
+- `docs/SETUP.md`
+- `SECURITY.md`
+- `src/tool_detection.rs`
+- `src/setup.rs`
+- Open GitHub issues for roadmap status

--- a/README.md
+++ b/README.md
@@ -1,149 +1,116 @@
-<div align="center">
-  <h1>MAG</h1>
-  <p><em>Open any tool. Your context is already there.</em></p>
-  <p>
-    <a href="https://github.com/George-RD/mag/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/George-RD/mag/ci.yml?branch=main" alt="CI"></a>
-    <a href="https://crates.io/crates/mag-memory"><img src="https://img.shields.io/crates/v/mag-memory" alt="crates.io"></a>
-    <a href="https://www.npmjs.com/package/mag-memory"><img src="https://img.shields.io/npm/v/mag-memory" alt="npm"></a>
-    <a href="https://github.com/George-RD/mag/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License"></a>
-    <a href="https://github.com/George-RD/mag"><img src="https://img.shields.io/github/stars/George-RD/mag" alt="GitHub Stars"></a>
-  </p>
-  <p>
-    <a href="https://github.com/George-RD/mag/tree/main/docs">Documentation</a> |
-    <a href="https://github.com/George-RD/mag/issues">Issues</a> |
-    <a href="https://github.com/George-RD/mag/blob/main/docs/benchmarks/methodology.md">Benchmarks</a> |
-    <a href="https://github.com/George-RD/mag/blob/main/SECURITY.md">Security</a>
-  </p>
-</div>
+<picture>
+  <img src="docs/readme-hero.svg" width="100%" alt="MAG. Your tools change. Your context should not. One local memory connects Claude Code, Cursor, Codex and other MCP clients." />
+</picture>
 
----
+<p align="center">
+  <a href="https://george-rd.github.io/mag/"><strong>See the landing page</strong></a>
+  ·
+  <a href="#quick-start"><strong>Install</strong></a>
+  ·
+  <a href="#how-mag-works"><strong>How it works</strong></a>
+  ·
+  <a href="#trade-offs"><strong>Trade-offs</strong></a>
+  ·
+  <a href="#roadmap"><strong>Roadmap</strong></a>
+</p>
 
-Every new session, your AI starts from zero. The decisions you made yesterday, the patterns you taught it, the bugs you already solved together - gone. You re-explain. It re-discovers. You lose hours every week to an assistant with no long-term memory.
+<p align="center">
+  <a href="https://github.com/George-RD/mag/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/George-RD/mag/ci.yml?branch=main" alt="CI status"></a>
+  <a href="https://crates.io/crates/mag-memory"><img src="https://img.shields.io/crates/v/mag-memory" alt="crates.io version"></a>
+  <a href="https://www.npmjs.com/package/mag-memory"><img src="https://img.shields.io/npm/v/mag-memory" alt="npm version"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-2457ff" alt="MIT licence"></a>
+  <a href="https://github.com/George-RD/mag"><img src="https://img.shields.io/github/stars/George-RD/mag" alt="GitHub stars"></a>
+</p>
 
-MAG fixes this. It gives your AI tools persistent memory that survives across sessions, across projects, and across tools. Open Claude on Monday. It already knows what you decided on Friday.
+Built-in memory helps inside one tool. The harder problem starts when you switch tools, start fresh, or come back next week.
 
----
+**MAG is a local memory layer for coding agents.** It stores useful choices, bug fixes, work rules and handoffs in one SQLite file, then returns the right pieces through MCP. Claude Code can also use native hooks to save and recall context.
 
-## Quick Start
+One Rust binary. One SQLite memory store. No account.
+
+Save a decision in Claude Code. Recall it later in Cursor or Codex.
+
+## Quick start
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/George-RD/mag/main/install.sh | sh
 ```
 
-That's it. The installer auto-detects your AI tools and wires MAG in automatically — no manual JSON editing needed. Open your coding tool and your assistant already has persistent memory.
+The installer gets the right binary, finds known tools and runs `mag setup`.
 
-To store or search memories directly from the CLI:
-
-```bash
-mag ingest "The retry logic should use exponential backoff with jitter"
-mag search "how should retries work?"
-# → "The retry logic should use exponential backoff with jitter" (score: 0.94)
-```
-
----
-
-## Why Developers Choose MAG
-
-- **Switch from Claude to Cursor. Your context came with you.** One memory store works across every MCP-compatible tool on your machine.
-- **Finds what you stored, even when you search differently than how you saved it.** Hybrid retrieval fuses full-text, semantic, and graph search so you don't need exact wording.
-- **No accounts. No intermediaries. No "free tier."** A single Rust binary, a single SQLite file. Install it, use it, own it.
-- **Your client signed an NDA with you. Not with Mem0's infrastructure.** Zero third-party data routing by default. Your memory data never touches servers you don't control.
-- **Your memory, not your vendor's.** Claude, Cursor, and ChatGPT are all building their own memory - but it stays inside their tool. MAG bridges all of them. One memory store, every tool, portable forever.
-
----
-
-## Works With
-
-| Tool | macOS | Linux | Auto-configured |
-|---|---|---|---|
-| Claude Code | ✅ | ✅ | `mag setup` |
-| Claude Desktop | ✅ | ✅ | `mag setup` |
-| Cursor | ✅ | ✅ | `mag setup` |
-| VS Code + Copilot | ✅ | ✅ | `mag setup` |
-| Windsurf | ✅ | ✅ | `mag setup` |
-| Cline | ✅ | ✅ | `mag setup` |
-| Gemini CLI | ✅ | ✅ | `mag setup` |
-| Zed | ✅ | ✅ | Manual |
-| Codex (OpenAI) | ✅ | ✅ | `mag setup` |
-
-Any tool that supports MCP can connect to MAG. Windows is untested - [report your results](https://github.com/George-RD/mag/issues).
-
----
-
-## Benchmarks
-
-**90.1% retrieval accuracy on the LoCoMo memory benchmark.** Don't trust our number - [run it yourself](docs/benchmarks/methodology.md#running-the-benchmark):
+Save one real choice. Then search for it in new words:
 
 ```bash
-./scripts/bench.sh
+mag ingest "Use exponential backoff with jitter for retries" \
+  --tags decision,project:api-gateway
+
+mag advanced-search "How should failed requests retry?" --explain
 ```
 
-AutoMem's published score on the same benchmark is 90.5%. Full methodology, model comparisons, and historical runs in [docs/benchmarks/](docs/benchmarks/).
+```text
+Use exponential backoff with jitter for retries
+score: 0.94
+```
 
----
+## Why MAG exists
 
-## Your Data, Your Control
+Built-in tool memory is useful. Project docs are useful. Cloud memory services are useful. They solve different parts of the problem.
 
-Your memory data never touches third-party servers. Not ours, not anyone else's. Same guarantee whether you run MAG on your laptop or deploy it on your own infrastructure.
+MAG is for people who want context to move between coding tools while the data stays on their machine.
 
-- Zero third-party data routing (API embedding models are optional, off by default)
-- Single SQLite file, portable and inspectable
-- Export everything with one command. Open it with any SQLite browser.
-- MIT licensed, no tiers, no vendor lock-in
-- The binary keeps working whether we maintain this project or not
-
-See [SECURITY.md](SECURITY.md) for the full data-flow audit.
-
----
-
-## Deploy Your Way
-
-| Mode | Description |
+| What matters | What MAG does |
 |---|---|
-| **Local** (default) | Single binary on your machine. Zero config. |
-| **Daemon** | `mag serve --http` for persistent HTTP access. Same binary, same file. |
-| **Self-hosted** | Deploy on your own server or cloud. Same privacy guarantees at scale. |
-| **MAG Cloud** | Coming soon. We run the infrastructure. You own the data. Same guarantees. |
+| Switch between coding agents | The same memory store is available through MCP. |
+| Keep private work local | Embeddings and recall run on your machine by default. |
+| Find a decision without exact wording | Text, meaning and graph signals work together. |
+| Keep control of the data | Memories live in one SQLite file that you can inspect and export. |
+| Understand why something matched | `--explain` shows the signals behind each result. |
+| Start without a new account | Install the binary and run `mag setup`. |
 
-Every mode: zero third-party data access, full data portability, MIT licensed.
+MAG does not replace project docs. Stable facts and contracts still belong in Git. MAG is for context that changes, spans projects, or should follow you between tools.
 
----
+## How MAG works
 
-## Install
+<picture>
+  <img src="docs/readme-flow.svg" width="100%" alt="MAG captures a decision in one coding tool, stores it in a local SQLite database, recalls it by meaning and returns it to another tool." />
+</picture>
 
-| Method | Command |
-|---|---|
-| **Shell** (macOS / Linux) | `curl -fsSL https://raw.githubusercontent.com/George-RD/mag/main/install.sh \| sh` |
-| **Homebrew** | `brew install George-RD/mag/mag` |
-| **npm** | `npm install -g mag-memory` |
-| **uv** | `uv tool install mag-memory` |
-| **pip** | `pip install mag-memory` |
-| **Cargo** | `cargo install mag-memory` |
+### Capture
 
-**From source (latest main):** `cargo install --git https://github.com/George-RD/mag.git`
+Store choices, root causes, work rules and session handoffs. MAG can be called from the CLI or through its MCP tools. The Claude Code plugin adds lifecycle hooks for automatic capture and context injection.
 
-**Prebuilt binaries:** macOS (x64, ARM), Linux (x64, ARM), Windows (x64) on the [Releases page](https://github.com/George-RD/mag/releases).
+### Store
 
----
+Before writing a memory, MAG checks for copies. It can mark old facts as replaced, build version chains, tag key names and link related memories.
 
-## Configure Your AI Tools
+### Recall
 
-The installer runs `mag setup` automatically. To reconfigure at any time:
+Advanced search runs meaning and full-text search at the same time. It joins the results, adds linked context and drops weak matches.
 
-```bash
-mag setup
-```
+### Explain
 
-This detects installed AI tools, shows their configuration status, and writes the correct MCP config for each one. Use `--non-interactive` for CI or scripted environments.
+Use `mag advanced-search "query" --explain` to see meaning match, text rank, overlap, graph links and the final score.
 
-**Let your AI set it up:** Paste this into any AI assistant and it will handle install + configuration for you:
+See [How MAG works](docs/architecture.md) for the full storage and recall pipelines.
 
-> Install and configure MAG by following https://github.com/George-RD/mag/blob/main/docs/SETUP.md
+## Tool support
 
-<details>
-<summary>Manual configuration</summary>
+`mag setup` knows these clients. MCP is the common layer; some tools get extra native guidance.
 
-MAG runs as an MCP server. Add it to your client's config file:
+| Tool | Connection | Extra integration |
+|---|---|---|
+| Claude Code | MCP | Native plugin and lifecycle hooks |
+| Claude Desktop | MCP | None |
+| Cursor | MCP | Project rules |
+| VS Code + Copilot | MCP | None |
+| Windsurf | MCP | Project rules |
+| Cline | MCP | None |
+| Zed | MCP | None |
+| Codex | MCP | `AGENTS.md` guidance |
+| Gemini CLI | MCP | `AGENTS.md` guidance |
+| OpenCode | MCP | Skill definitions |
+
+Any other client that supports MCP can connect manually:
 
 ```json
 {
@@ -156,41 +123,114 @@ MAG runs as an MCP server. Add it to your client's config file:
 }
 ```
 
-**Claude Code:** `claude mcp add mag -- mag serve`
+## Measured performance
 
-**npx (no install):**
+MAG scored **90.1% word-overlap recall** on the full LoCoMo run: 1,986 questions across 10 long conversations.
 
-```json
-{
-  "mcpServers": {
-    "mag": {
-      "command": "npx",
-      "args": ["-y", "mag-memory", "serve"]
-    }
-  }
-}
+AutoMem reports 90.5% in its own similar run. The scores are close. This is not proof that one system wins every workload. It shows that a fully local recall stack can be strong.
+
+| LoCoMo category | MAG | AutoMem |
+|---|---:|---:|
+| Single-hop QA | 86.9% | 79.8% |
+| Temporal reasoning | 85.0% | 85.1% |
+| Multi-hop QA | 56.2% | 50.0% |
+| Open-domain | 95.7% | 95.8% |
+| Adversarial | 92.6% | 100.0% |
+| **Overall** | **90.1%** | **90.5%** |
+
+The same run averaged about 7 ms per query. These are recall results, not a score for every agent task, model or real workload.
+
+Read the [benchmark method and environment](docs/benchmarks/methodology.md), then run it yourself:
+
+```bash
+./scripts/bench.sh
 ```
 
-Per-tool setup guides: [Claude Desktop](docs/setup/claude-desktop.md) | [Cursor](docs/setup/cursor.md) | [Claude Code](docs/setup/claude-code.md) | [Windsurf](docs/setup/windsurf.md) | [Cline](docs/setup/cline.md)
+## Trade-offs
 
-</details>
+Local-first removes one class of trade-off and adds another.
 
----
+| You gain | You accept |
+|---|---|
+| One memory store across tools | Team-wide cloud sync is not built in today. |
+| No outside calls when you search | The local search model must be downloaded and loaded. |
+| Data in a portable SQLite file | The database is plaintext. Use full-disk encryption. |
+| No account or hosted dependency | You own backups, upgrades and local storage. |
+| Search that works beyond exact words | Memory quality still depends on what you choose to store. |
+| An open 0.1.x codebase | APIs and setup may still change. |
 
-## Learn More
+The local search model uses about 32 MB on disk and roughly 180 MB peak memory when loaded. Windows binaries are published, but Windows has had less testing than macOS and Linux.
 
-- [MCP Tools](docs/mcp-tools.md) - all 19 tools MAG exposes over MCP
-- [Architecture](docs/architecture.md) - search pipeline, scoring, modules
-- [Benchmarks](docs/benchmarks/) - full results, model comparisons, methodology
-- [Security](SECURITY.md) - data-flow audit, threat model
-- [What to Store](docs/what-to-store.md) - get the most out of persistent memory
-- [Setup Guide](docs/SETUP.md) - install, configure, and best practices
-- [Per-Tool Guides](docs/setup/) - detailed per-tool configuration
-- [Changelog](CHANGELOG.md) - recent changes
-- [AGENTS.md](AGENTS.md) - conventions, development commands
+### Good fit
 
----
+MAG makes sense when you use several coding agents, work with private or client data, want local ownership, or need decisions to survive beyond one session.
 
-## License
+### Wrong fit
 
-MIT
+Choose a different approach when you need managed team sync now, encrypted app storage, a browser-only service with no local setup, or automatic memory with no curation.
+
+## Roadmap
+
+The roadmap is a direction, not a release promise. There are no invented dates.
+
+| Stage | Direction | Current issues |
+|---|---|---|
+| **Now** | Make capture and recall reliable across real sessions. Fix session IDs, recall after compaction, subagent capture and missing-model warnings. | [#247](https://github.com/George-RD/mag/issues/247), [#257](https://github.com/George-RD/mag/issues/257), [#258](https://github.com/George-RD/mag/issues/258), [#243](https://github.com/George-RD/mag/issues/243) |
+| **Next** | Define connectors once, adapt them per tool, sync native memories and test automatic recall. | [#234](https://github.com/George-RD/mag/issues/234), [#236](https://github.com/George-RD/mag/issues/236), [#266](https://github.com/George-RD/mag/issues/266), [#341](https://github.com/George-RD/mag/issues/341) |
+| **Explore** | Add local code search, codebase knowledge and portable skills without turning MAG into a cloud service. | [#210](https://github.com/George-RD/mag/issues/210), [#212](https://github.com/George-RD/mag/issues/212), [#213](https://github.com/George-RD/mag/issues/213) |
+
+Track the working backlog in [GitHub Issues](https://github.com/George-RD/mag/issues).
+
+## Install options
+
+| Method | Command |
+|---|---|
+| Shell, macOS or Linux | `curl -fsSL https://raw.githubusercontent.com/George-RD/mag/main/install.sh \| sh` |
+| Homebrew | `brew install George-RD/mag/mag` |
+| npm | `npm install -g mag-memory` |
+| uv | `uv tool install mag-memory` |
+| pip | `pip install mag-memory` |
+| Cargo | `cargo install mag-memory` |
+| Source | `cargo install --git https://github.com/George-RD/mag.git` |
+
+Prebuilt macOS, Linux and Windows binaries are on the [Releases page](https://github.com/George-RD/mag/releases).
+
+Package-manager installs do not run setup automatically:
+
+```bash
+mag setup
+```
+
+## Data and security
+
+By default, MAG stores data under `~/.mag/`:
+
+```text
+~/.mag/memory.db   # memories, embeddings and metadata
+~/.mag/models/     # local ONNX models
+```
+
+No memory data leaves the machine in the default setup. The first model download needs network access. API models only run when you set them up.
+
+The SQLite database is not encrypted. Do not store passwords, API keys or tokens. Use FileVault, LUKS or BitLocker when the threat model requires encryption at rest.
+
+See [SECURITY.md](SECURITY.md) for the data-flow and disclosure policy.
+
+## Documentation
+
+- [Setup guide](docs/SETUP.md)
+- [How MAG works](docs/architecture.md)
+- [MCP tools](docs/mcp-tools.md)
+- [What to store](docs/what-to-store.md)
+- [Benchmarks](docs/benchmarks/)
+- [Security](SECURITY.md)
+- [Changelog](CHANGELOG.md)
+- [Development conventions](AGENTS.md)
+
+## Contributing
+
+Bug reports, benchmark challenges and pull requests are welcome. Start with [open issues](https://github.com/George-RD/mag/issues) or read [AGENTS.md](AGENTS.md) before changing the codebase.
+
+## Licence
+
+MIT. See [LICENSE](LICENSE).

--- a/docs/readme-flow.svg
+++ b/docs/readme-flow.svg
@@ -1,0 +1,50 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="340" viewBox="0 0 1200 340" role="img" aria-labelledby="title desc">
+  <title id="title">How MAG carries context between coding sessions</title>
+  <desc id="desc">A decision is captured, stored locally with structure, recalled by meaning and explained to another coding tool.</desc>
+  <rect width="1200" height="340" fill="#f5f7f2"/>
+  <rect x="28" y="28" width="1144" height="284" fill="none" stroke="#0d1b2a" stroke-width="2"/>
+  <g font-family="Arial, sans-serif" fill="#0d1b2a">
+    <g transform="translate(64 73)">
+      <text x="0" y="0" fill="#2457ff" font-family="Courier New, monospace" font-size="16" font-weight="700">A · CAPTURE</text>
+      <rect x="0" y="25" width="226" height="150" fill="#ffffff" stroke="#0d1b2a" stroke-width="2"/>
+      <text x="18" y="59" fill="#526576" font-family="Courier New, monospace" font-size="13">CLAUDE CODE</text>
+      <text x="18" y="95" font-size="21" font-weight="700">Keep the retry</text>
+      <text x="18" y="123" font-size="21" font-weight="700">policy we chose.</text>
+      <rect x="18" y="143" width="150" height="22" fill="#2457ff"/>
+      <text x="27" y="159" fill="#ffffff" font-family="Courier New, monospace" font-size="11">decision · api</text>
+    </g>
+    <line x1="305" y1="173" x2="367" y2="173" stroke="#ff5a36" stroke-width="3"/>
+    <path d="M358 165 L368 173 L358 181" fill="none" stroke="#ff5a36" stroke-width="3"/>
+    <g transform="translate(382 73)">
+      <text x="0" y="0" fill="#2457ff" font-family="Courier New, monospace" font-size="16" font-weight="700">B · STORE</text>
+      <rect x="0" y="25" width="230" height="150" fill="#1238b6" stroke="#ccff3d" stroke-width="3"/>
+      <text x="20" y="61" fill="#ffffff" font-family="Arial Black, Arial, sans-serif" font-size="28">MAG</text>
+      <text x="20" y="89" fill="#dce5ff" font-family="Courier New, monospace" font-size="12">~/.mag/memory.db</text>
+      <text x="20" y="119" fill="#ffffff" font-family="Courier New, monospace" font-size="12">01  dedupe</text>
+      <text x="20" y="141" fill="#ffffff" font-family="Courier New, monospace" font-size="12">02  link versions</text>
+      <text x="20" y="163" fill="#ffffff" font-family="Courier New, monospace" font-size="12">03  build relations</text>
+    </g>
+    <line x1="627" y1="173" x2="689" y2="173" stroke="#ff5a36" stroke-width="3"/>
+    <path d="M680 165 L690 173 L680 181" fill="none" stroke="#ff5a36" stroke-width="3"/>
+    <g transform="translate(704 73)">
+      <text x="0" y="0" fill="#2457ff" font-family="Courier New, monospace" font-size="16" font-weight="700">C · RECALL</text>
+      <rect x="0" y="25" width="200" height="150" fill="#ffffff" stroke="#0d1b2a" stroke-width="2"/>
+      <text x="18" y="59" fill="#526576" font-family="Courier New, monospace" font-size="13">QUERY</text>
+      <text x="18" y="92" font-size="19" font-weight="700">How should failed</text>
+      <text x="18" y="118" font-size="19" font-weight="700">requests retry?</text>
+      <text x="18" y="153" fill="#2457ff" font-family="Courier New, monospace" font-size="12">meaning + text + graph</text>
+    </g>
+    <line x1="919" y1="173" x2="981" y2="173" stroke="#ff5a36" stroke-width="3"/>
+    <path d="M972 165 L982 173 L972 181" fill="none" stroke="#ff5a36" stroke-width="3"/>
+    <g transform="translate(996 73)">
+      <text x="0" y="0" fill="#2457ff" font-family="Courier New, monospace" font-size="16" font-weight="700">D · RESUME</text>
+      <rect x="0" y="25" width="140" height="150" fill="#0d1b2a" stroke="#0d1b2a" stroke-width="2"/>
+      <text x="16" y="59" fill="#ccff3d" font-family="Courier New, monospace" font-size="12">CURSOR</text>
+      <text x="16" y="91" fill="#ffffff" font-size="17" font-weight="700">Decision</text>
+      <text x="16" y="115" fill="#ffffff" font-size="17" font-weight="700">found.</text>
+      <rect x="16" y="137" width="106" height="22" fill="#ccff3d"/>
+      <text x="24" y="153" fill="#0d1b2a" font-family="Courier New, monospace" font-size="10">score 0.94</text>
+    </g>
+  </g>
+  <text x="600" y="286" text-anchor="middle" fill="#526576" font-family="Arial, sans-serif" font-size="18">Different words. Same decision. No old thread to hunt down.</text>
+</svg>

--- a/docs/readme-hero.svg
+++ b/docs/readme-hero.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="430" viewBox="0 0 1200 430" role="img" aria-labelledby="title desc">
+  <title id="title">MAG, one local memory for coding agents</title>
+  <desc id="desc">A signal path carries context from Claude Code through a local MAG SQLite store to Cursor and Codex.</desc>
+  <rect width="1200" height="430" fill="#0d1b2a"/>
+  <rect x="0" y="0" width="18" height="430" fill="#2457ff"/>
+  <rect x="18" y="0" width="10" height="430" fill="#ff5a36"/>
+  <g transform="translate(72 64)">
+    <rect x="0" y="16" width="10" height="22" fill="#2457ff"/>
+    <rect x="15" y="0" width="10" height="38" fill="#ff5a36"/>
+    <rect x="30" y="10" width="10" height="28" fill="#2457ff"/>
+    <text x="58" y="35" fill="#ffffff" font-family="Arial Black, Arial, sans-serif" font-size="37" font-weight="900">MAG</text>
+    <text x="170" y="31" fill="#ccff3d" font-family="Courier New, monospace" font-size="16" letter-spacing="2">LOCAL CONTEXT RELAY</text>
+  </g>
+  <text x="72" y="180" fill="#ffffff" font-family="Arial Black, Arial, sans-serif" font-size="61" font-weight="900" letter-spacing="-2">YOUR TOOLS CHANGE.</text>
+  <text x="72" y="245" fill="#90aaff" font-family="Arial Black, Arial, sans-serif" font-size="61" font-weight="900" letter-spacing="-2">YOUR CONTEXT SHOULDN'T.</text>
+  <text x="74" y="293" fill="#c6d1d9" font-family="Arial, sans-serif" font-size="24">One local memory for Claude Code, Cursor, Codex and other MCP clients.</text>
+  <g transform="translate(72 342)">
+    <circle cx="8" cy="8" r="8" fill="#ccff3d"/>
+    <line x1="16" y1="8" x2="330" y2="8" stroke="#ff5a36" stroke-width="3"/>
+    <rect x="330" y="-18" width="355" height="52" fill="#2457ff" stroke="#ccff3d" stroke-width="2"/>
+    <text x="507" y="15" text-anchor="middle" fill="#ffffff" font-family="Arial Black, Arial, sans-serif" font-size="23">~/.mag/memory.db</text>
+    <line x1="685" y1="8" x2="999" y2="8" stroke="#ff5a36" stroke-width="3"/>
+    <circle cx="1007" cy="8" r="8" fill="#ccff3d"/>
+    <text x="0" y="50" fill="#aebdca" font-family="Courier New, monospace" font-size="14">CLAUDE CODE</text>
+    <text x="842" y="50" fill="#aebdca" font-family="Courier New, monospace" font-size="14">CURSOR · CODEX · MCP</text>
+  </g>
+</svg>

--- a/site/app.js
+++ b/site/app.js
@@ -1,0 +1,28 @@
+function initMagPage() {
+  const copyButtons = document.querySelectorAll('[data-copy]');
+
+  for (const button of copyButtons) {
+    button.addEventListener('click', async () => {
+      const label = button.querySelector('.copy-label');
+      const original = label?.textContent ?? 'Copy';
+
+      try {
+        await navigator.clipboard.writeText(button.dataset.copy ?? '');
+        button.classList.add('is-copied');
+        if (label) label.textContent = 'Copied';
+        window.setTimeout(() => {
+          button.classList.remove('is-copied');
+          if (label) label.textContent = original;
+        }, 1800);
+      } catch {
+        if (label) label.textContent = 'Select command';
+      }
+    });
+  }
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', initMagPage, { once: true });
+} else {
+  initMagPage();
+}

--- a/site/favicon.svg
+++ b/site/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="MAG">
+  <rect width="64" height="64" fill="#0d1b2a"/>
+  <rect x="10" y="32" width="11" height="20" fill="#2457ff"/>
+  <rect x="27" y="12" width="11" height="40" fill="#ff5a36"/>
+  <rect x="44" y="23" width="11" height="29" fill="#2457ff"/>
+</svg>

--- a/site/parts/00-head.html
+++ b/site/parts/00-head.html
@@ -1,0 +1,49 @@
+<!--
+THESIS: MAG is the context relay between coding tools, not another chat-history product. The page refuses the generic AI-memory dashboard and shows continuity as a working signal path.
+OWN-WORLD: A local control-room field manual. Cool paper, deep ink, cobalt routes, orange interventions, chartreuse live states, hard rules, and schematic linework.
+STORY: The visitor sees the context-loss problem, understands the local mechanism, checks the evidence and limits, then installs MAG or leaves for the right reason.
+FIRST VIEWPORT: A blunt continuity headline and install command sit beside a live relay from one coding session through a local MAG store into another tool. The primary action is inside the install strip.
+FORM: Product-specific signal relay, ranked first for audience recognition. Seed key: mag-context-relay-2026-07.
+FINISH: unreviewed and undocumented is unfinished; this build ends with the finish review, the verdict, and DESIGN.md
+-->
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="theme-color" content="#f5f7f2">
+  <meta name="description" content="MAG gives coding agents one local memory across tools. Keep decisions, fixes and work rules in a portable SQLite file, then recall the right context through MCP.">
+  <meta property="og:title" content="MAG | One local memory for your coding agents">
+  <meta property="og:description" content="Your tools change. Your context should not. MAG keeps useful context local, portable and available across coding agents.">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://george-rd.github.io/mag/">
+  <meta property="og:image" content="https://george-rd.github.io/mag/social-card.svg">
+  <meta name="twitter:card" content="summary_large_image">
+  <title>MAG | One local memory for your coding agents</title>
+  <link rel="icon" href="favicon.svg" type="image/svg+xml">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Archivo+Black&family=Atkinson+Hyperlegible:ital,wght@0,400;0,700;1,400&family=JetBrains+Mono:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+  <script src="app.js" defer></script>
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+
+  <header class="site-header">
+    <div class="shell header-inner">
+      <a class="brand" href="#top" aria-label="MAG home">
+        <span class="brand-mark" aria-hidden="true"><i></i><i></i><i></i></span>
+        <span>MAG</span>
+      </a>
+      <nav class="desktop-nav" aria-label="Primary navigation">
+        <a href="#mechanism">How it works</a>
+        <a href="#evidence">Evidence</a>
+        <a href="#tradeoffs">Trade-offs</a>
+        <a href="#roadmap">Roadmap</a>
+      </nav>
+      <a class="header-action" href="https://github.com/George-RD/mag">View GitHub <span aria-hidden="true">↗</span></a>
+    </div>
+  </header>
+
+  <main id="main">

--- a/site/parts/10-hero.html
+++ b/site/parts/10-hero.html
@@ -1,0 +1,72 @@
+    <section class="hero" id="top">
+      <div class="shell hero-grid">
+        <div class="hero-copy">
+          <h1>Your tools change.<br><span>Your context shouldn&rsquo;t.</span></h1>
+          <p class="hero-lead">MAG gives coding agents one local memory. It keeps the choices, fixes and ways of working worth carrying forward, then recalls them in the tool you open next.</p>
+          <p class="hero-facts">One Rust binary. One SQLite memory store. No account.</p>
+
+          <div class="install-strip" role="group" aria-label="Install MAG">
+            <code>curl -fsSL https://raw.githubusercontent.com/George-RD/mag/main/install.sh | sh</code>
+            <button class="copy-button" type="button" data-copy="curl -fsSL https://raw.githubusercontent.com/George-RD/mag/main/install.sh | sh">
+              <span class="copy-label">Copy</span>
+            </button>
+          </div>
+          <div class="hero-actions">
+            <a class="button button-primary" href="#install">Install MAG</a>
+            <a class="button button-secondary" href="#mechanism">See the relay</a>
+          </div>
+          <p class="hero-note">The shell installer finds known tools and runs <code>mag setup</code>.</p>
+        </div>
+
+        <div class="relay-stage" aria-label="A decision moving from Claude Code through MAG into Cursor and Codex">
+          <div class="relay-head">
+            <span>LOCAL CONTEXT RELAY</span>
+            <span class="live-state"><i aria-hidden="true"></i> LIVE</span>
+          </div>
+
+          <div class="session-card session-card-a">
+            <div class="session-meta"><span>MON 09:42</span><span>CLAUDE CODE</span></div>
+            <p>Use exponential backoff with jitter for retries.</p>
+            <span class="session-tag">decision · api-gateway</span>
+          </div>
+
+          <div class="relay-line relay-line-a" aria-hidden="true">
+            <span class="relay-dot"></span>
+          </div>
+
+          <div class="mag-core">
+            <div class="core-title"><span>MAG</span><small>~/.mag/memory.db</small></div>
+            <ul>
+              <li><span>01</span> dedupe</li>
+              <li><span>02</span> link versions</li>
+              <li><span>03</span> recall by meaning</li>
+            </ul>
+          </div>
+
+          <div class="relay-line relay-line-b" aria-hidden="true">
+            <span class="relay-dot relay-dot-late"></span>
+          </div>
+
+          <div class="session-card session-card-b">
+            <div class="session-meta"><span>FRI 14:18</span><span>CURSOR</span></div>
+            <p>Retry policy found. Applying the existing decision.</p>
+            <span class="session-tag recalled">recalled · score 0.94</span>
+          </div>
+
+          <div class="tool-junction" aria-hidden="true">
+            <span>CLAUDE</span><i></i><span>CURSOR</span><i></i><span>CODEX</span><i></i><span>MCP</span>
+          </div>
+          <p class="relay-caption">A decision made here is still available there.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="evidence-rail" aria-label="Measured product evidence">
+      <div class="shell rail-grid">
+        <div><strong>90.1%</strong><span>LoCoMo recall score</span></div>
+        <div><strong>1,986</strong><span>questions in the full run</span></div>
+        <div><strong>~7 ms</strong><span>mean query time in that run</span></div>
+        <div><strong>0</strong><span>outside calls in the default search path</span></div>
+      </div>
+    </section>
+

--- a/site/parts/20-problem-mechanism.html
+++ b/site/parts/20-problem-mechanism.html
@@ -1,0 +1,81 @@
+    <section class="problem-section">
+      <div class="shell problem-grid">
+        <div class="section-heading">
+          <h2>Most agent context stops at the tool boundary.</h2>
+        </div>
+        <div class="problem-copy">
+          <p>Project files help. Chat history helps. Built-in memory helps. But each source lives in its own place. Switch tools and you often rebuild the same context.</p>
+          <p>MAG carries the small facts that rarely belong in code: why a choice was made, what fixed a hard bug, how you like work to be done, and where the last session stopped.</p>
+        </div>
+      </div>
+
+      <div class="shell context-leak" aria-label="Example of context lost across three coding tools">
+        <div class="leak-session">
+          <span class="leak-time">MON</span>
+          <strong>Claude Code</strong>
+          <p>Decision made</p>
+        </div>
+        <div class="leak-loss"><i aria-hidden="true"></i><span>context lost</span></div>
+        <div class="leak-session faded">
+          <span class="leak-time">WED</span>
+          <strong>Cursor</strong>
+          <p>Decision explained again</p>
+        </div>
+        <div class="leak-loss"><i aria-hidden="true"></i><span>context lost</span></div>
+        <div class="leak-session faded-more">
+          <span class="leak-time">FRI</span>
+          <strong>Codex</strong>
+          <p>Old option proposed again</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="mechanism-section" id="mechanism">
+      <div class="shell">
+        <div class="section-heading wide-heading">
+          <h2>One local layer between your tools.</h2>
+          <p>Claude Code can use MAG&rsquo;s hooks. Other clients connect through MCP. The memory stays in the same local store.</p>
+        </div>
+
+        <div class="pipeline" aria-label="MAG capture and recall pipeline">
+          <article class="pipeline-step">
+            <span class="step-number">A</span>
+            <h3>Capture what matters</h3>
+            <p>Choices, root causes, work rules and session handoffs.</p>
+          </article>
+          <div class="pipeline-connector" aria-hidden="true"><i></i></div>
+          <article class="pipeline-step core-step">
+            <span class="step-number">B</span>
+            <h3>Store with links</h3>
+            <p>MAG drops copies, tracks newer facts and links related memories.</p>
+          </article>
+          <div class="pipeline-connector" aria-hidden="true"><i></i></div>
+          <article class="pipeline-step">
+            <span class="step-number">C</span>
+            <h3>Recall by meaning</h3>
+            <p>Text, meaning and graph signals work together. Weak matches can be dropped.</p>
+          </article>
+          <div class="pipeline-connector" aria-hidden="true"><i></i></div>
+          <article class="pipeline-step">
+            <span class="step-number">D</span>
+            <h3>See why it matched</h3>
+            <p>Explain mode shows why a memory matched and what shaped its score.</p>
+          </article>
+        </div>
+
+        <div class="differentiator-grid">
+          <div class="diff-copy">
+            <h3>Not another chat archive.</h3>
+            <p>A chat archive waits for you to find the old thread. MAG finds a small set of useful memories for the task in front of the agent.</p>
+          </div>
+          <div class="query-demo" aria-label="Example of MAG finding a decision from a differently worded query">
+            <div class="query-line"><span>QUERY</span><code>How should failed requests retry?</code></div>
+            <div class="match-line"><span>MATCH</span><strong>Use exponential backoff with jitter.</strong></div>
+            <div class="signal-line">
+              <span>meaning 0.91</span><span>keyword 0.68</span><span>decision 0.84</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+

--- a/site/parts/30-comparison-benchmark.html
+++ b/site/parts/30-comparison-benchmark.html
@@ -1,0 +1,59 @@
+    <section class="comparison-section">
+      <div class="shell">
+        <div class="section-heading wide-heading">
+          <h2>Use the memory model that fits the work.</h2>
+          <p>MAG is strongest when context must follow you, stay local and work across tools.</p>
+        </div>
+
+        <div class="comparison-wrap" role="region" aria-label="Comparison of built-in agent memory, MAG and a typical cloud memory service" tabindex="0">
+          <table>
+            <thead>
+              <tr><th scope="col">Need</th><th scope="col">Built-in tool memory</th><th scope="col" class="mag-column">MAG</th><th scope="col">Typical cloud layer</th></tr>
+            </thead>
+            <tbody>
+              <tr><th scope="row">Works across tools</th><td>Usually no</td><td class="mag-column"><strong>Yes, through one store</strong></td><td>Often</td></tr>
+              <tr><th scope="row">Runs locally by default</th><td>Vendor controlled</td><td class="mag-column"><strong>Yes</strong></td><td>Usually no</td></tr>
+              <tr><th scope="row">Data you can inspect</th><td>Limited</td><td class="mag-column"><strong>One SQLite file</strong></td><td>Service dependent</td></tr>
+              <tr><th scope="row">Account required</th><td>Vendor account</td><td class="mag-column"><strong>No</strong></td><td>Yes</td></tr>
+              <tr><th scope="row">Team sync today</th><td>Vendor dependent</td><td class="mag-column"><strong>Not built in</strong></td><td>Often</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <section class="benchmark-section" id="evidence">
+      <div class="shell benchmark-grid">
+        <div class="benchmark-copy">
+          <h2>Measured, not magic.</h2>
+          <p>MAG scored <strong>90.1% word-overlap recall</strong> on the full LoCoMo run: 1,986 questions across 10 long conversations.</p>
+          <p>AutoMem reports 90.5% in its own similar run. The scores are close. That does not prove one tool always wins. It shows that local recall can be strong.</p>
+          <div class="benchmark-actions">
+            <a class="button button-dark" href="https://github.com/George-RD/mag/blob/main/docs/benchmarks/methodology.md">Read the method</a>
+            <a class="text-link" href="https://github.com/George-RD/mag/tree/main/docs/benchmarks">See all benchmark notes <span aria-hidden="true">↗</span></a>
+          </div>
+          <p class="fine-print">This test measures recall. It does not cover every agent task, model or real workload.</p>
+        </div>
+
+        <div class="benchmark-board" aria-label="LoCoMo recall comparison between MAG and AutoMem">
+          <div class="board-head"><span>LoCoMo word-overlap recall</span><span>Higher is better</span></div>
+          <div class="bar-group">
+            <div class="bar-label"><span>MAG</span><strong>90.1%</strong></div>
+            <div class="bar-track"><i class="bar mag-bar" style="--bar:90.1%"></i></div>
+          </div>
+          <div class="bar-group">
+            <div class="bar-label"><span>AutoMem</span><strong>90.5%</strong></div>
+            <div class="bar-track"><i class="bar reference-bar" style="--bar:90.5%"></i></div>
+          </div>
+          <div class="category-lines">
+            <div><span>Single-hop</span><strong>86.9</strong></div>
+            <div><span>Temporal</span><strong>85.0</strong></div>
+            <div><span>Multi-hop</span><strong>56.2</strong></div>
+            <div><span>Open-domain</span><strong>95.7</strong></div>
+            <div><span>Adversarial</span><strong>92.6</strong></div>
+          </div>
+          <p>MAG score by question type</p>
+        </div>
+      </div>
+    </section>
+

--- a/site/parts/40-tradeoffs-roadmap.html
+++ b/site/parts/40-tradeoffs-roadmap.html
@@ -1,0 +1,78 @@
+    <section class="tradeoff-section" id="tradeoffs">
+      <div class="shell">
+        <div class="section-heading wide-heading inverse-heading">
+          <h2>What you gain. What you accept.</h2>
+          <p>Local-first removes one trade-off and adds another. The useful choice is the honest one.</p>
+        </div>
+
+        <div class="tradeoff-grid">
+          <div class="gain-side">
+            <h3>MAG is a good fit when&hellip;</h3>
+            <ul class="fit-list positive-list">
+              <li>You switch between coding agents and want context to follow.</li>
+              <li>You work with client or private data that should stay on the machine.</li>
+              <li>You want a memory store you can inspect, export and keep.</li>
+              <li>You prefer an open local tool over another hosted account.</li>
+            </ul>
+          </div>
+          <div class="accept-side">
+            <h3>Choose something else when&hellip;</h3>
+            <ul class="fit-list caution-list">
+              <li>You need team-wide cloud sync now.</li>
+              <li>You need the app itself to encrypt its data.</li>
+              <li>You want a browser service with no local model download or setup.</li>
+              <li>You expect memory to decide what matters with no guidance or cleanup.</li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="constraint-strip">
+          <p><strong>Current limits:</strong> MAG is a 0.1.x project. APIs and setup may still move. The local search model takes about 32 MB on disk and roughly 180 MB peak memory when loaded. Windows builds exist, but Windows has had less testing than macOS and Linux. The SQLite database is plaintext.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="roadmap-section" id="roadmap">
+      <div class="shell">
+        <div class="roadmap-heading">
+          <h2>Built in public. No invented dates.</h2>
+          <p>These are working directions, not promises. Each item links to its issue.</p>
+        </div>
+
+        <div class="roadmap-track">
+          <article class="roadmap-phase active-phase">
+            <div class="phase-status"><i aria-hidden="true"></i><span>NOW</span></div>
+            <h3>Make capture and recall reliable</h3>
+            <p>Fix hooks, session IDs, recall after compaction, subagent capture and missing-model warnings.</p>
+            <div class="issue-links">
+              <a href="https://github.com/George-RD/mag/issues/247">#247</a>
+              <a href="https://github.com/George-RD/mag/issues/257">#257</a>
+              <a href="https://github.com/George-RD/mag/issues/258">#258</a>
+              <a href="https://github.com/George-RD/mag/issues/243">#243</a>
+            </div>
+          </article>
+          <article class="roadmap-phase">
+            <div class="phase-status"><span>NEXT</span></div>
+            <h3>Make new tool support easier</h3>
+            <p>Define each connector once, adapt it per tool, sync native memories and test automatic recall.</p>
+            <div class="issue-links">
+              <a href="https://github.com/George-RD/mag/issues/234">#234</a>
+              <a href="https://github.com/George-RD/mag/issues/236">#236</a>
+              <a href="https://github.com/George-RD/mag/issues/266">#266</a>
+              <a href="https://github.com/George-RD/mag/issues/341">#341</a>
+            </div>
+          </article>
+          <article class="roadmap-phase">
+            <div class="phase-status"><span>EXPLORE</span></div>
+            <h3>Carry more than chat memory</h3>
+            <p>Add local code search, codebase knowledge and portable skills without turning MAG into a cloud service.</p>
+            <div class="issue-links">
+              <a href="https://github.com/George-RD/mag/issues/210">#210</a>
+              <a href="https://github.com/George-RD/mag/issues/212">#212</a>
+              <a href="https://github.com/George-RD/mag/issues/213">#213</a>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+

--- a/site/parts/50-install-footer.html
+++ b/site/parts/50-install-footer.html
@@ -1,0 +1,68 @@
+    <section class="install-section" id="install">
+      <div class="shell install-grid">
+        <div class="install-copy">
+          <h2>Give the next session a head start.</h2>
+          <p>Install MAG, let it set up known tools, then store one real choice and search for it in different words.</p>
+        </div>
+        <div class="install-terminal">
+          <div class="terminal-head"><span>TERMINAL</span><span>macOS · Linux</span></div>
+          <pre><code><span class="prompt">$</span> curl -fsSL https://raw.githubusercontent.com/George-RD/mag/main/install.sh | sh
+<span class="prompt">$</span> mag ingest "Use exponential backoff with jitter" \
+    --tags decision,project:api-gateway
+<span class="prompt">$</span> mag advanced-search "How should failed requests retry?" --explain</code></pre>
+          <button class="copy-button terminal-copy" type="button" data-copy="curl -fsSL https://raw.githubusercontent.com/George-RD/mag/main/install.sh | sh">
+            <span class="copy-label">Copy install command</span>
+          </button>
+        </div>
+      </div>
+      <div class="shell package-row" aria-label="Other install methods">
+        <span>Also available:</span>
+        <code>brew install George-RD/mag/mag</code>
+        <code>npm install -g mag-memory</code>
+        <code>cargo install mag-memory</code>
+        <code>uv tool install mag-memory</code>
+      </div>
+    </section>
+
+    <section class="faq-section">
+      <div class="shell faq-grid">
+        <h2>Questions worth asking first.</h2>
+        <div class="faq-list">
+          <details>
+            <summary>Why not keep everything in project docs?</summary>
+            <p>Keep source-of-truth facts in project docs. MAG is better for context that changes often, spans projects or should follow you between tools. The two approaches work together.</p>
+          </details>
+          <details>
+            <summary>Does any memory data leave my machine?</summary>
+            <p>Not in the default setup. Search runs locally and needs no cloud API. First use downloads the model. API models only run when you set them up.</p>
+          </details>
+          <details>
+            <summary>Is the database encrypted?</summary>
+            <p>No. MAG stores memories in a plaintext SQLite file. Use full-disk encryption and do not store secrets.</p>
+          </details>
+          <details>
+            <summary>Will it remember the right things by itself?</summary>
+            <p>MAG can save and recall context, but memory quality still depends on what is stored. Clear rules for decisions, bug fixes and handoffs produce better results than saving everything.</p>
+          </details>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <div class="shell footer-grid">
+      <div>
+        <a class="brand footer-brand" href="#top"><span class="brand-mark" aria-hidden="true"><i></i><i></i><i></i></span><span>MAG</span></a>
+        <p>Local memory for coding agents.</p>
+      </div>
+      <div class="footer-links">
+        <a href="https://github.com/George-RD/mag">GitHub</a>
+        <a href="https://github.com/George-RD/mag/tree/main/docs">Docs</a>
+        <a href="https://github.com/George-RD/mag/blob/main/SECURITY.md">Security</a>
+        <a href="https://github.com/George-RD/mag/issues">Issues</a>
+      </div>
+      <p class="footer-meta">MIT licensed. Built in the open.</p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/site/social-card.svg
+++ b/site/social-card.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-labelledby="title desc">
+  <title id="title">MAG, one local memory for your coding agents</title>
+  <desc id="desc">A context relay links Claude Code through a local MAG memory store to Cursor and Codex.</desc>
+  <rect width="1200" height="630" fill="#f5f7f2"/>
+  <rect x="56" y="50" width="1088" height="530" fill="#0d1b2a"/>
+  <rect x="56" y="50" width="24" height="530" fill="#2457ff"/>
+  <rect x="80" y="50" width="13" height="530" fill="#ff5a36"/>
+  <text x="142" y="148" fill="#ccff3d" font-family="Arial, sans-serif" font-weight="700" font-size="28" letter-spacing="3">MAG · LOCAL CONTEXT RELAY</text>
+  <text x="142" y="250" fill="#ffffff" font-family="Arial Black, Arial, sans-serif" font-weight="900" font-size="72">YOUR TOOLS CHANGE.</text>
+  <text x="142" y="330" fill="#8fa9ff" font-family="Arial Black, Arial, sans-serif" font-weight="900" font-size="72">YOUR CONTEXT SHOULDN'T.</text>
+  <line x1="160" y1="428" x2="1018" y2="428" stroke="#ff5a36" stroke-width="4"/>
+  <circle cx="160" cy="428" r="11" fill="#ccff3d"/>
+  <circle cx="590" cy="428" r="11" fill="#ccff3d"/>
+  <circle cx="1018" cy="428" r="11" fill="#ccff3d"/>
+  <rect x="378" y="391" width="424" height="74" fill="#2457ff" stroke="#ccff3d" stroke-width="3"/>
+  <text x="590" y="439" text-anchor="middle" fill="#ffffff" font-family="Arial Black, Arial, sans-serif" font-size="32">ONE LOCAL MEMORY</text>
+  <text x="142" y="526" fill="#cad4dc" font-family="Arial, sans-serif" font-size="25">One Rust binary · One local SQLite store · No account</text>
+</svg>

--- a/site/styles/00-tokens-base.css
+++ b/site/styles/00-tokens-base.css
@@ -1,0 +1,60 @@
+:root {
+  --paper:#f5f7f2;
+  --paper-deep:#e8ece5;
+  --ink:#0d1b2a;
+  --ink-soft:#25384a;
+  --muted:#526576;
+  --line:#aeb8bd;
+  --line-dark:#5e6c77;
+  --blue:#2457ff;
+  --blue-deep:#1238b6;
+  --blue-pale:#dce5ff;
+  --signal:#ff5a36;
+  --signal-text:#a82c12;
+  --signal-pale:#ffdcd3;
+  --lime:#ccff3d;
+  --white:#fff;
+  --font-display:"Archivo Black","Arial Black",sans-serif;
+  --font-body:"Atkinson Hyperlegible",Arial,sans-serif;
+  --font-code:"JetBrains Mono",ui-monospace,SFMono-Regular,Consolas,monospace;
+  --shell:min(1180px,calc(100vw - 40px));
+}
+*{box-sizing:border-box}
+html{scroll-behavior:smooth}
+body{margin:0;min-width:320px;color:var(--ink);background:var(--paper);font-family:var(--font-body);font-size:18px;line-height:1.55;text-rendering:optimizeLegibility}
+a{color:inherit}
+button,input,textarea,select{font:inherit}
+button,a{-webkit-tap-highlight-color:transparent}
+code,pre{font-family:var(--font-code)}
+.shell{width:var(--shell);margin-inline:auto}
+.skip-link{position:fixed;top:8px;left:8px;z-index:100;padding:10px 14px;color:var(--white);background:var(--ink);transform:translateY(-150%)}
+.skip-link:focus{transform:translateY(0)}
+:focus-visible{outline:3px solid var(--white);outline-offset:3px;box-shadow:0 0 0 6px var(--ink)}
+
+.hero-grid>*,.problem-grid>*,.wide-heading>*,.differentiator-grid>*,.benchmark-grid>*,.install-grid>*,.faq-grid>*{min-width:0}
+.comparison-wrap,.install-terminal{max-width:100%;min-width:0}
+.install-terminal pre{max-width:100%}
+
+.site-header{position:relative;z-index:20;border-bottom:1px solid var(--line);background:var(--paper)}
+.header-inner{min-height:76px;display:grid;grid-template-columns:1fr auto 1fr;align-items:center;gap:28px}
+.brand{display:inline-flex;align-items:center;gap:11px;width:fit-content;color:var(--ink);font-family:var(--font-display);font-size:1.15rem;letter-spacing:-.03em;text-decoration:none}
+.brand-mark{display:inline-flex;align-items:end;gap:2px;width:25px;height:22px}
+.brand-mark i{display:block;width:6px;background:var(--blue)}
+.brand-mark i:nth-child(1){height:11px}
+.brand-mark i:nth-child(2){height:21px;background:var(--signal)}
+.brand-mark i:nth-child(3){height:15px}
+.desktop-nav{display:flex;align-items:center;gap:26px}
+.desktop-nav a{color:var(--ink-soft);font-size:.9rem;font-weight:700;text-decoration:none}
+.desktop-nav a:hover{color:var(--blue)}
+.header-action{justify-self:end;display:inline-flex;min-height:44px;align-items:center;gap:8px;padding:8px 14px;border:1px solid var(--ink);font-size:.88rem;font-weight:700;text-decoration:none}
+.header-action:hover{color:var(--white);background:var(--ink)}
+
+.hero{padding:76px 0 72px;overflow:hidden}
+.hero-grid{display:grid;grid-template-columns:minmax(0,1.03fr) minmax(420px,.97fr);gap:66px;align-items:center}
+.hero h1{max-width:760px;margin:0;font-family:var(--font-display);font-size:clamp(3.5rem,6.7vw,6rem);line-height:.95;letter-spacing:-.055em;text-wrap:balance}
+.hero h1 span{color:var(--blue)}
+.hero-lead{max-width:650px;margin:32px 0 0;color:var(--ink-soft);font-size:1.3rem;line-height:1.45}
+.hero-facts{margin:20px 0 28px;font-family:var(--font-code);font-size:.84rem;font-weight:600;letter-spacing:.015em}
+.install-strip{display:grid;grid-template-columns:minmax(0,1fr) auto;align-items:center;max-width:720px;min-height:60px;border:2px solid var(--ink);background:var(--white);box-shadow:7px 7px 0 var(--ink)}
+.install-strip code{display:block;overflow:hidden;padding:14px 16px;font-size:.72rem;white-space:nowrap;text-overflow:ellipsis}
+.copy-button{min-width:84px;min-height:56px;border:0;border-left:1px solid var(--ink);color:var(--white);background:var(--blue);font-size:.82rem;font-weight:700;cursor:pointer}

--- a/site/styles/05-hero-relay.css
+++ b/site/styles/05-hero-relay.css
@@ -1,0 +1,60 @@
+.copy-button:hover{background:var(--blue-deep)}
+.copy-button.is-copied{color:var(--ink);background:var(--lime)}
+.hero-actions{display:flex;flex-wrap:wrap;gap:12px;margin-top:27px}
+.button{display:inline-flex;min-height:50px;align-items:center;justify-content:center;padding:10px 19px;border:2px solid var(--ink);font-size:.94rem;font-weight:700;text-decoration:none}
+.button-primary{color:var(--white);background:var(--ink)}
+.button-primary:hover{color:var(--ink);background:var(--lime)}
+.button-secondary{background:transparent}
+.button-secondary:hover{color:var(--blue);border-color:var(--blue)}
+.button-dark{color:var(--white);background:var(--ink)}
+.button-dark:hover{color:var(--ink);background:var(--lime)}
+.hero-note{margin:17px 0 0;color:var(--muted);font-size:.84rem}
+.hero-note code{color:var(--ink);font-size:.8rem}
+
+.relay-stage{position:relative;min-height:610px;padding:20px;color:var(--white);background:var(--ink);box-shadow:14px 14px 0 var(--blue);isolation:isolate}
+.relay-stage::before,.relay-stage::after{content:"";position:absolute;z-index:-1;pointer-events:none}
+.relay-stage::before{inset:68px 20px 62px;border:1px solid rgba(255,255,255,.16)}
+.relay-stage::after{top:68px;bottom:62px;left:51%;border-left:1px solid rgba(255,255,255,.09)}
+.relay-head{display:flex;align-items:center;justify-content:space-between;padding-bottom:14px;border-bottom:1px solid rgba(255,255,255,.3);font-family:var(--font-code);font-size:.67rem;letter-spacing:.08em}
+.live-state{display:inline-flex;align-items:center;gap:7px;color:var(--lime)}
+.live-state i{width:8px;height:8px;border-radius:50%;background:var(--lime);box-shadow:0 0 0 4px rgba(204,255,61,.13)}
+.session-card{position:absolute;width:61%;padding:15px;color:var(--ink);background:var(--white);box-shadow:6px 6px 0 rgba(36,87,255,.8)}
+.session-card-a{top:96px;left:43px}
+.session-card-b{right:42px;bottom:102px}
+.session-meta{display:flex;justify-content:space-between;gap:12px;color:var(--muted);font-family:var(--font-code);font-size:.59rem;letter-spacing:.04em}
+.session-card p{margin:14px 0 17px;font-size:.91rem;font-weight:700;line-height:1.3}
+.session-tag{display:inline-flex;padding:4px 7px;color:var(--white);background:var(--blue);font-family:var(--font-code);font-size:.57rem}
+.session-tag.recalled{color:var(--ink);background:var(--lime)}
+.relay-line{position:absolute;height:2px;background:var(--signal)}
+.relay-line::before,.relay-line::after{content:"";position:absolute;top:-4px;width:10px;height:10px;border:2px solid var(--signal);border-radius:50%;background:var(--ink)}
+.relay-line::before{left:-2px}.relay-line::after{right:-2px}
+.relay-line-a{top:253px;left:124px;width:46%;transform:rotate(8deg)}
+.relay-line-b{right:103px;bottom:252px;width:48%;transform:rotate(6deg)}
+.relay-dot{position:absolute;top:-5px;left:0;width:12px;height:12px;border-radius:50%;background:var(--lime);box-shadow:0 0 0 4px rgba(204,255,61,.16);animation:relay-travel 3.8s cubic-bezier(.16,1,.3,1) infinite}
+.relay-dot-late{animation-delay:1.7s}
+@keyframes relay-travel{0%,10%{transform:translateX(0);opacity:0}18%{opacity:1}70%{opacity:1}82%,100%{transform:translateX(190px);opacity:0}}
+.mag-core{position:absolute;top:263px;left:50%;z-index:3;width:58%;padding:17px 19px;border:2px solid var(--lime);color:var(--white);background:var(--blue-deep);transform:translateX(-50%) rotate(-2deg)}
+.core-title{display:flex;align-items:baseline;justify-content:space-between;gap:10px}
+.core-title span{font-family:var(--font-display);font-size:1.65rem}
+.core-title small{color:var(--blue-pale);font-family:var(--font-code);font-size:.55rem}
+.mag-core ul{display:grid;gap:5px;margin:12px 0 0;padding:0;list-style:none}
+.mag-core li{display:flex;gap:9px;font-family:var(--font-code);font-size:.63rem}
+.mag-core li span{color:var(--lime)}
+.tool-junction{position:absolute;right:20px;bottom:22px;left:20px;display:flex;align-items:center;gap:8px;color:rgba(255,255,255,.7);font-family:var(--font-code);font-size:.53rem;letter-spacing:.04em}
+.tool-junction i{flex:1;border-top:1px solid rgba(255,255,255,.23)}
+.relay-caption{position:absolute;right:25px;bottom:57px;margin:0;color:var(--blue-pale);font-size:.72rem}
+
+.evidence-rail{color:var(--white);background:var(--blue);border-block:2px solid var(--ink)}
+.rail-grid{display:grid;grid-template-columns:repeat(4,1fr)}
+.rail-grid div{min-height:124px;padding:24px;border-right:1px solid rgba(255,255,255,.34)}
+.rail-grid div:last-child{border-right:0}
+.rail-grid strong{display:block;font-family:var(--font-display);font-size:2.1rem;line-height:1;letter-spacing:-.04em}
+.rail-grid span{display:block;margin-top:8px;color:#edf1ff;font-size:.79rem}
+
+.problem-section{padding:112px 0}
+.problem-grid{display:grid;grid-template-columns:1fr 1fr;gap:70px;align-items:start}
+.section-heading h2,.roadmap-heading h2,.install-copy h2,.faq-grid>h2,.benchmark-copy h2{margin:0;font-family:var(--font-display);font-size:clamp(2.5rem,5vw,4.35rem);line-height:1.02;letter-spacing:-.045em;text-wrap:balance}
+.problem-copy{max-width:620px;font-size:1.12rem}
+.problem-copy p{margin:0 0 20px}
+.context-leak{display:grid;grid-template-columns:1fr 150px 1fr 150px 1fr;align-items:center;margin-top:72px;padding:36px;border-block:1px solid var(--line)}
+.leak-session{padding:22px;border:2px solid var(--ink);background:var(--white)}

--- a/site/styles/10-sections-a.css
+++ b/site/styles/10-sections-a.css
@@ -1,0 +1,60 @@
+.leak-session strong{display:block;margin-top:8px;font-size:1.05rem}
+.leak-session p{margin:7px 0 0;color:var(--muted);font-size:.82rem}
+.leak-time{font-family:var(--font-code);font-size:.68rem;color:var(--blue)}
+.leak-session.faded{opacity:.72}.leak-session.faded-more{opacity:.47}
+.leak-loss{display:grid;grid-template-columns:1fr;justify-items:center;gap:7px;color:var(--signal-text);font-family:var(--font-code);font-size:.55rem;text-align:center}
+.leak-loss i{width:100%;border-top:2px dashed var(--signal)}
+
+.mechanism-section{padding:112px 0;border-block:2px solid var(--ink);background:var(--white)}
+.wide-heading{display:grid;grid-template-columns:1.15fr .85fr;gap:70px;align-items:end}
+.wide-heading p{max-width:560px;margin:0;color:var(--muted);font-size:1.08rem}
+.pipeline{display:grid;grid-template-columns:1fr 42px 1fr 42px 1fr 42px 1fr;align-items:stretch;margin-top:72px}
+.pipeline-step{position:relative;min-height:245px;padding:28px 22px;border-top:4px solid var(--ink);background:var(--paper)}
+.pipeline-step.core-step{color:var(--white);border-color:var(--lime);background:var(--blue-deep)}
+.step-number{display:block;color:var(--blue);font-family:var(--font-code);font-size:.72rem;font-weight:600}
+.core-step .step-number{color:var(--lime)}
+.pipeline-step h3{margin:42px 0 11px;font-size:1.28rem;line-height:1.15}
+.pipeline-step p{margin:0;color:var(--muted);font-size:.84rem}
+.core-step p{color:#e1e8ff}
+.pipeline-connector{position:relative;display:grid;place-items:center}
+.pipeline-connector::before{content:"";width:100%;border-top:2px solid var(--signal)}
+.pipeline-connector i{position:absolute;right:1px;width:8px;height:8px;border-top:2px solid var(--signal);border-right:2px solid var(--signal);transform:rotate(45deg)}
+.differentiator-grid{display:grid;grid-template-columns:.78fr 1.22fr;gap:70px;align-items:center;margin-top:90px}
+.diff-copy h3{margin:0 0 15px;font-family:var(--font-display);font-size:2.2rem;line-height:1;letter-spacing:-.035em}
+.diff-copy p{margin:0;color:var(--muted)}
+.query-demo{border:2px solid var(--ink);background:var(--paper);box-shadow:10px 10px 0 var(--signal)}
+.query-line,.match-line{display:grid;grid-template-columns:76px 1fr;gap:16px;padding:18px 20px;border-bottom:1px solid var(--line)}
+.query-line span,.match-line span{color:var(--muted);font-family:var(--font-code);font-size:.64rem}
+.query-line code{font-size:.82rem}.match-line strong{font-size:1.05rem}
+.signal-line{display:flex;flex-wrap:wrap;gap:8px;padding:14px 20px}
+.signal-line span{padding:4px 7px;color:var(--white);background:var(--blue);font-family:var(--font-code);font-size:.59rem}
+
+.comparison-section{padding:112px 0}
+.comparison-wrap{margin-top:66px;overflow-x:auto;border:2px solid var(--ink);background:var(--white)}
+table{width:100%;min-width:760px;border-collapse:collapse}
+th,td{padding:19px 20px;border-right:1px solid var(--line);border-bottom:1px solid var(--line);text-align:left;vertical-align:top}
+thead th{color:var(--white);background:var(--ink);font-size:.76rem}
+tbody th{width:25%;font-size:.88rem}
+td{color:var(--muted);font-size:.88rem}
+tr:last-child th,tr:last-child td{border-bottom:0}
+th:last-child,td:last-child{border-right:0}
+.mag-column{color:var(--ink);background:var(--blue-pale)}
+thead .mag-column{color:var(--white);background:var(--blue)}
+
+.benchmark-section{padding:112px 0;color:var(--white);background:var(--blue);border-block:2px solid var(--ink)}
+.benchmark-grid{display:grid;grid-template-columns:.9fr 1.1fr;gap:80px;align-items:center}
+.benchmark-copy p{max-width:650px;margin:24px 0 0;color:#f0f3ff}
+.benchmark-copy strong{color:var(--lime)}
+.benchmark-actions{display:flex;flex-wrap:wrap;align-items:center;gap:20px;margin-top:30px}
+.text-link{color:var(--white);font-size:.88rem;font-weight:700;text-underline-offset:4px}
+.fine-print{max-width:580px;padding-top:18px;border-top:1px solid rgba(255,255,255,.35);font-size:.73rem}
+.benchmark-board{padding:26px;color:var(--ink);background:var(--paper);box-shadow:12px 12px 0 var(--ink)}
+.board-head{display:flex;justify-content:space-between;gap:20px;padding-bottom:16px;border-bottom:2px solid var(--ink);font-family:var(--font-code);font-size:.66rem}
+.bar-group{margin-top:23px}
+.bar-label{display:flex;justify-content:space-between;gap:10px;margin-bottom:7px}
+.bar-label span{font-weight:700}
+.bar-label strong{font-family:var(--font-display);font-size:1.35rem}
+.bar-track{height:26px;border:2px solid var(--ink);background:var(--white)}
+.bar{display:block;width:var(--bar);height:100%;background:var(--blue)}
+.reference-bar{background:var(--signal)}
+.category-lines{display:grid;grid-template-columns:repeat(5,1fr);margin-top:30px;border-block:1px solid var(--line)}

--- a/site/styles/15-sections-b.css
+++ b/site/styles/15-sections-b.css
@@ -1,0 +1,66 @@
+.category-lines div{padding:14px 8px;border-right:1px solid var(--line);text-align:center}
+.category-lines div:last-child{border-right:0}
+.category-lines span{display:block;color:var(--muted);font-size:.59rem}
+.category-lines strong{display:block;margin-top:5px;font-family:var(--font-code);font-size:.8rem}
+.benchmark-board>p{margin:10px 0 0;color:var(--muted);font-family:var(--font-code);font-size:.58rem;text-align:right}
+
+.tradeoff-section{padding:112px 0;color:var(--white);background:var(--ink)}
+.inverse-heading p{color:#bdc9d2}
+.tradeoff-grid{display:grid;grid-template-columns:1fr 1fr;margin-top:68px;border:1px solid var(--line-dark)}
+.gain-side,.accept-side{padding:38px}
+.gain-side{border-right:1px solid var(--line-dark)}
+.tradeoff-grid h3{margin:0 0 26px;font-size:1.35rem}
+.fit-list{display:grid;gap:17px;margin:0;padding:0;list-style:none}
+.fit-list li{position:relative;padding-left:31px;color:#e6ebef}
+.fit-list li::before{position:absolute;left:0;top:2px;font-family:var(--font-code);font-weight:700}
+.positive-list li::before{content:"+";color:var(--lime)}
+.caution-list li::before{content:"×";color:var(--signal)}
+.constraint-strip{margin-top:36px;padding:22px 24px;border:1px solid var(--line-dark);background:#16283a}
+.constraint-strip p{margin:0;color:#c9d3db;font-size:.82rem}
+.constraint-strip strong{color:var(--white)}
+
+.roadmap-section{padding:112px 0}
+.roadmap-heading{display:grid;grid-template-columns:1.2fr .8fr;gap:70px;align-items:end}
+.roadmap-heading p{margin:0;color:var(--muted)}
+.roadmap-track{position:relative;display:grid;grid-template-columns:repeat(3,1fr);gap:0;margin-top:72px;border-block:2px solid var(--ink)}
+.roadmap-track::before{content:"";position:absolute;top:43px;right:0;left:0;border-top:2px solid var(--signal)}
+.roadmap-phase{position:relative;z-index:1;min-height:330px;padding:25px 30px 32px;border-right:1px solid var(--line);background:var(--paper)}
+.roadmap-phase:last-child{border-right:0}
+.phase-status{display:inline-flex;align-items:center;gap:8px;min-height:36px;padding:0 10px;border:2px solid var(--ink);background:var(--paper);font-family:var(--font-code);font-size:.65rem;font-weight:600}
+.phase-status i{width:8px;height:8px;border-radius:50%;background:var(--blue)}
+.roadmap-phase h3{margin:54px 0 15px;font-size:1.38rem;line-height:1.18}
+.roadmap-phase p{margin:0;color:var(--muted);font-size:.86rem}
+.issue-links{display:flex;flex-wrap:wrap;gap:7px;margin-top:27px}
+.issue-links a{display:inline-flex;min-width:44px;min-height:44px;align-items:center;justify-content:center;border:1px solid var(--ink);font-family:var(--font-code);font-size:.63rem;text-decoration:none}
+.issue-links a:hover{color:var(--white);background:var(--blue)}
+
+.install-section{padding:112px 0 72px;color:var(--white);background:var(--signal);border-block:2px solid var(--ink)}
+.install-grid{display:grid;grid-template-columns:.8fr 1.2fr;gap:70px;align-items:center}
+.install-copy p{max-width:500px;color:#351209}
+.install-terminal{border:2px solid var(--ink);color:var(--white);background:var(--ink);box-shadow:12px 12px 0 var(--blue)}
+.terminal-head{display:flex;justify-content:space-between;gap:15px;padding:12px 16px;border-bottom:1px solid var(--line-dark);color:#b8c4ce;font-family:var(--font-code);font-size:.62rem}
+.install-terminal pre{margin:0;padding:22px;overflow-x:auto;font-size:.72rem;line-height:1.8}
+.prompt{color:var(--lime)}
+.terminal-copy{width:100%;min-height:50px;border-top:1px solid var(--line-dark);border-left:0}
+.package-row{display:flex;flex-wrap:wrap;align-items:center;gap:10px;margin-top:64px;padding-top:25px;border-top:1px solid rgba(13,27,42,.55);color:var(--ink)}
+.package-row>span{margin-right:7px;font-weight:700}
+.package-row code{padding:6px 9px;background:var(--signal-pale);font-size:.66rem}
+
+.faq-section{padding:112px 0}
+.faq-grid{display:grid;grid-template-columns:.7fr 1.3fr;gap:80px;align-items:start}
+.faq-list{border-top:2px solid var(--ink)}
+details{border-bottom:1px solid var(--line)}
+summary{min-height:64px;display:flex;align-items:center;justify-content:space-between;gap:20px;padding:16px 2px;font-weight:700;cursor:pointer;list-style:none}
+summary::-webkit-details-marker{display:none}
+summary::after{content:"+";display:grid;width:32px;height:32px;flex:0 0 32px;place-items:center;border:1px solid var(--ink);font-family:var(--font-code)}
+details[open] summary::after{content:"−";color:var(--white);background:var(--ink)}
+details p{max-width:680px;margin:0;padding:0 48px 24px 2px;color:var(--muted)}
+
+.site-footer{padding:42px 0;color:var(--white);background:var(--ink)}
+.footer-grid{display:grid;grid-template-columns:1fr auto auto;gap:50px;align-items:end}
+.footer-brand{color:var(--white)}
+.footer-grid>div:first-child p{margin:8px 0 0;color:#b8c4ce;font-size:.8rem}
+.footer-links{display:flex;flex-wrap:wrap;gap:20px}
+.footer-links a{font-size:.8rem;text-underline-offset:4px}
+.footer-meta{margin:0;color:#b8c4ce;font-size:.74rem}
+

--- a/site/styles/20-responsive.css
+++ b/site/styles/20-responsive.css
@@ -1,0 +1,80 @@
+@media(max-width:1040px){
+  .desktop-nav{display:none}
+  .header-inner{grid-template-columns:1fr auto}
+  .hero-grid{grid-template-columns:1fr}
+  .hero-copy{max-width:820px}
+  .relay-stage{width:min(650px,100%);margin-inline:auto}
+  .context-leak{grid-template-columns:1fr 70px 1fr 70px 1fr;padding-inline:14px}
+  .pipeline{grid-template-columns:repeat(2,1fr);gap:20px}
+  .pipeline-connector{display:none}
+  .benchmark-grid,.install-grid{grid-template-columns:1fr}
+  .benchmark-copy,.install-copy{max-width:760px}
+}
+@media(max-width:780px){
+  :root{--shell:min(100% - 28px,1180px)}
+  body{font-size:17px}
+  .header-inner{min-height:66px}
+  .header-action{padding-inline:11px;font-size:.78rem}
+  .hero{padding:50px 0 56px}
+  .hero h1{font-size:clamp(3.15rem,16vw,4.7rem)}
+  .hero-lead{margin-top:24px;font-size:1.13rem}
+  .install-strip{grid-template-columns:1fr;box-shadow:5px 5px 0 var(--ink)}
+  .install-strip code{white-space:normal;overflow-wrap:anywhere}
+  .install-strip .copy-button{width:100%;border-top:1px solid var(--ink);border-left:0}
+  .hero-actions .button{flex:1}
+  .relay-stage{min-height:640px;padding:16px;box-shadow:8px 8px 0 var(--blue)}
+  .relay-stage::before{inset-inline:16px}
+  .session-card{width:76%}
+  .session-card-a{left:26px}
+  .session-card-b{right:25px;bottom:90px}
+  .mag-core{width:73%}
+  .relay-line-a{left:75px;width:54%}
+  .relay-line-b{right:65px;width:55%}
+  .rail-grid{grid-template-columns:1fr 1fr}
+  .rail-grid div:nth-child(2){border-right:0}
+  .rail-grid div:nth-child(-n+2){border-bottom:1px solid rgba(255,255,255,.34)}
+  .problem-section,.mechanism-section,.comparison-section,.benchmark-section,.tradeoff-section,.roadmap-section,.install-section,.faq-section{padding-block:82px}
+  .problem-grid,.wide-heading,.roadmap-heading,.differentiator-grid,.faq-grid{grid-template-columns:1fr;gap:30px}
+  .section-heading h2,.roadmap-heading h2,.install-copy h2,.faq-grid>h2,.benchmark-copy h2{font-size:clamp(2.45rem,12vw,3.8rem)}
+  .context-leak{grid-template-columns:1fr;gap:0;margin-top:50px;padding:0;border:0}
+  .leak-loss{min-height:58px;display:flex;align-items:center;gap:10px;padding-inline:22px}
+  .leak-loss i{height:100%;width:0;border-top:0;border-left:2px dashed var(--signal)}
+  .pipeline{grid-template-columns:1fr;gap:18px;margin-top:50px}
+  .pipeline-step{min-height:205px}
+  .query-line,.match-line{grid-template-columns:1fr;gap:5px}
+  .benchmark-grid{gap:54px}
+  .benchmark-board{padding:20px 16px;box-shadow:7px 7px 0 var(--ink)}
+  .category-lines{grid-template-columns:repeat(2,1fr)}
+  .category-lines div{border-bottom:1px solid var(--line)}
+  .category-lines div:nth-child(2n){border-right:0}
+  .category-lines div:last-child{grid-column:1/-1;border-bottom:0}
+  .tradeoff-grid{grid-template-columns:1fr}
+  .gain-side{border-right:0;border-bottom:1px solid var(--line-dark)}
+  .gain-side,.accept-side{padding:28px 22px}
+  .roadmap-track{grid-template-columns:1fr;border-block:0;border-left:2px solid var(--signal)}
+  .roadmap-track::before{display:none}
+  .roadmap-phase{min-height:0;padding:24px 24px 40px;border-right:0;border-bottom:1px solid var(--line)}
+  .roadmap-phase h3{margin-top:30px}
+  .install-terminal{box-shadow:7px 7px 0 var(--blue)}
+  .footer-grid{grid-template-columns:1fr;gap:28px;align-items:start}
+}
+@media(max-width:430px){
+  .header-action span{display:none}
+  .hero h1{font-size:3rem}
+  .relay-stage{min-height:640px}
+  .session-card{width:82%}
+  .session-card p{font-size:.81rem}
+  .mag-core{width:80%}
+  .core-title small{display:none}
+  .relay-caption{right:18px;left:18px;text-align:right}
+  .rail-grid strong{font-size:1.75rem}
+  .rail-grid div{min-height:108px;padding:20px 15px}
+  .hero-actions{display:grid;grid-template-columns:1fr}
+  .package-row{align-items:stretch}
+  .package-row code{width:100%;overflow-wrap:anywhere}
+}
+@media(prefers-reduced-motion:reduce){
+  html{scroll-behavior:auto}
+  .relay-dot{animation:none;left:50%;opacity:1}
+  *,*::before,*::after{transition-duration:.01ms!important}
+}


### PR DESCRIPTION
## What changed

- Repositioned MAG around cross-tool continuity rather than generic “AI memory”.
- Added a static GitHub Pages landing page with a product-specific context relay, install path, mechanism, benchmark evidence, comparison, explicit fit and wrong-fit criteria, constraints, FAQ, and an issue-linked roadmap.
- Rewrote the README around the same positioning and added two GitHub-safe SVG visuals.
- Added `PRODUCT.md` and `DESIGN.md` so product claims and visual decisions remain explicit.
- Added a GitHub Pages deployment workflow. The source fragments assemble into the exact HTML and CSS used for browser QA.

## Claim boundaries

- The 90.1% result is identified as LoCoMo word-overlap recall, not an end-to-end agent score.
- Local-first limitations are visible: first model download, roughly 32 MB model size, roughly 180 MB peak memory, plaintext SQLite, no managed team sync, 0.1.x maturity, and less Windows testing.
- Roadmap items link to current issues and carry no invented dates.

## Validation

- Responsive browser pass at 390, 820, and 1440 px with no document overflow.
- No console errors, broken local anchors, duplicate IDs, unlabeled buttons, or missing alt text.
- Keyboard focus, reduced motion, touch targets, and WCAG AA text contrast checked.
- HTML assets served successfully; JavaScript syntax, CSS parsing, SVG XML, and workflow YAML validated.
- Growth Arsenal copy gates pass: site grade 4.7, README pitch grade 4.8, zero em dashes, and zero Tier-1 AI vocabulary.

## After merge

GitHub Pages may need a one-time repository setting: **Settings → Pages → Source → GitHub Actions**.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned MAG’s public entry points with a static GitHub Pages site and a tighter README focused on cross‑tool context relay. Adds a Pages deploy workflow plus product and design docs to keep claims and visuals explicit.

- **New Features**
  - Static landing page under `site/` with product mechanism, benchmark, trade‑offs, FAQ, and social card; assembled into `_site/index.html` and `_site/styles.css`.
  - New GitHub Pages workflow (`.github/workflows/pages.yml`) that concatenates parts/styles, uploads the artifact, and deploys on push to `main`.
  - README rewritten around the relay positioning with quick start, “how it works,” tool support, benchmark table, trade‑offs, data/security, and two GitHub‑safe SVGs.
  - Added `PRODUCT.md` and `DESIGN.md` to lock product claims and the visual system.

- **Migration**
  - After merge, enable GitHub Pages: Settings → Pages → Source → GitHub Actions.

<sup>Written for commit ed65338c5ef3944990c2518078185d39df468182. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/George-RD/mag/pull/367?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

