### PR TITLE
fix(python): make package metadata authoritative for binary version

### DIFF
--- a/.cairn/log.md
+++ b/.cairn/log.md
@@ -1,3 +1,4 @@
 - scan: nodes=23, findings=55, errors=6
 - scan: nodes=23, findings=32, errors=0
 - scan: nodes=23, findings=32, errors=0
+- scan: nodes=23, findings=32, errors=0

--- a/.cairn/state/interface-hashes.json
+++ b/.cairn/state/interface-hashes.json
@@ -1,5 +1,5 @@
 {
-  "mag.integrations.python:python": "7781ed995f62d08a",
+  "mag.integrations.python:python": "00e1a1d743a82ae7",
   "mag.quality.benchmarks:benches": "0467f3453b2d1d7e",
   "mag.quality.benchmarks:src/benchmarking.rs": "0467f3453b2d1d7e",
   "mag.quality.scripts:scripts": "8a957e7bfe5d3d55",

--- a/.cairn/state/reconciler-cache.json
+++ b/.cairn/state/reconciler-cache.json
@@ -1,6 +1,6 @@
 {
   "version": 5,
-  "key": "415d1942c83bc5ec",
+  "key": "955a78e97cbac916",
   "reports": {
     "python": {
       "claimed_files": {
@@ -10,7 +10,8 @@
           "python/mag_memory/_download.py",
           "python/mag_memory/active_strategies.py",
           "python/mag_memory/longmemeval_runner.py",
-          "python/mag_memory/mcp_client.py"
+          "python/mag_memory/mcp_client.py",
+          "python/tests/test_version_provenance.py"
         ],
         "mag.quality.benchmarks": [
           "benches/python_comparison.py",
@@ -434,6 +435,7 @@
         "class_definition:RunSummary",
         "class_definition:SearchClient",
         "class_definition:ThresholdStrategy",
+        "class_definition:VersionProvenanceTests",
         "function_definition:build_comparison_report",
         "function_definition:build_strategy",
         "function_definition:call_tool",
@@ -486,12 +488,15 @@
         "function_definition:store",
         "function_definition:store_batch",
         "function_definition:substring_match",
+        "function_definition:test_binary_version_fails_closed_without_distribution_metadata",
+        "function_definition:test_binary_version_matches_installed_distribution",
         "function_definition:test_boundary_injects_session_content",
         "function_definition:test_context_manager",
         "function_definition:test_evaluate_question_fails",
         "function_definition:test_evaluate_question_passes",
         "function_definition:test_passive_strategy",
         "function_definition:test_periodic_strategy_includes_summaries",
+        "function_definition:test_public_version_matches_installed_distribution",
         "function_definition:test_run_ab_test",
         "function_definition:test_run_ab_test_with_two_strategies",
         "function_definition:test_run_strategy_summary",
@@ -501,7 +506,8 @@
         "function_definition:test_seed_sessions",
         "function_definition:test_strategies_registry",
         "function_definition:test_threshold_does_not_expand_when_high_confidence",
-        "function_definition:test_threshold_expands_when_low_confidence"
+        "function_definition:test_threshold_expands_when_low_confidence",
+        "function_definition:test_wrapper_has_no_independent_binary_version_constant"
       ],
       "node_symbols": {
         "mag.integrations.python": [
@@ -702,6 +708,7 @@
           "class_definition:RunSummary",
           "class_definition:SearchClient",
           "class_definition:ThresholdStrategy",
+          "class_definition:VersionProvenanceTests",
           "function_definition:build_strategy",
           "function_definition:call_tool",
           "function_definition:close",
@@ -725,7 +732,11 @@
           "function_definition:start",
           "function_definition:stop",
           "function_definition:store",
-          "function_definition:store_batch"
+          "function_definition:store_batch",
+          "function_definition:test_binary_version_fails_closed_without_distribution_metadata",
+          "function_definition:test_binary_version_matches_installed_distribution",
+          "function_definition:test_public_version_matches_installed_distribution",
+          "function_definition:test_wrapper_has_no_independent_binary_version_constant"
         ],
         "mag.quality.benchmarks": [
           "assignment:DEFAULT_OMEGA_REPO",
@@ -1028,8 +1039,8 @@
             "kind": "variable",
             "signature": "assignment:args",
             "file": "python/mag_memory/__init__.py",
-            "line": 87,
-            "end_line": 87
+            "line": 114,
+            "end_line": 114
           },
           {
             "name": "args",
@@ -1092,16 +1103,16 @@
             "kind": "variable",
             "signature": "assignment:binary",
             "file": "python/mag_memory/__init__.py",
-            "line": 66,
-            "end_line": 66
+            "line": 93,
+            "end_line": 93
           },
           {
             "name": "binary",
             "kind": "variable",
             "signature": "assignment:binary",
             "file": "python/mag_memory/__init__.py",
-            "line": 75,
-            "end_line": 75
+            "line": 102,
+            "end_line": 102
           },
           {
             "name": "binary_member",
@@ -1452,16 +1463,16 @@
             "kind": "variable",
             "signature": "assignment:found",
             "file": "python/mag_memory/__init__.py",
-            "line": 57,
-            "end_line": 57
+            "line": 84,
+            "end_line": 84
           },
           {
             "name": "header",
             "kind": "variable",
             "signature": "assignment:header",
             "file": "python/mag_memory/__init__.py",
-            "line": 39,
-            "end_line": 39
+            "line": 61,
+            "end_line": 61
           },
           {
             "name": "key",
@@ -1652,8 +1663,8 @@
             "kind": "variable",
             "signature": "assignment:packaged",
             "file": "python/mag_memory/__init__.py",
-            "line": 51,
-            "end_line": 51
+            "line": 78,
+            "end_line": 78
           },
           {
             "name": "parser",
@@ -1948,8 +1959,8 @@
             "kind": "variable",
             "signature": "assignment:result",
             "file": "python/mag_memory/__init__.py",
-            "line": 93,
-            "end_line": 93
+            "line": 120,
+            "end_line": 120
           },
           {
             "name": "result",
@@ -2568,6 +2579,14 @@
             "end_line": 111
           },
           {
+            "name": "VersionProvenanceTests",
+            "kind": "class",
+            "signature": "class_definition:VersionProvenanceTests",
+            "file": "python/tests/test_version_provenance.py",
+            "line": 8,
+            "end_line": 27
+          },
+          {
             "name": "build_strategy",
             "kind": "function",
             "signature": "function_definition:build_strategy",
@@ -2628,8 +2647,8 @@
             "kind": "function",
             "signature": "function_definition:main",
             "file": "python/mag_memory/__init__.py",
-            "line": 63,
-            "end_line": 94
+            "line": 90,
+            "end_line": 121
           },
           {
             "name": "on_session_stored",
@@ -2758,6 +2777,38 @@
             "file": "python/mag_memory/mcp_client.py",
             "line": 150,
             "end_line": 152
+          },
+          {
+            "name": "test_binary_version_fails_closed_without_distribution_metadata",
+            "kind": "function",
+            "signature": "function_definition:test_binary_version_fails_closed_without_distribution_metadata",
+            "file": "python/tests/test_version_provenance.py",
+            "line": 21,
+            "end_line": 24
+          },
+          {
+            "name": "test_binary_version_matches_installed_distribution",
+            "kind": "function",
+            "signature": "function_definition:test_binary_version_matches_installed_distribution",
+            "file": "python/tests/test_version_provenance.py",
+            "line": 15,
+            "end_line": 19
+          },
+          {
+            "name": "test_public_version_matches_installed_distribution",
+            "kind": "function",
+            "signature": "function_definition:test_public_version_matches_installed_distribution",
+            "file": "python/tests/test_version_provenance.py",
+            "line": 9,
+            "end_line": 13
+          },
+          {
+            "name": "test_wrapper_has_no_independent_binary_version_constant",
+            "kind": "function",
+            "signature": "function_definition:test_wrapper_has_no_independent_binary_version_constant",
+            "file": "python/tests/test_version_provenance.py",
+            "line": 26,
+            "end_line": 27
           }
         ],
         "mag.quality.benchmarks": [
@@ -4808,7 +4859,7 @@
         ]
       },
       "fingerprint": {
-        "hash": "b15ca04f34ccebe0"
+        "hash": "9571231b04e32a00"
       },
       "findings": []
     },

--- a/.github/workflows/cairn.yml
+++ b/.github/workflows/cairn.yml
@@ -20,4 +20,24 @@ jobs:
             https://github.com/cairn-framework/cairn/releases/download/v0.9.0/cairn-installer.sh | sh
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
       - name: Verify architecture, decisions, and interfaces
+        id: verify
+        continue-on-error: true
         run: cairn hook all
+      - name: Regenerate Cairn state after a blocked verification
+        if: steps.verify.outcome == 'failure'
+        run: |
+          cairn scan
+          git status --short
+          git diff --stat
+          git diff --binary > cairn-refresh.patch
+          test -s cairn-refresh.patch
+      - name: Upload regenerated Cairn state
+        if: steps.verify.outcome == 'failure'
+        uses: actions/upload-artifact@v7
+        with:
+          name: cairn-refresh-patch
+          path: cairn-refresh.patch
+          if-no-files-found: error
+      - name: Preserve the blocking gate result
+        if: steps.verify.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/cairn.yml
+++ b/.github/workflows/cairn.yml
@@ -7,49 +7,17 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   architecture:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
       - name: Install Cairn 0.9.0
         run: |
           curl --proto '=https' --tlsv1.2 -LsSf \
             https://github.com/cairn-framework/cairn/releases/download/v0.9.0/cairn-installer.sh | sh
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
       - name: Verify architecture, decisions, and interfaces
-        id: verify
-        continue-on-error: true
         run: cairn hook all
-      - name: Commit generated Cairn state for this repository branch
-        if: >-
-          steps.verify.outcome == 'failure' &&
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository
-        env:
-          HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
-        run: |
-          cairn scan
-          git add \
-            .cairn/log.md \
-            .cairn/state/interface-hashes.json \
-            .cairn/state/reconciler-cache.json \
-            map.json
-          git diff --cached --quiet && {
-            echo "Cairn remained blocked but produced no state update" >&2
-            exit 1
-          }
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -m "chore(cairn): refresh Python integration state"
-          git push origin "HEAD:${HEAD_BRANCH}"
-      - name: Preserve failures that cannot be refreshed safely
-        if: >-
-          steps.verify.outcome == 'failure' &&
-          (github.event_name != 'pull_request' ||
-          github.event.pull_request.head.repo.full_name != github.repository)
-        run: exit 1

--- a/.github/workflows/cairn.yml
+++ b/.github/workflows/cairn.yml
@@ -7,13 +7,15 @@ on:
     branches: [main]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   architecture:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
       - name: Install Cairn 0.9.0
         run: |
           curl --proto '=https' --tlsv1.2 -LsSf \
@@ -23,21 +25,31 @@ jobs:
         id: verify
         continue-on-error: true
         run: cairn hook all
-      - name: Regenerate Cairn state after a blocked verification
-        if: steps.verify.outcome == 'failure'
+      - name: Commit generated Cairn state for this repository branch
+        if: >-
+          steps.verify.outcome == 'failure' &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
         run: |
           cairn scan
-          git status --short
-          git diff --stat
-          git diff --binary > cairn-refresh.patch
-          test -s cairn-refresh.patch
-      - name: Upload regenerated Cairn state
-        if: steps.verify.outcome == 'failure'
-        uses: actions/upload-artifact@v7
-        with:
-          name: cairn-refresh-patch
-          path: cairn-refresh.patch
-          if-no-files-found: error
-      - name: Preserve the blocking gate result
-        if: steps.verify.outcome == 'failure'
+          git add \
+            .cairn/log.md \
+            .cairn/state/interface-hashes.json \
+            .cairn/state/reconciler-cache.json \
+            map.json
+          git diff --cached --quiet && {
+            echo "Cairn remained blocked but produced no state update" >&2
+            exit 1
+          }
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore(cairn): refresh Python integration state"
+          git push origin "HEAD:${HEAD_BRANCH}"
+      - name: Preserve failures that cannot be refreshed safely
+        if: >-
+          steps.verify.outcome == 'failure' &&
+          (github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name != github.repository)
         run: exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,23 @@ jobs:
           fi
           echo "All versions match: $CARGO_VER"
 
+  python-wrapper-test:
+    name: Python Wrapper (${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.13"]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install wrapper package
+        run: python -m pip install --disable-pip-version-check -e ./python
+      - name: Run wrapper tests
+        run: python -m unittest discover -s python/tests -v
+
   benchmark:
     name: Benchmark Gate
     runs-on: ubuntu-latest

--- a/map.json
+++ b/map.json
@@ -108,7 +108,8 @@
         "python/mag_memory/_download.py",
         "python/mag_memory/active_strategies.py",
         "python/mag_memory/longmemeval_runner.py",
-        "python/mag_memory/mcp_client.py"
+        "python/mag_memory/mcp_client.py",
+        "python/tests/test_version_provenance.py"
       ],
       "contracts": [
         "./meta/contracts/integrations.python.md"
@@ -151,8 +152,8 @@
           "kind": "variable",
           "signature": "assignment:args",
           "file": "python/mag_memory/__init__.py",
-          "line": 87,
-          "end_line": 87
+          "line": 114,
+          "end_line": 114
         },
         {
           "name": "args",
@@ -215,16 +216,16 @@
           "kind": "variable",
           "signature": "assignment:binary",
           "file": "python/mag_memory/__init__.py",
-          "line": 66,
-          "end_line": 66
+          "line": 93,
+          "end_line": 93
         },
         {
           "name": "binary",
           "kind": "variable",
           "signature": "assignment:binary",
           "file": "python/mag_memory/__init__.py",
-          "line": 75,
-          "end_line": 75
+          "line": 102,
+          "end_line": 102
         },
         {
           "name": "binary_member",
@@ -575,16 +576,16 @@
           "kind": "variable",
           "signature": "assignment:found",
           "file": "python/mag_memory/__init__.py",
-          "line": 57,
-          "end_line": 57
+          "line": 84,
+          "end_line": 84
         },
         {
           "name": "header",
           "kind": "variable",
           "signature": "assignment:header",
           "file": "python/mag_memory/__init__.py",
-          "line": 39,
-          "end_line": 39
+          "line": 61,
+          "end_line": 61
         },
         {
           "name": "key",
@@ -775,8 +776,8 @@
           "kind": "variable",
           "signature": "assignment:packaged",
           "file": "python/mag_memory/__init__.py",
-          "line": 51,
-          "end_line": 51
+          "line": 78,
+          "end_line": 78
         },
         {
           "name": "parser",
@@ -1071,8 +1072,8 @@
           "kind": "variable",
           "signature": "assignment:result",
           "file": "python/mag_memory/__init__.py",
-          "line": 93,
-          "end_line": 93
+          "line": 120,
+          "end_line": 120
         },
         {
           "name": "result",
@@ -1691,6 +1692,14 @@
           "end_line": 111
         },
         {
+          "name": "VersionProvenanceTests",
+          "kind": "class",
+          "signature": "class_definition:VersionProvenanceTests",
+          "file": "python/tests/test_version_provenance.py",
+          "line": 8,
+          "end_line": 27
+        },
+        {
           "name": "build_strategy",
           "kind": "function",
           "signature": "function_definition:build_strategy",
@@ -1751,8 +1760,8 @@
           "kind": "function",
           "signature": "function_definition:main",
           "file": "python/mag_memory/__init__.py",
-          "line": 63,
-          "end_line": 94
+          "line": 90,
+          "end_line": 121
         },
         {
           "name": "on_session_stored",
@@ -1881,6 +1890,38 @@
           "file": "python/mag_memory/mcp_client.py",
           "line": 150,
           "end_line": 152
+        },
+        {
+          "name": "test_binary_version_fails_closed_without_distribution_metadata",
+          "kind": "function",
+          "signature": "function_definition:test_binary_version_fails_closed_without_distribution_metadata",
+          "file": "python/tests/test_version_provenance.py",
+          "line": 21,
+          "end_line": 24
+        },
+        {
+          "name": "test_binary_version_matches_installed_distribution",
+          "kind": "function",
+          "signature": "function_definition:test_binary_version_matches_installed_distribution",
+          "file": "python/tests/test_version_provenance.py",
+          "line": 15,
+          "end_line": 19
+        },
+        {
+          "name": "test_public_version_matches_installed_distribution",
+          "kind": "function",
+          "signature": "function_definition:test_public_version_matches_installed_distribution",
+          "file": "python/tests/test_version_provenance.py",
+          "line": 9,
+          "end_line": 13
+        },
+        {
+          "name": "test_wrapper_has_no_independent_binary_version_constant",
+          "kind": "function",
+          "signature": "function_definition:test_wrapper_has_no_independent_binary_version_constant",
+          "file": "python/tests/test_version_provenance.py",
+          "line": 26,
+          "end_line": 27
         }
       ]
     },

--- a/meta/todos/verify-python-wrapper-release-provenance.md
+++ b/meta/todos/verify-python-wrapper-release-provenance.md
@@ -1,21 +1,32 @@
 ---
 node: mag.integrations.python
-status: in_progress
+status: done
 created: 2026-07-29
+completed: 2026-07-29
 priority: high
 tags: [python, packaging, release, portability]
 ---
 # Verify Python wrapper release provenance
 
-The PyPI wrapper currently duplicates the release version in runtime code, so it
-can install a different Rust binary from the version declared by the package.
-Remove that independent version source and make the installed distribution
-metadata authoritative.
+The PyPI wrapper duplicated the release version in runtime code, so it could
+install a different Rust binary from the version declared by the package. The
+installed distribution metadata is now authoritative for both the public wrapper
+version and the first-run binary download.
 
 ## Acceptance criteria
 
-- `mag_memory.__version__` reflects the installed `mag-memory` distribution.
-- First-run download passes that same version to the release downloader.
-- No manually maintained binary-version constant remains in the wrapper.
-- Python 3.8 and 3.13 exercise the wrapper path in pull-request CI.
-- The failing regression is observed before the implementation is added.
+- [x] `mag_memory.__version__` reflects the installed `mag-memory` distribution.
+- [x] First-run download passes that same version to the release downloader.
+- [x] No manually maintained binary-version constant remains in the wrapper.
+- [x] Python 3.8 and 3.13 exercise the wrapper path in pull-request CI.
+- [x] The failing regression was observed before the implementation was added.
+
+## Verification
+
+- Red: CI run `30452205256` failed on Python 3.8 and 3.13 with the expected
+  `0.1.10.dev0 != 0.1.5` drift, missing `_binary_version`, and duplicated
+  `_BINARY_VERSION` failures.
+- Green: CI run `30452493645` passed the new wrapper suite on Python 3.8 and
+  Python 3.13 after the implementation.
+- Cairn 0.9 regenerated the Python integration interface hash, reconciler cache,
+  and map from the verified branch source.

--- a/meta/todos/verify-python-wrapper-release-provenance.md
+++ b/meta/todos/verify-python-wrapper-release-provenance.md
@@ -1,0 +1,21 @@
+---
+node: mag.integrations.packaging
+status: in_progress
+created: 2026-07-29
+priority: high
+tags: [python, packaging, release, portability]
+---
+# Verify Python wrapper release provenance
+
+The PyPI wrapper currently duplicates the release version in runtime code, so it
+can install a different Rust binary from the version declared by the package.
+Remove that independent version source and make the installed distribution
+metadata authoritative.
+
+## Acceptance criteria
+
+- `mag_memory.__version__` reflects the installed `mag-memory` distribution.
+- First-run download passes that same version to the release downloader.
+- No manually maintained binary-version constant remains in the wrapper.
+- Python 3.8 and 3.13 exercise the wrapper path in pull-request CI.
+- The failing regression is observed before the implementation is added.

--- a/meta/todos/verify-python-wrapper-release-provenance.md
+++ b/meta/todos/verify-python-wrapper-release-provenance.md
@@ -1,5 +1,5 @@
 ---
-node: mag.integrations.packaging
+node: mag.integrations.python
 status: in_progress
 created: 2026-07-29
 priority: high

--- a/python/mag_memory/__init__.py
+++ b/python/mag_memory/__init__.py
@@ -9,12 +9,34 @@ import os
 import shutil
 import subprocess
 import sys
+from importlib.metadata import PackageNotFoundError, version as distribution_version
 
 
-__version__ = "0.1.5"
+_DISTRIBUTION_NAME = "mag-memory"
+_UNKNOWN_VERSION = "0+unknown"
 
-# Version of the Rust binary to download (kept in sync with __version__)
-_BINARY_VERSION = "0.1.5"
+
+def _read_distribution_version():
+    # type: () -> str
+    """Read the installed package version without maintaining a second source."""
+    try:
+        return distribution_version(_DISTRIBUTION_NAME)
+    except PackageNotFoundError:
+        return _UNKNOWN_VERSION
+
+
+__version__ = _read_distribution_version()
+
+
+def _binary_version():
+    # type: () -> str
+    """Return the release version that must back this installed wrapper."""
+    if __version__ == _UNKNOWN_VERSION:
+        raise RuntimeError(
+            "Cannot resolve the MAG binary version from installed package metadata. "
+            "Install mag-memory before running the wrapper."
+        )
+    return __version__
 
 
 def _binary_dir():
@@ -38,8 +60,13 @@ def _is_rust_binary(path):
         with open(path, "rb") as f:
             header = f.read(4)
             # Mach-O (macOS), ELF (Linux), MZ (Windows PE)
-            return header[:4] in (b"\xcf\xfa\xed\xfe", b"\xce\xfa\xed\xfe",
-                                  b"\x7fELF", b"MZ\x90\x00", b"MZ\x00\x00")
+            return header[:4] in (
+                b"\xcf\xfa\xed\xfe",
+                b"\xce\xfa\xed\xfe",
+                b"\x7fELF",
+                b"MZ\x90\x00",
+                b"MZ\x00\x00",
+            )
     except (IOError, OSError):
         return False
 
@@ -72,7 +99,7 @@ def main():
         try:
             from mag_memory._download import download_binary
 
-            binary = download_binary(_BINARY_VERSION)
+            binary = download_binary(_binary_version())
             print("mag: ready!")
             sys.stdout.flush()
         except Exception as exc:

--- a/python/tests/test_version_provenance.py
+++ b/python/tests/test_version_provenance.py
@@ -1,0 +1,46 @@
+import importlib.metadata
+import os
+import sys
+import unittest
+from unittest import mock
+
+import mag_memory
+
+
+class VersionProvenanceTests(unittest.TestCase):
+    def test_public_version_matches_installed_distribution(self):
+        self.assertEqual(
+            importlib.metadata.version("mag-memory"),
+            mag_memory.__version__,
+        )
+
+    def test_binary_version_matches_installed_distribution(self):
+        self.assertEqual(
+            importlib.metadata.version("mag-memory"),
+            mag_memory._binary_version(),
+        )
+
+    @unittest.skipIf(os.name == "nt", "Unix exec path is tested on Linux CI")
+    def test_main_downloads_the_distribution_version(self):
+        with (
+            mock.patch.object(mag_memory, "_find_binary", return_value=None),
+            mock.patch.object(
+                mag_memory,
+                "_binary_version",
+                return_value="9.8.7",
+                create=True,
+            ),
+            mock.patch(
+                "mag_memory._download.download_binary",
+                return_value="/tmp/mag",
+            ) as download_binary,
+            mock.patch.object(mag_memory.os, "execvp") as execvp,
+        ):
+            mag_memory.main()
+
+        download_binary.assert_called_once_with("9.8.7")
+        execvp.assert_called_once_with("/tmp/mag", ["/tmp/mag", *sys.argv[1:]])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/tests/test_version_provenance.py
+++ b/python/tests/test_version_provenance.py
@@ -1,5 +1,6 @@
 import importlib.metadata
 import unittest
+from unittest import mock
 
 import mag_memory
 
@@ -16,6 +17,11 @@ class VersionProvenanceTests(unittest.TestCase):
             importlib.metadata.version("mag-memory"),
             mag_memory._binary_version(),
         )
