### PR TITLE
docs: plan staged LFM2.5 retriever adoption

### DIFF
--- a/docs/specs/local-first-roadmap.md
+++ b/docs/specs/local-first-roadmap.md
@@ -1,6 +1,6 @@
 # MAG local-first development roadmap
 
-<!-- Revised: 2026-07-28 | Status is held in Cairn todo artefacts -->
+<!-- Revised: 2026-07-29 | Status is held in Cairn todo artefacts -->
 
 ## Mission
 
@@ -48,12 +48,20 @@ here; doing so would create two status sources.
 1. Cairn is the queryable development-context and work-status layer.
 2. LFM2.5 1.2B Instruct is the local generative quality reference.
 3. LFM2.5 350M is eligible only after task-level parity against 1.2B.
-4. Generation, embedding, and reranking are separate model roles.
+4. Generation, dense embedding, cross-encoding, and late-interaction reranking
+   are separate model roles.
 5. Current generation is HTTP-local; direct ONNX generation is a candidate
    runtime, not a preselected outcome.
 6. Derived facts, relationships, clusters, and summaries never overwrite raw
    memories and retain provenance.
 7. Cleanup is evidence-based; stale recon reports are inputs, not authority.
+8. LFM2.5 Embedding is an optional multilingual dense-retrieval candidate;
+   BGE remains the compact default until MAG-specific evaluation says otherwise.
+9. LFM2.5 ColBERT is evaluated first as a bounded reranker. A full multi-vector
+   index requires a separate evidence-backed storage decision.
+10. Retriever and generative fine-tuning follows stable architecture and
+    held-out evaluations. Evaluation runs begin collecting training evidence
+    before training begins.
 
 ## Contradictions resolved
 
@@ -76,6 +84,26 @@ concentrated modules. Those statements can both be true. The current priority is
 live semantic duplication and composition ambiguity, not deleting code because a
 file is large or feature-gated.
 
+### One model family versus one model role
+
+Using LFM2.5 checkpoints for generation, dense retrieval, and late interaction
+can simplify packaging and future specialization, but the checkpoints have
+different heads, outputs, runtime needs, and licences. MAG therefore shares
+model-profile and evaluation infrastructure without treating them as one
+interchangeable loaded model.
+
+## Dependency and parallelism
+
+P0 is the common gate. After it:
+
+- P1 and P2 form the generative-runtime track.
+- P3 is an independent retrieval track and may proceed once the P0 model
+  boundary and evaluation harness exist; it does not wait for direct generative
+  inference.
+- P4 depends on the P1 production baseline.
+- P5 qualifies smaller generative routing only after P1 and relevant P4 tasks.
+- P6 depends on stable selected behavior from P3 through P5.
+
 ## Ordered development plan
 
 ### P0 — Establish the architecture and evaluation foundation
@@ -84,10 +112,13 @@ file is large or feature-gated.
 - Audit current callers, feature flags, fallback paths, tests, and benchmarks.
 - Choose the production composition root and define the migration/removal path.
 - Separate model role, runtime, and transport in the chosen architecture.
+- Define model profiles with query/document roles, embedding-space identity,
+  dimensions, pooling, runtime, quantization, checksums, and licence metadata.
 - Build the local memory-intelligence evaluation harness and versioned dataset.
 
 **Gate:** one documented production path, no unexplained duplicate semantics,
-bounded Cairn queries for connected context, and a reproducible local scorecard.
+bounded Cairn queries for connected context, explicit model-profile contracts,
+and a reproducible local scorecard.
 
 ### P1 — Establish the local LFM2.5 1.2B production baseline
 
@@ -100,7 +131,7 @@ bounded Cairn queries for connected context, and a reproducible local scorecard.
 **Gate:** the 1.2B profile works end to end without cloud credentials and improves
 memory usefulness over rule-only extraction within local latency/RAM budgets.
 
-### P2 — Evaluate direct local inference
+### P2 — Evaluate direct local generative inference
 
 - Prototype `LiquidAI/LFM2.5-1.2B-Instruct-ONNX` behind the model-runtime boundary.
 - Add manifest, revision, checksums, quantization, tokenizer/chat template,
@@ -112,17 +143,30 @@ memory usefulness over rule-only extraction within local latency/RAM budgets.
 **Decision rule:** direct ONNX becomes default only if it lowers end-to-end
 operational cost without a material quality or portability regression.
 
-### P3 — Calibrate retrieval and reranking
+### P3 — Calibrate retrieval and qualify LFM2.5 retrievers
 
-- Calibrate confidence from semantic score, score margin, lexical/semantic
-  agreement, reranker score, query intent, and candidate diversity.
-- Benchmark the existing cross-encoder within session-start latency limits.
-- Evaluate local embedding/reranker alternatives against the current BGE path.
-- Use dynamic result count and token budget.
+- Complete role-aware retriever profiles and the explicit re-embedding migration
+  tracked by issue #89.
+- Establish the current BGE plus MiniLM/no-reranker baseline on the versioned
+  evaluation set.
+- Evaluate `LFM2.5-Embedding-350M` as a 1024-dimensional multilingual and
+  cross-lingual first-stage profile with correct query/document semantics.
+- Evaluate `LFM2.5-ColBERT-350M` first as a bounded top-N reranker through the
+  existing reranker boundary.
+- Compare on-demand and content-hash-cached ColBERT document embeddings.
+- Run the full matrix: BGE baseline, LFM dense, BGE plus ColBERT, and LFM dense
+  plus ColBERT.
+- Include English, Arabic, and English/Arabic cross-lingual retrieval.
+- Calibrate confidence from semantic score, margin, lexical/semantic agreement,
+  reranker score, query intent, and candidate diversity per model profile.
+- Use dynamic result count and token budget only after calibration.
 - Measure active injection versus passive retrieval on agent-resumption tasks.
 
-**Gate:** useful recall and injection precision improve without exceeding local
-latency, RAM, and context budgets.
+**Gate:** a profile improves useful recall, injection precision, or downstream
+task success without exceeding local latency, RAM, disk/index, migration, and
+licence budgets. BGE remains the default without that evidence. A full ColBERT
+multi-vector index is considered only through a later decision if bounded
+reranking leaves first-stage recall as the measured bottleneck.
 
 ### P4 — Add local memory intelligence
 
@@ -138,14 +182,31 @@ Use the 1.2B model for narrow, evaluated operations:
 **Gate:** derived structures improve downstream task success, retain full source
 lineage, and can be invalidated or regenerated independently of raw memories.
 
-### P5 — Qualify the 350M speed tier
+### P5 — Qualify the 350M generative speed tier
 
 Run the same task-level evaluations with LFM2.5 350M. Promote only tasks within a
 predeclared tolerance of the 1.2B reference. Classification and constrained
 tagging are likely candidates; relationship reasoning and consolidation remain
 on 1.2B unless evidence says otherwise.
 
-### P6 — Add service and cross-device mode
+### P6 — Prepare task-specific LFM specialization
+
+- Freeze the selected production composition, retrieval profiles, candidate
+  semantics, memory schemas, and evaluation datasets before training.
+- Retain provenance-linked query, positive, hard-negative, wrong-time,
+  superseded/current, feedback, and downstream task-outcome examples.
+- Evaluate dense retriever fine-tuning first when retrieval evidence supports it.
+- Fine-tune ColBERT only if its bounded reranker role is selected.
+- Fine-tune 350M and 1.2B generative checkpoints only for narrow tasks with
+  separate quality references.
+- Version datasets, prompts, adapters, model lineage, licence metadata, and
+  rollback behavior.
+
+**Gate:** a fine-tuned profile improves held-out downstream task success over the
+untuned production baseline without hiding an architectural or algorithmic
+failure.
+
+### P7 — Add service and cross-device mode
 
 - Reuse the same model/runtime interfaces behind hosted workers or HTTP.
 - Add authentication, encryption, synchronization, tenancy, and conflict handling