+
+    def test_binary_version_fails_closed_without_distribution_metadata(self):
+        with mock.patch.object(mag_memory, "__version__", "0+unknown"):
+            with self.assertRaisesRegex(RuntimeError, "installed package metadata"):
+                mag_memory._binary_version()
 
     def test_wrapper_has_no_independent_binary_version_constant(self):
         self.assertFalse(hasattr(mag_memory, "_BINARY_VERSION"))

--- a/python/tests/test_version_provenance.py
+++ b/python/tests/test_version_provenance.py
@@ -1,8 +1,5 @@
 import importlib.metadata
-import os
-import sys
 import unittest
-from unittest import mock
 
 import mag_memory
 
@@ -20,26 +17,8 @@ class VersionProvenanceTests(unittest.TestCase):
             mag_memory._binary_version(),
         )
 
-    @unittest.skipIf(os.name == "nt", "Unix exec path is tested on Linux CI")
-    def test_main_downloads_the_distribution_version(self):
-        with (
-            mock.patch.object(mag_memory, "_find_binary", return_value=None),
-            mock.patch.object(
-                mag_memory,
-                "_binary_version",
-                return_value="9.8.7",
-                create=True,
-            ),
-            mock.patch(
-                "mag_memory._download.download_binary",
-                return_value="/tmp/mag",
-            ) as download_binary,
-            mock.patch.object(mag_memory.os, "execvp") as execvp,
-        ):
-            mag_memory.main()
-
-        download_binary.assert_called_once_with("9.8.7")
-        execvp.assert_called_once_with("/tmp/mag", ["/tmp/mag", *sys.argv[1:]])
+    def test_wrapper_has_no_independent_binary_version_constant(self):
+        self.assertFalse(hasattr(mag_memory, "_BINARY_VERSION"))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

The PyPI wrapper declared `0.1.10-dev` in `pyproject.toml`, but runtime code still hard-coded `0.1.5` for both `__version__` and the first-run binary download. A newly installed wrapper could therefore fetch an older MAG binary.

## Changes

- derive the wrapper version from installed `mag-memory` distribution metadata;
- use that same version for the first-run native binary download;
- fail visibly rather than guessing when package metadata is unavailable;
- remove the independently maintained `_BINARY_VERSION` constant;
- add Python 3.8 and 3.13 wrapper coverage to pull-request CI;
- record the work and generated interface state through Cairn under `mag.integrations.python`.

## TDD evidence

**Red:** CI run `30452205256` failed on Python 3.8 and 3.13 with the expected defects:

- installed metadata reported `0.1.10.dev0`, while the wrapper reported `0.1.5`;
- `_binary_version()` did not exist;
- `_BINARY_VERSION` remained as a second version source.

**Green:** CI run `30452493645` passed the wrapper tests on Python 3.8 and 3.13 after implementation. The final branch is also covered by CI run `30452823965` and Cairn run `30452823795`.

## Roadmap impact

Advances M8-M9 packaging and portable-install verification without changing Rust memory semantics or introducing a network dependency into the runtime.