@@ -159,9 +220,11 @@ Every model, runtime, retrieval, or intelligence change reports:
 - extraction schema validity;
 - fact/entity/relationship precision and recall;
 - retrieval Recall@5/10, MRR, and abstention accuracy;
+- English, Arabic, and English/Arabic cross-lingual retrieval where relevant;
 - injected-memory precision and active-injection task-success delta;
 - p50/p95 cold and warm latency;
-- peak RAM, on-disk model size, and model load time;
+- peak RAM, on-disk model size, database/index growth, and model load time;
+- re-embedding or migration time and recovery behavior when vector spaces change;
 - generated tokens and context tokens injected;
 - offline success after model installation;
-- quality delta versus the LFM2.5 1.2B local reference.
+- quality delta versus the relevant untuned local reference.

--- a/docs/specs/local-first-roadmap.md
+++ b/docs/specs/local-first-roadmap.md
@@ -59,7 +59,7 @@ here; doing so would create two status sources.
    BGE remains the compact default until MAG-specific evaluation says otherwise.
 9. LFM2.5 ColBERT is evaluated first as a bounded reranker. A full multi-vector
    index requires a separate evidence-backed storage decision.
-10. Retriever and generative fine-tuning follows stable architecture and
+10. Retriever and generative fine-tuning follow stable architecture and
     held-out evaluations. Evaluation runs begin collecting training evidence
     before training begins.
 

--- a/meta/contracts/memory.models.md
+++ b/meta/contracts/memory.models.md
@@ -1,10 +1,22 @@
 ---
-        node: mag.runtime.memory.models
-        ---
-        # mag.runtime.memory.models contract
+node: mag.runtime.memory.models
+---
+# mag.runtime.memory.models contract
 
-        Embedding, generation, and reranking are separate model roles behind
-explicit interfaces. The core quality baseline must run locally without
-cloud credentials. Remote and self-hosted adapters remain optional and use
-the same memory semantics. Missing models fail visibly and fall back only
-when the caller explicitly permits it.
+Embedding, generation, cross-encoding, and late-interaction reranking are
+separate model roles behind explicit interfaces. The core quality baseline must
+run locally without cloud credentials; remote and self-hosted adapters use the
+same memory semantics.
+
+Every production model profile declares its model ID, revision, checksums, role,
+runtime, quantization, output dimensions, pooling, query/document handling,
+maximum input length, licence, and expected local resource envelope. Embedding
+interfaces distinguish query and document roles when a model's semantics
+require it.
+
+Persisted vectors carry an embedding-space identity. A profile change never
+silently mixes vector spaces: MAG fails visibly and requires an explicit,
+recoverable re-embedding migration. Missing models fail visibly and fall back
+only when the caller explicitly permits it. Models with additional licence
+conditions are opt-in profiles unless an accepted decision establishes another
+default.

--- a/meta/contracts/memory.retrieval.md
+++ b/meta/contracts/memory.retrieval.md
@@ -1,9 +1,17 @@
 ---
-        node: mag.runtime.memory.retrieval
-        ---
-        # mag.runtime.memory.retrieval contract
+node: mag.runtime.memory.retrieval
+---
+# mag.runtime.memory.retrieval contract
 
-        Retrieval combines independently useful channels, preserves explainability,
-abstains when evidence is weak, and is benchmark-gated. Fixed thresholds are
-provisional; changes report recall, precision, abstention, latency, memory,
-and context-budget effects.
+Retrieval combines independently useful channels, preserves explainability,
+abstains when evidence is weak, and is benchmark-gated. Dense first-stage
+retrieval and cross-encoder or late-interaction reranking remain distinct roles.
+
+Rerankers operate over a bounded candidate set by default. A full multi-vector
+retrieval index is a separate storage and architecture decision, not an
+incidental reranker implementation detail.
+
+Fixed thresholds are provisional and calibration is model-profile-specific.
+Changes report recall, precision, abstention, score margin, active-injection task
+success, latency, RAM, disk/index growth, and context-budget effects. A new model
+is not promoted solely from vendor benchmarks or embedding similarity gains.

--- a/meta/contracts/quality.benchmarks.md
+++ b/meta/contracts/quality.benchmarks.md
@@ -1,8 +1,15 @@
 ---
-        node: mag.quality.benchmarks
-        ---
-        # mag.quality.benchmarks contract
+node: mag.quality.benchmarks
+---
+# mag.quality.benchmarks contract
 
-        Benchmarks use versioned datasets, disclose methodology, and distinguish
+Benchmarks use versioned datasets, disclose methodology, and distinguish
 retrieval from end-to-end answer quality. Local-first scorecards include
-quality, latency, RAM, disk size, cold start, and offline success.
+quality, latency, RAM, disk size, cold start, migration cost, and offline
+success.
+
+Model comparisons use the same corpus, queries, code revision, candidate limits,
+and scoring method. Multilingual profiles include English, Arabic, and
+cross-lingual cases. Fine-tuned models require held-out task-success improvement,
+reproducible training inputs, licence and lineage metadata, and regression
+comparison against the untuned production baseline.

--- a/meta/contracts/storage.sqlite.md
+++ b/meta/contracts/storage.sqlite.md
@@ -1,9 +1,15 @@
 ---
-        node: mag.runtime.memory.storage.sqlite
-        ---
-        # mag.runtime.memory.storage.sqlite contract
+node: mag.runtime.memory.storage.sqlite
+---
+# mag.runtime.memory.storage.sqlite contract
 
-        SQLite is the durable local source of truth. Database work runs off the
-async executor, writes are transactional, migrations are additive and
-idempotent, FTS/vector/graph indexes are repairable, and caches never become
-durability authorities.
+SQLite is the durable local source of truth. Database work runs off the async
+executor, writes are transactional, migrations are additive and idempotent,
+FTS/vector/graph indexes are repairable, and caches never become durability
+authorities.
+
+The database records the profile and embedding-space identity used for persisted
+vectors. Re-embedding and dimension changes update the memory BLOB and vector
+index through an interruption-safe, recoverable migration. Opening or querying
+mixed, stale, or unknown embedding spaces fails visibly rather than returning
+uncalibrated results.

--- a/meta/decisions/dec.stage-lfm25-retriever-adoption.md
+++ b/meta/decisions/dec.stage-lfm25-retriever-adoption.md
@@ -1,0 +1,39 @@
+---
+id: dec.stage-lfm25-retriever-adoption
+nodes:
+  - mag.runtime.memory.models
+  - mag.runtime.memory.retrieval
+  - mag.runtime.memory.storage.sqlite
+  - mag.quality.benchmarks
+status: accepted
+date: 2026-07-29
+revisit_triggers:
+  - "MAG evaluation shows material task-success gains within local budgets"
+  - "Bounded ColBERT reranking leaves first-stage recall as the bottleneck"
+  - "The LFM licence or supported deployment formats change"
+  - "A stronger permissively licensed edge retriever becomes available"
+informed_by: [res.lfm25-retriever-fit]
+related: [dec.lfm25-1-2b-baseline, dec.local-first-dual-mode]
+---
+# Stage LFM2.5 retriever adoption behind evidence
+
+MAG will evaluate both LFM2.5 retrievers without changing the production default
+in advance of evidence.
+
+1. `LFM2.5-Embedding-350M` is a candidate optional multilingual and
+   cross-lingual first-stage profile. BGE remains the compact default until the
+   candidate passes MAG-specific quality, latency, memory, disk, migration, and
+   licence gates.
+2. `LFM2.5-ColBERT-350M` will first be evaluated as a bounded top-N reranker
+   behind the existing reranker interface. A full multi-vector index requires a
+   later decision supported by measured first-stage recall limits.
+3. Model profiles, query/document role semantics, embedding-space identity,
+   explicit re-embedding, and per-profile calibration are prerequisites for
+   production adoption.
+4. Evaluation runs should retain training examples and hard negatives, but
+   fine-tuning begins only after the selected retrieval architecture and
+   held-out task-success measures are stable.
+
+This keeps the immediate experiment reversible, preserves MAG's small local
+baseline, and leaves room for a higher-quality multilingual tier where its
+larger footprint is justified.

--- a/meta/research/res.lfm25-retriever-fit.md
+++ b/meta/research/res.lfm25-retriever-fit.md
@@ -32,7 +32,7 @@ It is not a model-file swap for the current embedder:
 - similarity, margin, supersession, fusion, and abstention thresholds must be
   calibrated for the new score distribution.
 
-The raw vector payload is about 2.67 times the current dimension before database
+The raw f32 vector payload is about 2.67 times the current one before database
 and index overhead. It therefore needs an explicit quality-versus-footprint
 decision rather than automatic replacement of BGE.
 
@@ -76,9 +76,9 @@ The same versioned corpus and query set should compare:
 
 | Profile | First-stage dense model | Reranker |
 |---|---|---|
-| Current baseline | BGE-small | MiniLM or none |
+| Current baseline | bge-small-en-v1.5 | MiniLM or none |
 | Multilingual candidate | LFM2.5 Embedding | MiniLM or none |
-| Late-interaction value | BGE-small | LFM2.5 ColBERT |
+| Late-interaction value | bge-small-en-v1.5 | LFM2.5 ColBERT |
 | Full LFM retrieval | LFM2.5 Embedding | LFM2.5 ColBERT |
 
 The scorecard should include Recall@5/10, MRR, abstention accuracy, paraphrase

--- a/meta/research/res.lfm25-retriever-fit.md
+++ b/meta/research/res.lfm25-retriever-fit.md
@@ -1,0 +1,113 @@
+---
+id: res.lfm25-retriever-fit
+nodes:
+  - mag.runtime.memory.models
+  - mag.runtime.memory.retrieval
+  - mag.runtime.memory.storage.sqlite
+  - mag.quality.benchmarks
+sources: [src.lfm25-retriever-official-materials, src.local-first-roadmap]
+date: 2026-07-29
+---
+# LFM2.5 retriever fit for MAG
+
+MAG already separates dense embedding and reranking roles. The current production
+path uses a 384-dimensional BGE embedding and can optionally rerank a bounded
+candidate set through the `Reranker` trait. The new LFM2.5 retrievers fit those
+two roles differently.
+
+## Dense retriever
+
+`LFM2.5-Embedding-350M` is a multilingual dense bi-encoder. It emits one
+1024-dimensional CLS-pooled vector per query or document and uses asymmetric
+`query:` and `document:` prompts. Its strongest MAG use is an optional
+multilingual and cross-lingual first-stage retrieval profile, including
+English/Arabic memory.
+
+It is not a model-file swap for the current embedder:
+
+- query and document encoding must be role-aware;
+- the pooling contract differs from MAG's current mean-pooling path;
+- the vector dimension grows from 384 to 1024;
+- stored memories must be re-embedded into the new vector space;
+- similarity, margin, supersession, fusion, and abstention thresholds must be
+  calibrated for the new score distribution.
+
+The raw vector payload is about 2.67 times the current dimension before database
+and index overhead. It therefore needs an explicit quality-versus-footprint
+decision rather than automatic replacement of BGE.
+
+## Late-interaction retriever
+
+`LFM2.5-ColBERT-350M` emits one 128-dimensional vector per token and scores
+query/document pairs with MaxSim. MAG should evaluate it first as a bounded
+top-N reranker behind the existing `Reranker` boundary. This preserves the
+current dense/FTS candidate generation and avoids committing to a new
+multi-vector primary index.
+
+The first experiment should compare:
+
+- encoding candidate passages on demand;
+- caching document token embeddings by content hash;
+- the existing MiniLM cross-encoder;
+- no reranker.
+
+A full PLAID-style ColBERT index is a separate architectural decision. It should
+be considered only if bounded reranking materially improves downstream task
+success and the remaining bottleneck is first-stage recall rather than ranking.
+
+## Required foundation
+
+Production qualification requires:
+
+1. a model profile that records model ID, revision, checksum, role, runtime,
+   quantization, dimensions, pooling, prefixes, maximum length, and licence;
+2. role-aware query/document embedding without model-specific strings leaking
+   through ingestion and search call sites;
+3. persisted embedding-space identity plus transactional batch re-embedding;
+4. per-profile calibration rather than shared global thresholds;
+5. runtime adapters behind the model/runtime boundary, without assuming that the
+   generative-model runtime is also the best retriever runtime;
+6. explicit licence handling so a restricted model is not silently made the
+   universal default.
+
+## Evaluation matrix
+
+The same versioned corpus and query set should compare:
+
+| Profile | First-stage dense model | Reranker |
+|---|---|---|
+| Current baseline | BGE-small | MiniLM or none |
+| Multilingual candidate | LFM2.5 Embedding | MiniLM or none |
+| Late-interaction value | BGE-small | LFM2.5 ColBERT |
+| Full LFM retrieval | LFM2.5 Embedding | LFM2.5 ColBERT |
+
+The scorecard should include Recall@5/10, MRR, abstention accuracy, paraphrase
+recall, active-injection task success, English retrieval, Arabic retrieval,
+English/Arabic cross-lingual retrieval, p50/p95 cold and warm latency, RAM, model
+load time, re-embedding time, database/index growth, and offline success.
+
+## Fine-tuning sequence
+
+MAG should retain evaluated query-to-memory examples while the retrieval
+architecture is calibrated:
+
+- required evidence memories and useful candidates;
+- same-project and same-entity hard negatives;
+- correct entity but wrong time;
+- superseded versus current facts;
+- lexical near-matches that are semantically wrong;
+- downstream task success and user feedback.
+
+Training should wait until candidate generation, ranking semantics, abstention,
+and evaluation labels are stable. The dense retriever is the first likely
+specialization target. ColBERT should be fine-tuned only if its reranker role is
+selected. Generative LFM2.5 models remain separate task-specific candidates for
+classification, extraction, relationships, and consolidation.
+
+## Conclusion
+
+Keep BGE as the compact permissively licensed default until MAG-specific
+evidence supports a change. Evaluate LFM2.5 Embedding as an optional multilingual
+profile and LFM2.5 ColBERT first as an optional quality reranker. Collect
+fine-tuning data during evaluation, but promote no fine-tuned model before the
+retrieval architecture and held-out task-success gates are stable.

--- a/meta/sources/src.lfm25-retriever-official-materials.md
+++ b/meta/sources/src.lfm25-retriever-official-materials.md
@@ -1,0 +1,17 @@
+---
+id: src.lfm25-retriever-official-materials
+file: https://www.liquid.ai/blog/lfm2-5-retrievers
+verification: external
+type: official-release-and-model-documentation
+date: 2026-07-29
+---
+
+Official Liquid AI materials reviewed for the retriever plan:
+
+- https://huggingface.co/LiquidAI/LFM2.5-Embedding-350M
+- https://huggingface.co/LiquidAI/LFM2.5-ColBERT-350M
+- https://www.liquid.ai/lfm-license
+
+They define the dense and late-interaction model roles, output shapes,
+query/document handling, deployment examples, fine-tuning path, and licence
+constraints.

--- a/meta/sources/src.local-first-roadmap.md
+++ b/meta/sources/src.local-first-roadmap.md
@@ -1,10 +1,10 @@
 ---
 id: src.local-first-roadmap
 file: docs/specs/local-first-roadmap.md
-sha256: 9e8dc59f61bf5ecd308959845c77afcaf803be293db20f828e52be6064b72db7
+sha256: 86b62adbc4c6eafe9134cc78d9ac01c214d6b48322b57dad1676dbce478900e0
 verification: verified
 type: roadmap
-date: 2026-07-28
+date: 2026-07-29
 ---
 
 Current local-first mission, ordered gates, and Cairn execution model.

--- a/meta/todos/calibrate-retrieval-and-reranking.md
+++ b/meta/todos/calibrate-retrieval-and-reranking.md
@@ -1,13 +1,32 @@
 ---
-        node: mag.runtime.memory.retrieval
-        status: blocked
-        created: 2026-07-28
-        ---
-        # Calibrate Retrieval And Reranking
+node: mag.runtime.memory.retrieval
+status: blocked
+created: 2026-07-28
+---
+# Calibrate Retrieval And Reranking
 
-        Blocked by the local evaluation harness.
+Blocked by `todo.build-local-memory-intelligence-eval-harness`,
+`todo.define-role-aware-retriever-profiles`, and
+`todo.implement-embedding-space-migration`.
 
 Replace provisional global cutoffs with calibrated confidence from semantic
-score, margin, lexical agreement, reranker score, intent, and candidate
-diversity. Evaluate the existing cross-encoder and local embedding/reranker
-alternatives. Add dynamic result count and token budget.
+score, score margin, lexical agreement, reranker score, query intent, and
+candidate diversity. Establish the current BGE and MiniLM baseline, then run the
+same versioned evaluation across:
+
+- BGE with the existing reranker or no reranker;
+- LFM2.5 Embedding as the dense first-stage model;
+- BGE with LFM2.5 ColBERT as a bounded top-N reranker;
+- LFM2.5 Embedding with LFM2.5 ColBERT.
+
+Include English, Arabic, and English/Arabic cross-lingual cases. Compare
+on-demand versus content-hash-cached ColBERT document embeddings. Report
+Recall@5/10, MRR, abstention, paraphrase recall, active-injection task success,
+cold/warm p50 and p95, RAM, model load time, re-embedding time, database/index
+growth, and offline operation.
+
+Keep BGE as the default unless a candidate materially improves MAG-specific task
+success within the local footprint and licence budget. Treat a full ColBERT
+multi-vector index as a separate decision after bounded reranking identifies
+first-stage recall as the remaining bottleneck. Add dynamic result count and
+token budget only from the same calibrated evidence.

--- a/meta/todos/define-role-aware-retriever-profiles.md
+++ b/meta/todos/define-role-aware-retriever-profiles.md
@@ -1,0 +1,18 @@
+---
+node: mag.runtime.memory.models
+status: blocked
+created: 2026-07-29
+---
+# Define Role-Aware Retriever Profiles
+
+Blocked by `todo.select-production-composition-root`.
+
+Define one model-profile contract for dense encoders and rerankers. It must
+record model ID, revision, checksum, role, runtime, quantization, dimensions,
+pooling, query/document prefixes, maximum input length, licence, and local
+resource expectations.
+
+Change the embedding boundary so models can distinguish query and document
+encoding without leaking model-specific prefixes into ingestion or retrieval
+call sites. Keep generation, dense embedding, cross-encoding, and late
+interaction as separate roles even when they use the same model family.

--- a/meta/todos/implement-embedding-space-migration.md
+++ b/meta/todos/implement-embedding-space-migration.md
@@ -1,0 +1,18 @@
+---
+node: mag.runtime.memory.storage.sqlite
+status: blocked
+created: 2026-07-29
+---
+# Implement Embedding-Space Migration
+
+Blocked by `todo.define-role-aware-retriever-profiles`.
+
+Complete the model migration capability tracked by GitHub issue #89. Persist the
+profile and embedding-space identity that produced stored vectors, detect
+mismatches on open, and provide a transactional batch `re-embed` path for the
+memory BLOB and vector index.
+
+The operation needs dry-run and progress reporting, interruption-safe recovery,
+dimension changes, cache invalidation, index repair, and a clear rollback or
+backup path. MAG must never silently query a database containing mixed or stale
+embedding spaces.

--- a/meta/todos/prepare-lfm25-specialization-data.md
+++ b/meta/todos/prepare-lfm25-specialization-data.md
@@ -1,0 +1,19 @@
+---
+node: mag.quality.benchmarks
+status: blocked
+created: 2026-07-29
+---
+# Prepare LFM2.5 Specialization Data
+
+Blocked by `todo.calibrate-retrieval-and-reranking`.
+
+Retain versioned, provenance-linked examples from retriever and memory-
+intelligence evaluations: query, required evidence, useful candidates, hard
+negatives, wrong-time and superseded facts, model profile, scores, feedback, and
+downstream task outcome.
+
+After the production retrieval and intelligence algorithms are stable, evaluate
+task-specific fine-tuning separately for the LFM2.5 dense retriever, selected
+ColBERT reranker, 350M constrained tasks, and 1.2B reasoning tasks. Promotion
+requires held-out task-success improvement, reproducible training inputs,
+licence metadata, and rollback to the untuned baseline.


### PR DESCRIPTION
## Summary

Updates MAG's dependency-led roadmap and Cairn context to incorporate the new LFM2.5 retrieval models without prematurely replacing the current compact baseline.

## What changed

- Adds an official source record, research analysis, and accepted decision for `LFM2.5-Embedding-350M` and `LFM2.5-ColBERT-350M`.
- Keeps `bge-small-en-v1.5` as the default until MAG-specific evaluation justifies migration.
- Plans LFM2.5 Embedding as an optional multilingual and English/Arabic cross-lingual dense profile.
- Plans LFM2.5 ColBERT first as a bounded top-N reranker behind the existing `Reranker` interface; a full multi-vector index remains a separate later decision.
- Adds prerequisite todos for role-aware model profiles and recoverable embedding-space migration, explicitly connecting the latter to issue #89.
- Expands the retrieval calibration todo into a four-profile evaluation matrix with quality, latency, RAM, index growth, migration, and active-injection gates.
- Adds a later specialization phase that collects hard-negative and task-outcome evidence now but defers fine-tuning until retrieval and memory-intelligence algorithms are stable.
- Strengthens model, retrieval, SQLite, and benchmark contracts around model identity, query/document semantics, per-profile calibration, migration safety, multilingual tests, licence metadata, and held-out evaluation.

## Sequencing

P0 remains the shared architecture and evaluation gate. After it, the generative-runtime work and retriever qualification can proceed as independent tracks. Production retriever adoption still requires the selected composition root, the local evaluation harness, model-profile support, and re-embedding migration.

## Validation

- Reviewed the final branch diff against `main`.
- Validated the new Cairn frontmatter schemas and node/source identifiers.
- No runtime code changed; repository CI and the pinned Cairn architecture gate will validate the final branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Plans staged adoption of `LFM2.5-Embedding-350M` and `LFM2.5-ColBERT-350M` in MAG’s retriever stack while keeping `bge-small-en-v1.5` as the default until MAG evaluations pass, with clear licence gates and a safe migration path.

- **Refactors**
  - Adds an accepted decision, research record, and official sources for the LFM2.5 retrievers.
  - Updates contracts to require rich model profiles (role-aware query/doc semantics, dimensions/pooling, runtime, checksums, licence), persisted embedding‑space identity with visible failures on mixed spaces, per‑profile calibration, bounded reranking by default, and benchmark gates that include multilingual/cross‑lingual cases and migration/index‑growth costs; no promotion from vendor benchmarks alone.
  - Expands the roadmap: LFM2.5 Embedding as an optional multilingual dense first stage; LFM2.5 ColBERT first as a bounded top‑N reranker via `Reranker`; a full multi‑vector index is a separate later decision.

- **Migration**
  - Add role‑aware retriever profiles and persist embedding‑space identity; implement a transactional re‑embedding path (connected to issue #89).
  - Run a four‑profile evaluation matrix (BGE baseline, LFM dense, BGE+ColBERT, LFM dense+ColBERT) across English, Arabic, and cross‑lingual; calibrate per profile; compare on‑demand vs content‑hash‑cached ColBERT embeddings; enable dynamic result count and token budget after calibration.
  - Keep BGE as default unless a candidate improves recall/precision or task success within local latency, RAM, disk/index, migration, and licence budgets.

<sup>Written for commit c51c69b608f966b3292706d05fc7004845f90bc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/George-RD/mag/pull/371?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

