### PR TITLE
fix(python): verify release checksums before extraction

### DIFF
--- a/.cairn/log.md
+++ b/.cairn/log.md
@@ -2,3 +2,4 @@
 - scan: nodes=23, findings=32, errors=0
 - scan: nodes=23, findings=32, errors=0
 - scan: nodes=23, findings=32, errors=0
+- scan: nodes=23, findings=32, errors=0

--- a/.cairn/state/interface-hashes.json
+++ b/.cairn/state/interface-hashes.json
@@ -1,5 +1,5 @@
 {
-  "mag.integrations.python:python": "00e1a1d743a82ae7",
+  "mag.integrations.python:python": "0f67bdcbdbff1627",
   "mag.quality.benchmarks:benches": "0467f3453b2d1d7e",
   "mag.quality.benchmarks:src/benchmarking.rs": "0467f3453b2d1d7e",
   "mag.quality.scripts:scripts": "8a957e7bfe5d3d55",

--- a/.cairn/state/reconciler-cache.json
+++ b/.cairn/state/reconciler-cache.json
@@ -1,6 +1,6 @@
 {
   "version": 5,
-  "key": "955a78e97cbac916",
+  "key": "e63ba652aac71f3a",
   "reports": {
     "python": {
       "claimed_files": {
@@ -11,6 +11,7 @@
           "python/mag_memory/active_strategies.py",
           "python/mag_memory/longmemeval_runner.py",
           "python/mag_memory/mcp_client.py",
+          "python/tests/test_download_integrity.py",
           "python/tests/test_version_provenance.py"
         ],
         "mag.quality.benchmarks": [
@@ -40,8 +41,17 @@
         "assignment:accuracy",
         "assignment:actual",
         "assignment:actual",
+        "assignment:actual_digest",
         "assignment:all_results",
         "assignment:all_within_equiv",
+        "assignment:archive",
+        "assignment:archive",
+        "assignment:archive",
+        "assignment:archive",
+        "assignment:archive",
+        "assignment:archive_name",
+        "assignment:archive_name",
+        "assignment:archive_url",
         "assignment:args",
         "assignment:args",
         "assignment:args",
@@ -73,6 +83,8 @@
         "assignment:binary_name",
         "assignment:binary_path",
         "assignment:binary_path",
+        "assignment:binary_path",
+        "assignment:binary_path",
         "assignment:bl_overall",
         "assignment:bl_samples",
         "assignment:calls",
@@ -88,6 +100,7 @@
         "assignment:categories[name]",
         "assignment:category_breakdown",
         "assignment:category_deltas",
+        "assignment:checksum_url",
         "assignment:client",
         "assignment:client",
         "assignment:client",
@@ -138,6 +151,9 @@
         "assignment:deltas",
         "assignment:deltas[key]",
         "assignment:dest_dir",
+        "assignment:dest_dir",
+        "assignment:dest_dir",
+        "assignment:dest_dir",
         "assignment:dest_path",
         "assignment:dest_path",
         "assignment:detail",
@@ -150,6 +166,10 @@
         "assignment:detail",
         "assignment:detail",
         "assignment:detail",
+        "assignment:digest",
+        "assignment:digest",
+        "assignment:digest",
+        "assignment:digest, filename",
         "assignment:dirname",
         "assignment:embedder",
         "assignment:env",
@@ -158,7 +178,10 @@
         "assignment:eor",
         "assignment:expanded",
         "assignment:expanded",
+        "assignment:expected",
+        "assignment:expected",
         "assignment:expected_answer",
+        "assignment:expected_digest",
         "assignment:expected_lower",
         "assignment:expected_str",
         "assignment:ext",
@@ -166,6 +189,8 @@
         "assignment:f1_sum",
         "assignment:failed",
         "assignment:fallback_kwargs",
+        "assignment:filename",
+        "assignment:filename",
         "assignment:fileobj",
         "assignment:found",
         "assignment:g._EMBEDDING_CACHE_MAX",
@@ -182,9 +207,19 @@
         "assignment:latency_ms",
         "assignment:line",
         "assignment:line",
+        "assignment:line",
         "assignment:lines",
         "assignment:machine",
+        "assignment:manifest",
+        "assignment:manifest",
+        "assignment:manifest",
+        "assignment:manifest",
+        "assignment:manifest",
+        "assignment:manifest",
+        "assignment:manifest",
+        "assignment:manifest",
         "assignment:markdown",
+        "assignment:matches",
         "assignment:max_cat_regression",
         "assignment:md_path",
         "assignment:member",
@@ -228,6 +263,7 @@
         "assignment:parser",
         "assignment:parser",
         "assignment:parser",
+        "assignment:parts",
         "assignment:passed",
         "assignment:passed",
         "assignment:passed",
@@ -237,6 +273,8 @@
         "assignment:passed",
         "assignment:passed",
         "assignment:passed",
+        "assignment:path",
+        "assignment:path",
         "assignment:path",
         "assignment:pkg_bin",
         "assignment:plat",
@@ -266,7 +304,6 @@
         "assignment:req_id",
         "assignment:res",
         "assignment:resource",
-        "assignment:resp",
         "assignment:resp",
         "assignment:resp",
         "assignment:resp",
@@ -404,7 +441,9 @@
         "assignment:t0",
         "assignment:t1",
         "assignment:target",
+        "assignment:target",
         "assignment:target, ext",
+        "assignment:text",
         "assignment:text",
         "assignment:tmpdir",
         "assignment:tools_result",
@@ -415,13 +454,14 @@
         "assignment:total_stored",
         "assignment:trace_path",
         "assignment:two_weeks_range",
-        "assignment:url",
         "assignment:ver",
         "assignment:verdict, verdict_reason",
         "assignment:wc",
         "assignment:week_range",
         "assignment:window_range",
+        "class_definition:ArchiveChecksumTests",
         "class_definition:BoundaryStrategy",
+        "class_definition:ChecksumManifestTests",
         "class_definition:FakeClient",
         "class_definition:FakeMcpClient",
         "class_definition:LongMemEvalRunner",
@@ -435,6 +475,7 @@
         "class_definition:RunSummary",
         "class_definition:SearchClient",
         "class_definition:ThresholdStrategy",
+        "class_definition:VerifiedDownloadFlowTests",
         "class_definition:VersionProvenanceTests",
         "function_definition:build_comparison_report",
         "function_definition:build_strategy",
@@ -447,6 +488,8 @@
         "function_definition:download_binary",
         "function_definition:emit_skip",
         "function_definition:evaluate_question",
+        "function_definition:extract",
+        "function_definition:extract",
         "function_definition:extract_scores",
         "function_definition:format_delta",
         "function_definition:generate_markdown",
@@ -488,15 +531,21 @@
         "function_definition:store",
         "function_definition:store_batch",
         "function_definition:substring_match",
+        "function_definition:test_accepts_matching_archive_bytes",
         "function_definition:test_binary_version_fails_closed_without_distribution_metadata",
         "function_definition:test_binary_version_matches_installed_distribution",
         "function_definition:test_boundary_injects_session_content",
+        "function_definition:test_checksum_failure_happens_before_install_side_effects",
         "function_definition:test_context_manager",
         "function_definition:test_evaluate_question_fails",
         "function_definition:test_evaluate_question_passes",
         "function_definition:test_passive_strategy",
         "function_definition:test_periodic_strategy_includes_summaries",
         "function_definition:test_public_version_matches_installed_distribution",
+        "function_definition:test_rejects_a_malformed_digest",
+        "function_definition:test_rejects_a_missing_archive_entry",
+        "function_definition:test_rejects_duplicate_archive_entries",
+        "function_definition:test_rejects_mismatched_archive_bytes",
         "function_definition:test_run_ab_test",
         "function_definition:test_run_ab_test_with_two_strategies",
         "function_definition:test_run_strategy_summary",
@@ -504,16 +553,28 @@
         "function_definition:test_search_with_scores_falls_back_to_text_overlap",
         "function_definition:test_search_with_scores_uses_canonical_score",
         "function_definition:test_seed_sessions",
+        "function_definition:test_selects_the_exact_archive_entry",
         "function_definition:test_strategies_registry",
         "function_definition:test_threshold_does_not_expand_when_high_confidence",
         "function_definition:test_threshold_expands_when_low_confidence",
+        "function_definition:test_verified_tar_archive_is_installed_after_checksum_validation",
+        "function_definition:test_verified_zip_archive_uses_the_windows_extractor",
         "function_definition:test_wrapper_has_no_independent_binary_version_constant"
       ],
       "node_symbols": {
         "mag.integrations.python": [
           "assignment:STRATEGIES",
           "assignment:accuracy",
+          "assignment:actual_digest",
           "assignment:all_results",
+          "assignment:archive",
+          "assignment:archive",
+          "assignment:archive",
+          "assignment:archive",
+          "assignment:archive",
+          "assignment:archive_name",
+          "assignment:archive_name",
+          "assignment:archive_url",
           "assignment:args",
           "assignment:args",
           "assignment:args",
@@ -533,12 +594,15 @@
           "assignment:binary_name",
           "assignment:binary_path",
           "assignment:binary_path",
+          "assignment:binary_path",
+          "assignment:binary_path",
           "assignment:candidate",
           "assignment:cat",
           "assignment:categories",
           "assignment:categories[cat]",
           "assignment:categories[cat][\"accuracy\"]",
           "assignment:category_breakdown",
+          "assignment:checksum_url",
           "assignment:client",
           "assignment:cls",
           "assignment:confidence",
@@ -554,19 +618,31 @@
           "assignment:data",
           "assignment:deadline",
           "assignment:dest_dir",
+          "assignment:dest_dir",
+          "assignment:dest_dir",
+          "assignment:dest_dir",
           "assignment:dest_path",
           "assignment:dest_path",
+          "assignment:digest",
+          "assignment:digest",
+          "assignment:digest",
+          "assignment:digest, filename",
           "assignment:env",
           "assignment:env[\"HOME\"]",
           "assignment:env[\"USERPROFILE\"]",
           "assignment:expanded",
           "assignment:expanded",
+          "assignment:expected",
+          "assignment:expected",
           "assignment:expected_answer",
+          "assignment:expected_digest",
           "assignment:expected_str",
           "assignment:ext",
           "assignment:extra_results",
           "assignment:failed",
           "assignment:fallback_kwargs",
+          "assignment:filename",
+          "assignment:filename",
           "assignment:fileobj",
           "assignment:found",
           "assignment:header",
@@ -578,7 +654,17 @@
           "assignment:latency_ms",
           "assignment:line",
           "assignment:line",
+          "assignment:line",
           "assignment:machine",
+          "assignment:manifest",
+          "assignment:manifest",
+          "assignment:manifest",
+          "assignment:manifest",
+          "assignment:manifest",
+          "assignment:manifest",
+          "assignment:manifest",
+          "assignment:manifest",
+          "assignment:matches",
           "assignment:member",
           "assignment:members",
           "assignment:memory_id",
@@ -595,10 +681,13 @@
           "assignment:names",
           "assignment:packaged",
           "assignment:parser",
+          "assignment:parts",
           "assignment:passed",
           "assignment:passed",
           "assignment:passed",
           "assignment:passed",
+          "assignment:path",
+          "assignment:path",
           "assignment:path",
           "assignment:pkg_bin",
           "assignment:plat",
@@ -619,7 +708,6 @@
           "assignment:report[\"strategies\"][name]",
           "assignment:req",
           "assignment:req_id",
-          "assignment:resp",
           "assignment:resp",
           "assignment:resp",
           "assignment:resp",
@@ -689,15 +777,18 @@
           "assignment:summary",
           "assignment:t0",
           "assignment:target",
+          "assignment:target",
           "assignment:target, ext",
+          "assignment:text",
           "assignment:text",
           "assignment:tools_result",
           "assignment:total_questions",
           "assignment:total_stored",
           "assignment:trace_path",
-          "assignment:url",
           "assignment:ver",
+          "class_definition:ArchiveChecksumTests",
           "class_definition:BoundaryStrategy",
+          "class_definition:ChecksumManifestTests",
           "class_definition:LongMemEvalRunner",
           "class_definition:McpClient",
           "class_definition:McpToolError",
@@ -708,12 +799,15 @@
           "class_definition:RunSummary",
           "class_definition:SearchClient",
           "class_definition:ThresholdStrategy",
+          "class_definition:VerifiedDownloadFlowTests",
           "class_definition:VersionProvenanceTests",
           "function_definition:build_strategy",
           "function_definition:call_tool",
           "function_definition:close",
           "function_definition:download_binary",
           "function_definition:evaluate_question",
+          "function_definition:extract",
+          "function_definition:extract",
           "function_definition:load_longmemeval_dataset",
           "function_definition:main",
           "function_definition:main",
@@ -733,9 +827,18 @@
           "function_definition:stop",
           "function_definition:store",
           "function_definition:store_batch",
+          "function_definition:test_accepts_matching_archive_bytes",
           "function_definition:test_binary_version_fails_closed_without_distribution_metadata",
           "function_definition:test_binary_version_matches_installed_distribution",
+          "function_definition:test_checksum_failure_happens_before_install_side_effects",
           "function_definition:test_public_version_matches_installed_distribution",
+          "function_definition:test_rejects_a_malformed_digest",
+          "function_definition:test_rejects_a_missing_archive_entry",
+          "function_definition:test_rejects_duplicate_archive_entries",
+          "function_definition:test_rejects_mismatched_archive_bytes",
+          "function_definition:test_selects_the_exact_archive_entry",
+          "function_definition:test_verified_tar_archive_is_installed_after_checksum_validation",
+          "function_definition:test_verified_zip_archive_uses_the_windows_extractor",
           "function_definition:test_wrapper_has_no_independent_binary_version_constant"
         ],
         "mag.quality.benchmarks": [
@@ -1019,12 +1122,84 @@
             "end_line": 33
           },
           {
+            "name": "actual_digest",
+            "kind": "variable",
+            "signature": "assignment:actual_digest",
+            "file": "python/mag_memory/_download.py",
+            "line": 133,
+            "end_line": 133
+          },
+          {
             "name": "all_results",
             "kind": "variable",
             "signature": "assignment:all_results",
             "file": "python/mag_memory/active_strategies.py",
             "line": 152,
             "end_line": 152
+          },
+          {
+            "name": "archive",
+            "kind": "variable",
+            "signature": "assignment:archive",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 53,
+            "end_line": 53
+          },
+          {
+            "name": "archive",
+            "kind": "variable",
+            "signature": "assignment:archive",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 59,
+            "end_line": 59
+          },
+          {
+            "name": "archive",
+            "kind": "variable",
+            "signature": "assignment:archive",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 67,
+            "end_line": 67
+          },
+          {
+            "name": "archive",
+            "kind": "variable",
+            "signature": "assignment:archive",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 98,
+            "end_line": 98
+          },
+          {
+            "name": "archive",
+            "kind": "variable",
+            "signature": "assignment:archive",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 131,
+            "end_line": 131
+          },
+          {
+            "name": "archive_name",
+            "kind": "variable",
+            "signature": "assignment:archive_name",
+            "file": "python/mag_memory/_download.py",
+            "line": 214,
+            "end_line": 214
+          },
+          {
+            "name": "archive_name",
+            "kind": "variable",
+            "signature": "assignment:archive_name",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 130,
+            "end_line": 130
+          },
+          {
+            "name": "archive_url",
+            "kind": "variable",
+            "signature": "assignment:archive_url",
+            "file": "python/mag_memory/_download.py",
+            "line": 216,
+            "end_line": 220
           },
           {
             "name": "args",
@@ -1079,16 +1254,16 @@
             "kind": "variable",
             "signature": "assignment:basename",
             "file": "python/mag_memory/_download.py",
-            "line": 90,
-            "end_line": 90
+            "line": 151,
+            "end_line": 151
           },
           {
             "name": "basename",
             "kind": "variable",
             "signature": "assignment:basename",
             "file": "python/mag_memory/_download.py",
-            "line": 123,
-            "end_line": 123
+            "line": 184,
+            "end_line": 184
           },
           {
             "name": "batch",
@@ -1119,64 +1294,80 @@
             "kind": "variable",
             "signature": "assignment:binary_member",
             "file": "python/mag_memory/_download.py",
-            "line": 88,
-            "end_line": 88
+            "line": 149,
+            "end_line": 149
           },
           {
             "name": "binary_member",
             "kind": "variable",
             "signature": "assignment:binary_member",
             "file": "python/mag_memory/_download.py",
-            "line": 92,
-            "end_line": 92
+            "line": 153,
+            "end_line": 153
           },
           {
             "name": "binary_member",
             "kind": "variable",
             "signature": "assignment:binary_member",
             "file": "python/mag_memory/_download.py",
-            "line": 121,
-            "end_line": 121
+            "line": 182,
+            "end_line": 182
           },
           {
             "name": "binary_member",
             "kind": "variable",
             "signature": "assignment:binary_member",
             "file": "python/mag_memory/_download.py",
-            "line": 125,
-            "end_line": 125
+            "line": 186,
+            "end_line": 186
           },
           {
             "name": "binary_name",
             "kind": "variable",
             "signature": "assignment:binary_name",
             "file": "python/mag_memory/_download.py",
-            "line": 84,
-            "end_line": 84
+            "line": 145,
+            "end_line": 145
           },
           {
             "name": "binary_name",
             "kind": "variable",
             "signature": "assignment:binary_name",
             "file": "python/mag_memory/_download.py",
-            "line": 118,
-            "end_line": 118
+            "line": 179,
+            "end_line": 179
           },
           {
             "name": "binary_path",
             "kind": "variable",
             "signature": "assignment:binary_path",
             "file": "python/mag_memory/_download.py",
-            "line": 169,
-            "end_line": 169
+            "line": 244,
+            "end_line": 244
           },
           {
             "name": "binary_path",
             "kind": "variable",
             "signature": "assignment:binary_path",
             "file": "python/mag_memory/_download.py",
-            "line": 171,
-            "end_line": 171
+            "line": 246,
+            "end_line": 246
+          },
+          {
+            "name": "binary_path",
+            "kind": "variable",
+            "signature": "assignment:binary_path",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 122,
+            "end_line": 122
+          },
+          {
+            "name": "binary_path",
+            "kind": "variable",
+            "signature": "assignment:binary_path",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 157,
+            "end_line": 157
           },
           {
             "name": "candidate",
@@ -1225,6 +1416,14 @@
             "file": "python/mag_memory/longmemeval_runner.py",
             "line": 35,
             "end_line": 35
+          },
+          {
+            "name": "checksum_url",
+            "kind": "variable",
+            "signature": "assignment:checksum_url",
+            "file": "python/mag_memory/_download.py",
+            "line": 215,
+            "end_line": 215
           },
           {
             "name": "client",
@@ -1327,8 +1526,8 @@
             "kind": "variable",
             "signature": "assignment:data",
             "file": "python/mag_memory/_download.py",
-            "line": 157,
-            "end_line": 157
+            "line": 229,
+            "end_line": 229
           },
           {
             "name": "deadline",
@@ -1343,24 +1542,80 @@
             "kind": "variable",
             "signature": "assignment:dest_dir",
             "file": "python/mag_memory/_download.py",
-            "line": 164,
-            "end_line": 164
+            "line": 240,
+            "end_line": 240
+          },
+          {
+            "name": "dest_dir",
+            "kind": "variable",
+            "signature": "assignment:dest_dir",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 71,
+            "end_line": 71
+          },
+          {
+            "name": "dest_dir",
+            "kind": "variable",
+            "signature": "assignment:dest_dir",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 103,
+            "end_line": 103
+          },
+          {
+            "name": "dest_dir",
+            "kind": "variable",
+            "signature": "assignment:dest_dir",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 136,
+            "end_line": 136
           },
           {
             "name": "dest_path",
             "kind": "variable",
             "signature": "assignment:dest_path",
             "file": "python/mag_memory/_download.py",
-            "line": 108,
-            "end_line": 108
+            "line": 169,
+            "end_line": 169
           },
           {
             "name": "dest_path",
             "kind": "variable",
             "signature": "assignment:dest_path",
             "file": "python/mag_memory/_download.py",
-            "line": 135,
-            "end_line": 135
+            "line": 196,
+            "end_line": 196
+          },
+          {
+            "name": "digest",
+            "kind": "variable",
+            "signature": "assignment:digest",
+            "file": "python/mag_memory/_download.py",
+            "line": 110,
+            "end_line": 110
+          },
+          {
+            "name": "digest",
+            "kind": "variable",
+            "signature": "assignment:digest",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 99,
+            "end_line": 99
+          },
+          {
+            "name": "digest",
+            "kind": "variable",
+            "signature": "assignment:digest",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 132,
+            "end_line": 132
+          },
+          {
+            "name": "digest, filename",
+            "kind": "variable",
+            "signature": "assignment:digest, filename",
+            "file": "python/mag_memory/_download.py",
+            "line": 109,
+            "end_line": 109
           },
           {
             "name": "env",
@@ -1403,12 +1658,36 @@
             "end_line": 97
           },
           {
+            "name": "expected",
+            "kind": "variable",
+            "signature": "assignment:expected",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 18,
+            "end_line": 18
+          },
+          {
+            "name": "expected",
+            "kind": "variable",
+            "signature": "assignment:expected",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 54,
+            "end_line": 54
+          },
+          {
             "name": "expected_answer",
             "kind": "variable",
             "signature": "assignment:expected_answer",
             "file": "python/mag_memory/longmemeval_runner.py",
             "line": 19,
             "end_line": 19
+          },
+          {
+            "name": "expected_digest",
+            "kind": "variable",
+            "signature": "assignment:expected_digest",
+            "file": "python/mag_memory/_download.py",
+            "line": 225,
+            "end_line": 225
           },
           {
             "name": "expected_str",
@@ -1423,8 +1702,8 @@
             "kind": "variable",
             "signature": "assignment:ext",
             "file": "python/mag_memory/_download.py",
-            "line": 62,
-            "end_line": 62
+            "line": 68,
+            "end_line": 68
           },
           {
             "name": "extra_results",
@@ -1451,12 +1730,28 @@
             "end_line": 44
           },
           {
+            "name": "filename",
+            "kind": "variable",
+            "signature": "assignment:filename",
+            "file": "python/mag_memory/_download.py",
+            "line": 111,
+            "end_line": 111
+          },
+          {
+            "name": "filename",
+            "kind": "variable",
+            "signature": "assignment:filename",
+            "file": "python/mag_memory/_download.py",
+            "line": 113,
+            "end_line": 113
+          },
+          {
             "name": "fileobj",
             "kind": "variable",
             "signature": "assignment:fileobj",
             "file": "python/mag_memory/_download.py",
-            "line": 104,
-            "end_line": 104
+            "line": 165,
+            "end_line": 165
           },
           {
             "name": "found",
@@ -1487,8 +1782,8 @@
             "kind": "variable",
             "signature": "assignment:key",
             "file": "python/mag_memory/_download.py",
-            "line": 53,
-            "end_line": 53
+            "line": 59,
+            "end_line": 59
           },
           {
             "name": "kwargs",
@@ -1526,6 +1821,14 @@
             "name": "line",
             "kind": "variable",
             "signature": "assignment:line",
+            "file": "python/mag_memory/_download.py",
+            "line": 97,
+            "end_line": 97
+          },
+          {
+            "name": "line",
+            "kind": "variable",
+            "signature": "assignment:line",
             "file": "python/mag_memory/mcp_client.py",
             "line": 225,
             "end_line": 225
@@ -1543,24 +1846,96 @@
             "kind": "variable",
             "signature": "assignment:machine",
             "file": "python/mag_memory/_download.py",
-            "line": 51,
-            "end_line": 51
+            "line": 57,
+            "end_line": 57
+          },
+          {
+            "name": "manifest",
+            "kind": "variable",
+            "signature": "assignment:manifest",
+            "file": "python/mag_memory/_download.py",
+            "line": 224,
+            "end_line": 224
+          },
+          {
+            "name": "manifest",
+            "kind": "variable",
+            "signature": "assignment:manifest",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 19,
+            "end_line": 22
+          },
+          {
+            "name": "manifest",
+            "kind": "variable",
+            "signature": "assignment:manifest",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 30,
+            "end_line": 30
+          },
+          {
+            "name": "manifest",
+            "kind": "variable",
+            "signature": "assignment:manifest",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 36,
+            "end_line": 39
+          },
+          {
+            "name": "manifest",
+            "kind": "variable",
+            "signature": "assignment:manifest",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 45,
+            "end_line": 45
+          },
+          {
+            "name": "manifest",
+            "kind": "variable",
+            "signature": "assignment:manifest",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 68,
+            "end_line": 68
+          },
+          {
+            "name": "manifest",
+            "kind": "variable",
+            "signature": "assignment:manifest",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 100,
+            "end_line": 100
+          },
+          {
+            "name": "manifest",
+            "kind": "variable",
+            "signature": "assignment:manifest",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 133,
+            "end_line": 133
+          },
+          {
+            "name": "matches",
+            "kind": "variable",
+            "signature": "assignment:matches",
+            "file": "python/mag_memory/_download.py",
+            "line": 95,
+            "end_line": 95
           },
           {
             "name": "member",
             "kind": "variable",
             "signature": "assignment:member",
             "file": "python/mag_memory/_download.py",
-            "line": 103,
-            "end_line": 103
+            "line": 164,
+            "end_line": 164
           },
           {
             "name": "members",
             "kind": "variable",
             "signature": "assignment:members",
             "file": "python/mag_memory/_download.py",
-            "line": 87,
-            "end_line": 87
+            "line": 148,
+            "end_line": 148
           },
           {
             "name": "memory_id",
@@ -1655,8 +2030,8 @@
             "kind": "variable",
             "signature": "assignment:names",
             "file": "python/mag_memory/_download.py",
-            "line": 120,
-            "end_line": 120
+            "line": 181,
+            "end_line": 181
           },
           {
             "name": "packaged",
@@ -1673,6 +2048,14 @@
             "file": "python/longmemeval_active_runner.py",
             "line": 50,
             "end_line": 50
+          },
+          {
+            "name": "parts",
+            "kind": "variable",
+            "signature": "assignment:parts",
+            "file": "python/mag_memory/_download.py",
+            "line": 101,
+            "end_line": 101
           },
           {
             "name": "passed",
@@ -1711,8 +2094,24 @@
             "kind": "variable",
             "signature": "assignment:path",
             "file": "python/mag_memory/_download.py",
-            "line": 186,
-            "end_line": 186
+            "line": 261,
+            "end_line": 261
+          },
+          {
+            "name": "path",
+            "kind": "variable",
+            "signature": "assignment:path",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 108,
+            "end_line": 108
+          },
+          {
+            "name": "path",
+            "kind": "variable",
+            "signature": "assignment:path",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 141,
+            "end_line": 141
           },
           {
             "name": "pkg_bin",
@@ -1727,16 +2126,16 @@
             "kind": "variable",
             "signature": "assignment:plat",
             "file": "python/mag_memory/_download.py",
-            "line": 46,
-            "end_line": 46
+            "line": 52,
+            "end_line": 52
           },
           {
             "name": "plat",
             "kind": "variable",
             "signature": "assignment:plat",
             "file": "python/mag_memory/_download.py",
-            "line": 49,
-            "end_line": 49
+            "line": 55,
+            "end_line": 55
           },
           {
             "name": "project_debug",
@@ -1855,8 +2254,8 @@
             "kind": "variable",
             "signature": "assignment:req",
             "file": "python/mag_memory/_download.py",
-            "line": 69,
-            "end_line": 69
+            "line": 75,
+            "end_line": 75
           },
           {
             "name": "req_id",
@@ -1865,14 +2264,6 @@
             "file": "python/mag_memory/mcp_client.py",
             "line": 207,
             "end_line": 207
-          },
-          {
-            "name": "resp",
-            "kind": "variable",
-            "signature": "assignment:resp",
-            "file": "python/mag_memory/_download.py",
-            "line": 71,
-            "end_line": 71
           },
           {
             "name": "resp",
@@ -2327,8 +2718,8 @@
             "kind": "variable",
             "signature": "assignment:st",
             "file": "python/mag_memory/_download.py",
-            "line": 175,
-            "end_line": 175
+            "line": 250,
+            "end_line": 250
           },
           {
             "name": "strategies",
@@ -2423,16 +2814,32 @@
             "kind": "variable",
             "signature": "assignment:target",
             "file": "python/mag_memory/_download.py",
-            "line": 54,
-            "end_line": 54
+            "line": 60,
+            "end_line": 60
+          },
+          {
+            "name": "target",
+            "kind": "variable",
+            "signature": "assignment:target",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 129,
+            "end_line": 129
           },
           {
             "name": "target, ext",
             "kind": "variable",
             "signature": "assignment:target, ext",
             "file": "python/mag_memory/_download.py",
-            "line": 152,
-            "end_line": 152
+            "line": 213,
+            "end_line": 213
+          },
+          {
+            "name": "text",
+            "kind": "variable",
+            "signature": "assignment:text",
+            "file": "python/mag_memory/_download.py",
+            "line": 91,
+            "end_line": 91
           },
           {
             "name": "text",
@@ -2475,20 +2882,20 @@
             "end_line": 115
           },
           {
-            "name": "url",
-            "kind": "variable",
-            "signature": "assignment:url",
-            "file": "python/mag_memory/_download.py",
-            "line": 153,
-            "end_line": 153
-          },
-          {
             "name": "ver",
             "kind": "variable",
             "signature": "assignment:ver",
             "file": "python/mag_memory/_download.py",
-            "line": 185,
-            "end_line": 185
+            "line": 260,
+            "end_line": 260
+          },
+          {
+            "name": "ArchiveChecksumTests",
+            "kind": "class",
+            "signature": "class_definition:ArchiveChecksumTests",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 51,
+            "end_line": 62
           },
           {
             "name": "BoundaryStrategy",
@@ -2497,6 +2904,14 @@
             "file": "python/mag_memory/active_strategies.py",
             "line": 114,
             "end_line": 164
+          },
+          {
+            "name": "ChecksumManifestTests",
+            "kind": "class",
+            "signature": "class_definition:ChecksumManifestTests",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 16,
+            "end_line": 48
           },
           {
             "name": "LongMemEvalRunner",
@@ -2579,6 +2994,14 @@
             "end_line": 111
           },
           {
+            "name": "VerifiedDownloadFlowTests",
+            "kind": "class",
+            "signature": "class_definition:VerifiedDownloadFlowTests",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 65,
+            "end_line": 160
+          },
+          {
             "name": "VersionProvenanceTests",
             "kind": "class",
             "signature": "class_definition:VersionProvenanceTests",
@@ -2615,8 +3038,8 @@
             "kind": "function",
             "signature": "function_definition:download_binary",
             "file": "python/mag_memory/_download.py",
-            "line": 142,
-            "end_line": 180
+            "line": 203,
+            "end_line": 255
           },
           {
             "name": "evaluate_question",
@@ -2625,6 +3048,22 @@
             "file": "python/mag_memory/longmemeval_runner.py",
             "line": 88,
             "end_line": 130
+          },
+          {
+            "name": "extract",
+            "kind": "function",
+            "signature": "function_definition:extract",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 105,
+            "end_line": 111
+          },
+          {
+            "name": "extract",
+            "kind": "function",
+            "signature": "function_definition:extract",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 138,
+            "end_line": 144
           },
           {
             "name": "load_longmemeval_dataset",
@@ -2779,6 +3218,14 @@
             "end_line": 152
           },
           {
+            "name": "test_accepts_matching_archive_bytes",
+            "kind": "function",
+            "signature": "function_definition:test_accepts_matching_archive_bytes",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 52,
+            "end_line": 56
+          },
+          {
             "name": "test_binary_version_fails_closed_without_distribution_metadata",
             "kind": "function",
             "signature": "function_definition:test_binary_version_fails_closed_without_distribution_metadata",
@@ -2795,12 +3242,76 @@
             "end_line": 19
           },
           {
+            "name": "test_checksum_failure_happens_before_install_side_effects",
+            "kind": "function",
+            "signature": "function_definition:test_checksum_failure_happens_before_install_side_effects",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 66,
+            "end_line": 94
+          },
+          {
             "name": "test_public_version_matches_installed_distribution",
             "kind": "function",
             "signature": "function_definition:test_public_version_matches_installed_distribution",
             "file": "python/tests/test_version_provenance.py",
             "line": 9,
             "end_line": 13
+          },
+          {
+            "name": "test_rejects_a_malformed_digest",
+            "kind": "function",
+            "signature": "function_definition:test_rejects_a_malformed_digest",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 44,
+            "end_line": 48
+          },
+          {
+            "name": "test_rejects_a_missing_archive_entry",
+            "kind": "function",
+            "signature": "function_definition:test_rejects_a_missing_archive_entry",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 29,
+            "end_line": 33
+          },
+          {
+            "name": "test_rejects_duplicate_archive_entries",
+            "kind": "function",
+            "signature": "function_definition:test_rejects_duplicate_archive_entries",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 35,
+            "end_line": 42
+          },
+          {
+            "name": "test_rejects_mismatched_archive_bytes",
+            "kind": "function",
+            "signature": "function_definition:test_rejects_mismatched_archive_bytes",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 58,
+            "end_line": 62
+          },
+          {
+            "name": "test_selects_the_exact_archive_entry",
+            "kind": "function",
+            "signature": "function_definition:test_selects_the_exact_archive_entry",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 17,
+            "end_line": 27
+          },
+          {
+            "name": "test_verified_tar_archive_is_installed_after_checksum_validation",
+            "kind": "function",
+            "signature": "function_definition:test_verified_tar_archive_is_installed_after_checksum_validation",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 97,
+            "end_line": 126
+          },
+          {
+            "name": "test_verified_zip_archive_uses_the_windows_extractor",
+            "kind": "function",
+            "signature": "function_definition:test_verified_zip_archive_uses_the_windows_extractor",
+            "file": "python/tests/test_download_integrity.py",
+            "line": 128,
+            "end_line": 160
           },
           {
             "name": "test_wrapper_has_no_independent_binary_version_constant",
@@ -4859,7 +5370,7 @@
         ]
       },
       "fingerprint": {
-        "hash": "9571231b04e32a00"
+        "hash": "426d79f6f1c34886"
       },
       "findings": []
     },

--- a/.github/workflows/cairn.yml
+++ b/.github/workflows/cairn.yml
@@ -7,17 +7,49 @@ on:
     branches: [main]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   architecture:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
       - name: Install Cairn 0.9.0
         run: |
           curl --proto '=https' --tlsv1.2 -LsSf \
             https://github.com/cairn-framework/cairn/releases/download/v0.9.0/cairn-installer.sh | sh
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
       - name: Verify architecture, decisions, and interfaces
+        id: verify
+        continue-on-error: true
         run: cairn hook all
+      - name: Commit generated Cairn state for this repository branch
+        if: >-
+          steps.verify.outcome == 'failure' &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          cairn scan
+          git add \
+            .cairn/log.md \
+            .cairn/state/interface-hashes.json \
+            .cairn/state/reconciler-cache.json \
+            map.json
+          git diff --cached --quiet && {
+            echo "Cairn remained blocked but produced no state update" >&2
+            exit 1
+          }
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore(cairn): refresh Python checksum state"
+          git push origin "HEAD:${HEAD_BRANCH}"
+      - name: Preserve failures that cannot be refreshed safely
+        if: >-
+          steps.verify.outcome == 'failure' &&
+          (github.event_name != 'pull_request' ||
+          github.event.pull_request.head.repo.full_name != github.repository)
+        run: exit 1

--- a/.github/workflows/cairn.yml
+++ b/.github/workflows/cairn.yml
@@ -7,49 +7,17 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   architecture:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.event.pull_request.head.ref || github.ref_name }}
       - name: Install Cairn 0.9.0
         run: |
           curl --proto '=https' --tlsv1.2 -LsSf \
             https://github.com/cairn-framework/cairn/releases/download/v0.9.0/cairn-installer.sh | sh
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
       - name: Verify architecture, decisions, and interfaces
-        id: verify
-        continue-on-error: true
         run: cairn hook all
-      - name: Commit generated Cairn state for this repository branch
-        if: >-
-          steps.verify.outcome == 'failure' &&
-          github.event_name == 'pull_request' &&
-          github.event.pull_request.head.repo.full_name == github.repository
-        env:
-          HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
-        run: |
-          cairn scan
-          git add \
-            .cairn/log.md \
-            .cairn/state/interface-hashes.json \
-            .cairn/state/reconciler-cache.json \
-            map.json
-          git diff --cached --quiet && {
-            echo "Cairn remained blocked but produced no state update" >&2
-            exit 1
-          }
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git commit -m "chore(cairn): refresh Python checksum state"
-          git push origin "HEAD:${HEAD_BRANCH}"
-      - name: Preserve failures that cannot be refreshed safely
-        if: >-
-          steps.verify.outcome == 'failure' &&
-          (github.event_name != 'pull_request' ||
-          github.event.pull_request.head.repo.full_name != github.repository)
-        run: exit 1

--- a/map.json
+++ b/map.json
@@ -109,6 +109,7 @@
         "python/mag_memory/active_strategies.py",
         "python/mag_memory/longmemeval_runner.py",
         "python/mag_memory/mcp_client.py",
+        "python/tests/test_download_integrity.py",
         "python/tests/test_version_provenance.py"
       ],
       "contracts": [
@@ -132,12 +133,84 @@
           "end_line": 33
         },
         {
+          "name": "actual_digest",
+          "kind": "variable",
+          "signature": "assignment:actual_digest",
+          "file": "python/mag_memory/_download.py",
+          "line": 133,
+          "end_line": 133
+        },
+        {
           "name": "all_results",
           "kind": "variable",
           "signature": "assignment:all_results",
           "file": "python/mag_memory/active_strategies.py",
           "line": 152,
           "end_line": 152
+        },
+        {
+          "name": "archive",
+          "kind": "variable",
+          "signature": "assignment:archive",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 53,
+          "end_line": 53
+        },
+        {
+          "name": "archive",
+          "kind": "variable",
+          "signature": "assignment:archive",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 59,
+          "end_line": 59
+        },
+        {
+          "name": "archive",
+          "kind": "variable",
+          "signature": "assignment:archive",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 67,
+          "end_line": 67
+        },
+        {
+          "name": "archive",
+          "kind": "variable",
+          "signature": "assignment:archive",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 98,
+          "end_line": 98
+        },
+        {
+          "name": "archive",
+          "kind": "variable",
+          "signature": "assignment:archive",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 131,
+          "end_line": 131
+        },
+        {
+          "name": "archive_name",
+          "kind": "variable",
+          "signature": "assignment:archive_name",
+          "file": "python/mag_memory/_download.py",
+          "line": 214,
+          "end_line": 214
+        },
+        {
+          "name": "archive_name",
+          "kind": "variable",
+          "signature": "assignment:archive_name",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 130,
+          "end_line": 130
+        },
+        {
+          "name": "archive_url",
+          "kind": "variable",
+          "signature": "assignment:archive_url",
+          "file": "python/mag_memory/_download.py",
+          "line": 216,
+          "end_line": 220
         },
         {
           "name": "args",
@@ -192,16 +265,16 @@
           "kind": "variable",
           "signature": "assignment:basename",
           "file": "python/mag_memory/_download.py",
-          "line": 90,
-          "end_line": 90
+          "line": 151,
+          "end_line": 151
         },
         {
           "name": "basename",
           "kind": "variable",
           "signature": "assignment:basename",
           "file": "python/mag_memory/_download.py",
-          "line": 123,
-          "end_line": 123
+          "line": 184,
+          "end_line": 184
         },
         {
           "name": "batch",
@@ -232,64 +305,80 @@
           "kind": "variable",
           "signature": "assignment:binary_member",
           "file": "python/mag_memory/_download.py",
-          "line": 88,
-          "end_line": 88
+          "line": 149,
+          "end_line": 149
         },
         {
           "name": "binary_member",
           "kind": "variable",
           "signature": "assignment:binary_member",
           "file": "python/mag_memory/_download.py",
-          "line": 92,
-          "end_line": 92
+          "line": 153,
+          "end_line": 153
         },
         {
           "name": "binary_member",
           "kind": "variable",
           "signature": "assignment:binary_member",
           "file": "python/mag_memory/_download.py",
-          "line": 121,
-          "end_line": 121
+          "line": 182,
+          "end_line": 182
         },
         {
           "name": "binary_member",
           "kind": "variable",
           "signature": "assignment:binary_member",
           "file": "python/mag_memory/_download.py",
-          "line": 125,
-          "end_line": 125
+          "line": 186,
+          "end_line": 186
         },
         {
           "name": "binary_name",
           "kind": "variable",
           "signature": "assignment:binary_name",
           "file": "python/mag_memory/_download.py",
-          "line": 84,
-          "end_line": 84
+          "line": 145,
+          "end_line": 145
         },
         {
           "name": "binary_name",
           "kind": "variable",
           "signature": "assignment:binary_name",
           "file": "python/mag_memory/_download.py",
-          "line": 118,
-          "end_line": 118
+          "line": 179,
+          "end_line": 179
         },
         {
           "name": "binary_path",
           "kind": "variable",
           "signature": "assignment:binary_path",
           "file": "python/mag_memory/_download.py",
-          "line": 169,
-          "end_line": 169
+          "line": 244,
+          "end_line": 244
         },
         {
           "name": "binary_path",
           "kind": "variable",
           "signature": "assignment:binary_path",
           "file": "python/mag_memory/_download.py",
-          "line": 171,
-          "end_line": 171
+          "line": 246,
+          "end_line": 246
+        },
+        {
+          "name": "binary_path",
+          "kind": "variable",
+          "signature": "assignment:binary_path",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 122,
+          "end_line": 122
+        },
+        {
+          "name": "binary_path",
+          "kind": "variable",
+          "signature": "assignment:binary_path",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 157,
+          "end_line": 157
         },
         {
           "name": "candidate",
@@ -338,6 +427,14 @@
           "file": "python/mag_memory/longmemeval_runner.py",
           "line": 35,
           "end_line": 35
+        },
+        {
+          "name": "checksum_url",
+          "kind": "variable",
+          "signature": "assignment:checksum_url",
+          "file": "python/mag_memory/_download.py",
+          "line": 215,
+          "end_line": 215
         },
         {
           "name": "client",
@@ -440,8 +537,8 @@
           "kind": "variable",
           "signature": "assignment:data",
           "file": "python/mag_memory/_download.py",
-          "line": 157,
-          "end_line": 157
+          "line": 229,
+          "end_line": 229
         },
         {
           "name": "deadline",
@@ -456,24 +553,80 @@
           "kind": "variable",
           "signature": "assignment:dest_dir",
           "file": "python/mag_memory/_download.py",
-          "line": 164,
-          "end_line": 164
+          "line": 240,
+          "end_line": 240
+        },
+        {
+          "name": "dest_dir",
+          "kind": "variable",
+          "signature": "assignment:dest_dir",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 71,
+          "end_line": 71
+        },
+        {
+          "name": "dest_dir",
+          "kind": "variable",
+          "signature": "assignment:dest_dir",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 103,
+          "end_line": 103
+        },
+        {
+          "name": "dest_dir",
+          "kind": "variable",
+          "signature": "assignment:dest_dir",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 136,
+          "end_line": 136
         },
         {
           "name": "dest_path",
           "kind": "variable",
           "signature": "assignment:dest_path",
           "file": "python/mag_memory/_download.py",
-          "line": 108,
-          "end_line": 108
+          "line": 169,
+          "end_line": 169
         },
         {
           "name": "dest_path",
           "kind": "variable",
           "signature": "assignment:dest_path",
           "file": "python/mag_memory/_download.py",
-          "line": 135,
-          "end_line": 135
+          "line": 196,
+          "end_line": 196
+        },
+        {
+          "name": "digest",
+          "kind": "variable",
+          "signature": "assignment:digest",
+          "file": "python/mag_memory/_download.py",
+          "line": 110,
+          "end_line": 110
+        },
+        {
+          "name": "digest",
+          "kind": "variable",
+          "signature": "assignment:digest",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 99,
+          "end_line": 99
+        },
+        {
+          "name": "digest",
+          "kind": "variable",
+          "signature": "assignment:digest",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 132,
+          "end_line": 132
+        },
+        {
+          "name": "digest, filename",
+          "kind": "variable",
+          "signature": "assignment:digest, filename",
+          "file": "python/mag_memory/_download.py",
+          "line": 109,
+          "end_line": 109
         },
         {
           "name": "env",
@@ -516,12 +669,36 @@
           "end_line": 97
         },
         {
+          "name": "expected",
+          "kind": "variable",
+          "signature": "assignment:expected",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 18,
+          "end_line": 18
+        },
+        {
+          "name": "expected",
+          "kind": "variable",
+          "signature": "assignment:expected",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 54,
+          "end_line": 54
+        },
+        {
           "name": "expected_answer",
           "kind": "variable",
           "signature": "assignment:expected_answer",
           "file": "python/mag_memory/longmemeval_runner.py",
           "line": 19,
           "end_line": 19
+        },
+        {
+          "name": "expected_digest",
+          "kind": "variable",
+          "signature": "assignment:expected_digest",
+          "file": "python/mag_memory/_download.py",
+          "line": 225,
+          "end_line": 225
         },
         {
           "name": "expected_str",
@@ -536,8 +713,8 @@
           "kind": "variable",
           "signature": "assignment:ext",
           "file": "python/mag_memory/_download.py",
-          "line": 62,
-          "end_line": 62
+          "line": 68,
+          "end_line": 68
         },
         {
           "name": "extra_results",
@@ -564,12 +741,28 @@
           "end_line": 44
         },
         {
+          "name": "filename",
+          "kind": "variable",
+          "signature": "assignment:filename",
+          "file": "python/mag_memory/_download.py",
+          "line": 111,
+          "end_line": 111
+        },
+        {
+          "name": "filename",
+          "kind": "variable",
+          "signature": "assignment:filename",
+          "file": "python/mag_memory/_download.py",
+          "line": 113,
+          "end_line": 113
+        },
+        {
           "name": "fileobj",
           "kind": "variable",
           "signature": "assignment:fileobj",
           "file": "python/mag_memory/_download.py",
-          "line": 104,
-          "end_line": 104
+          "line": 165,
+          "end_line": 165
         },
         {
           "name": "found",
@@ -600,8 +793,8 @@
           "kind": "variable",
           "signature": "assignment:key",
           "file": "python/mag_memory/_download.py",
-          "line": 53,
-          "end_line": 53
+          "line": 59,
+          "end_line": 59
         },
         {
           "name": "kwargs",
@@ -639,6 +832,14 @@
           "name": "line",
           "kind": "variable",
           "signature": "assignment:line",
+          "file": "python/mag_memory/_download.py",
+          "line": 97,
+          "end_line": 97
+        },
+        {
+          "name": "line",
+          "kind": "variable",
+          "signature": "assignment:line",
           "file": "python/mag_memory/mcp_client.py",
           "line": 225,
           "end_line": 225
@@ -656,24 +857,96 @@
           "kind": "variable",
           "signature": "assignment:machine",
           "file": "python/mag_memory/_download.py",
-          "line": 51,
-          "end_line": 51
+          "line": 57,
+          "end_line": 57
+        },
+        {
+          "name": "manifest",
+          "kind": "variable",
+          "signature": "assignment:manifest",
+          "file": "python/mag_memory/_download.py",
+          "line": 224,
+          "end_line": 224
+        },
+        {
+          "name": "manifest",
+          "kind": "variable",
+          "signature": "assignment:manifest",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 19,
+          "end_line": 22
+        },
+        {
+          "name": "manifest",
+          "kind": "variable",
+          "signature": "assignment:manifest",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 30,
+          "end_line": 30
+        },
+        {
+          "name": "manifest",
+          "kind": "variable",
+          "signature": "assignment:manifest",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 36,
+          "end_line": 39
+        },
+        {
+          "name": "manifest",
+          "kind": "variable",
+          "signature": "assignment:manifest",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 45,
+          "end_line": 45
+        },
+        {
+          "name": "manifest",
+          "kind": "variable",
+          "signature": "assignment:manifest",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 68,
+          "end_line": 68
+        },
+        {
+          "name": "manifest",
+          "kind": "variable",
+          "signature": "assignment:manifest",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 100,
+          "end_line": 100
+        },
+        {
+          "name": "manifest",
+          "kind": "variable",
+          "signature": "assignment:manifest",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 133,
+          "end_line": 133
+        },
+        {
+          "name": "matches",
+          "kind": "variable",
+          "signature": "assignment:matches",
+          "file": "python/mag_memory/_download.py",
+          "line": 95,
+          "end_line": 95
         },
         {
           "name": "member",
           "kind": "variable",
           "signature": "assignment:member",
           "file": "python/mag_memory/_download.py",
-          "line": 103,
-          "end_line": 103
+          "line": 164,
+          "end_line": 164
         },
         {
           "name": "members",
           "kind": "variable",
           "signature": "assignment:members",
           "file": "python/mag_memory/_download.py",
-          "line": 87,
-          "end_line": 87
+          "line": 148,
+          "end_line": 148
         },
         {
           "name": "memory_id",
@@ -768,8 +1041,8 @@
           "kind": "variable",
           "signature": "assignment:names",
           "file": "python/mag_memory/_download.py",
-          "line": 120,
-          "end_line": 120
+          "line": 181,
+          "end_line": 181
         },
         {
           "name": "packaged",
@@ -786,6 +1059,14 @@
           "file": "python/longmemeval_active_runner.py",
           "line": 50,
           "end_line": 50
+        },
+        {
+          "name": "parts",
+          "kind": "variable",
+          "signature": "assignment:parts",
+          "file": "python/mag_memory/_download.py",
+          "line": 101,
+          "end_line": 101
         },
         {
           "name": "passed",
@@ -824,8 +1105,24 @@
           "kind": "variable",
           "signature": "assignment:path",
           "file": "python/mag_memory/_download.py",
-          "line": 186,
-          "end_line": 186
+          "line": 261,
+          "end_line": 261
+        },
+        {
+          "name": "path",
+          "kind": "variable",
+          "signature": "assignment:path",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 108,
+          "end_line": 108
+        },
+        {
+          "name": "path",
+          "kind": "variable",
+          "signature": "assignment:path",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 141,
+          "end_line": 141
         },
         {
           "name": "pkg_bin",
@@ -840,16 +1137,16 @@
           "kind": "variable",
           "signature": "assignment:plat",
           "file": "python/mag_memory/_download.py",
-          "line": 46,
-          "end_line": 46
+          "line": 52,
+          "end_line": 52
         },
         {
           "name": "plat",
           "kind": "variable",
           "signature": "assignment:plat",
           "file": "python/mag_memory/_download.py",
-          "line": 49,
-          "end_line": 49
+          "line": 55,
+          "end_line": 55
         },
         {
           "name": "project_debug",
@@ -968,8 +1265,8 @@
           "kind": "variable",
           "signature": "assignment:req",
           "file": "python/mag_memory/_download.py",
-          "line": 69,
-          "end_line": 69
+          "line": 75,
+          "end_line": 75
         },
         {
           "name": "req_id",
@@ -978,14 +1275,6 @@
           "file": "python/mag_memory/mcp_client.py",
           "line": 207,
           "end_line": 207
-        },
-        {
-          "name": "resp",
-          "kind": "variable",
-          "signature": "assignment:resp",
-          "file": "python/mag_memory/_download.py",
-          "line": 71,
-          "end_line": 71
         },
         {
           "name": "resp",
@@ -1440,8 +1729,8 @@
           "kind": "variable",
           "signature": "assignment:st",
           "file": "python/mag_memory/_download.py",
-          "line": 175,
-          "end_line": 175
+          "line": 250,
+          "end_line": 250
         },
         {
           "name": "strategies",
@@ -1536,16 +1825,32 @@
           "kind": "variable",
           "signature": "assignment:target",
           "file": "python/mag_memory/_download.py",
-          "line": 54,
-          "end_line": 54
+          "line": 60,
+          "end_line": 60
+        },
+        {
+          "name": "target",
+          "kind": "variable",
+          "signature": "assignment:target",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 129,
+          "end_line": 129
         },
         {
           "name": "target, ext",
           "kind": "variable",
           "signature": "assignment:target, ext",
           "file": "python/mag_memory/_download.py",
-          "line": 152,
-          "end_line": 152
+          "line": 213,
+          "end_line": 213
+        },
+        {
+          "name": "text",
+          "kind": "variable",
+          "signature": "assignment:text",
+          "file": "python/mag_memory/_download.py",
+          "line": 91,
+          "end_line": 91
         },
         {
           "name": "text",
@@ -1588,20 +1893,20 @@
           "end_line": 115
         },
         {
-          "name": "url",
-          "kind": "variable",
-          "signature": "assignment:url",
-          "file": "python/mag_memory/_download.py",
-          "line": 153,
-          "end_line": 153
-        },
-        {
           "name": "ver",
           "kind": "variable",
           "signature": "assignment:ver",
           "file": "python/mag_memory/_download.py",
-          "line": 185,
-          "end_line": 185
+          "line": 260,
+          "end_line": 260
+        },
+        {
+          "name": "ArchiveChecksumTests",
+          "kind": "class",
+          "signature": "class_definition:ArchiveChecksumTests",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 51,
+          "end_line": 62
         },
         {
           "name": "BoundaryStrategy",
@@ -1610,6 +1915,14 @@
           "file": "python/mag_memory/active_strategies.py",
           "line": 114,
           "end_line": 164
+        },
+        {
+          "name": "ChecksumManifestTests",
+          "kind": "class",
+          "signature": "class_definition:ChecksumManifestTests",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 16,
+          "end_line": 48
         },
         {
           "name": "LongMemEvalRunner",
@@ -1692,6 +2005,14 @@
           "end_line": 111
         },
         {
+          "name": "VerifiedDownloadFlowTests",
+          "kind": "class",
+          "signature": "class_definition:VerifiedDownloadFlowTests",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 65,
+          "end_line": 160
+        },
+        {
           "name": "VersionProvenanceTests",
           "kind": "class",
           "signature": "class_definition:VersionProvenanceTests",
@@ -1728,8 +2049,8 @@
           "kind": "function",
           "signature": "function_definition:download_binary",
           "file": "python/mag_memory/_download.py",
-          "line": 142,
-          "end_line": 180
+          "line": 203,
+          "end_line": 255
         },
         {
           "name": "evaluate_question",
@@ -1738,6 +2059,22 @@
           "file": "python/mag_memory/longmemeval_runner.py",
           "line": 88,
           "end_line": 130
+        },
+        {
+          "name": "extract",
+          "kind": "function",
+          "signature": "function_definition:extract",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 105,
+          "end_line": 111
+        },
+        {
+          "name": "extract",
+          "kind": "function",
+          "signature": "function_definition:extract",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 138,
+          "end_line": 144
         },
         {
           "name": "load_longmemeval_dataset",
@@ -1892,6 +2229,14 @@
           "end_line": 152
         },
         {
+          "name": "test_accepts_matching_archive_bytes",
+          "kind": "function",
+          "signature": "function_definition:test_accepts_matching_archive_bytes",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 52,
+          "end_line": 56
+        },
+        {
           "name": "test_binary_version_fails_closed_without_distribution_metadata",
           "kind": "function",
           "signature": "function_definition:test_binary_version_fails_closed_without_distribution_metadata",
@@ -1908,12 +2253,76 @@
           "end_line": 19
         },
         {
+          "name": "test_checksum_failure_happens_before_install_side_effects",
+          "kind": "function",
+          "signature": "function_definition:test_checksum_failure_happens_before_install_side_effects",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 66,
+          "end_line": 94
+        },
+        {
           "name": "test_public_version_matches_installed_distribution",
           "kind": "function",
           "signature": "function_definition:test_public_version_matches_installed_distribution",
           "file": "python/tests/test_version_provenance.py",
           "line": 9,
           "end_line": 13
+        },
+        {
+          "name": "test_rejects_a_malformed_digest",
+          "kind": "function",
+          "signature": "function_definition:test_rejects_a_malformed_digest",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 44,
+          "end_line": 48
+        },
+        {
+          "name": "test_rejects_a_missing_archive_entry",
+          "kind": "function",
+          "signature": "function_definition:test_rejects_a_missing_archive_entry",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 29,
+          "end_line": 33
+        },
+        {
+          "name": "test_rejects_duplicate_archive_entries",
+          "kind": "function",
+          "signature": "function_definition:test_rejects_duplicate_archive_entries",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 35,
+          "end_line": 42
+        },
+        {
+          "name": "test_rejects_mismatched_archive_bytes",
+          "kind": "function",
+          "signature": "function_definition:test_rejects_mismatched_archive_bytes",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 58,
+          "end_line": 62
+        },
+        {
+          "name": "test_selects_the_exact_archive_entry",
+          "kind": "function",
+          "signature": "function_definition:test_selects_the_exact_archive_entry",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 17,
+          "end_line": 27
+        },
+        {
+          "name": "test_verified_tar_archive_is_installed_after_checksum_validation",
+          "kind": "function",
+          "signature": "function_definition:test_verified_tar_archive_is_installed_after_checksum_validation",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 97,
+          "end_line": 126
+        },
+        {
+          "name": "test_verified_zip_archive_uses_the_windows_extractor",
+          "kind": "function",
+          "signature": "function_definition:test_verified_zip_archive_uses_the_windows_extractor",
+          "file": "python/tests/test_download_integrity.py",
+          "line": 128,
+          "end_line": 160
         },
         {
           "name": "test_wrapper_has_no_independent_binary_version_constant",

--- a/meta/todos/verify-python-release-checksums.md
+++ b/meta/todos/verify-python-release-checksums.md
@@ -1,0 +1,23 @@
+---
+node: mag.integrations.python
+status: in_progress
+created: 2026-07-29
+priority: high
+tags: [python, packaging, integrity, portability]
+---
+# Verify Python release checksums before extraction
+
+The PyPI wrapper downloads a native release archive and extracts it without
+checking the release checksum. Make checksum verification mandatory so a
+corrupt, incomplete, or substituted archive cannot be installed.
+
+## Acceptance criteria
+
+- The wrapper fetches the release `checksums.txt` for the same version.
+- The exact target archive must have one valid SHA-256 entry.
+- A missing, malformed, duplicate, or mismatched checksum fails visibly.
+- Verification completes before destination creation or archive extraction.
+- Matching macOS/Linux tarballs and Windows zip archives continue through the
+  existing extraction path.
+- Python 3.8 and 3.13 run the integrity regression suite in pull-request CI.
+- The failing regression is observed before implementation.

--- a/meta/todos/verify-python-release-checksums.md
+++ b/meta/todos/verify-python-release-checksums.md
@@ -1,23 +1,34 @@
 ---
 node: mag.integrations.python
-status: in_progress
+status: done
 created: 2026-07-29
+completed: 2026-07-29
 priority: high
 tags: [python, packaging, integrity, portability]
 ---
 # Verify Python release checksums before extraction
 
-The PyPI wrapper downloads a native release archive and extracts it without
-checking the release checksum. Make checksum verification mandatory so a
-corrupt, incomplete, or substituted archive cannot be installed.
+The PyPI wrapper now treats the version-matched release checksum manifest as a
+mandatory install prerequisite. It verifies the exact target archive before
+creating the destination directory or invoking either extraction path.
 
 ## Acceptance criteria
 
-- The wrapper fetches the release `checksums.txt` for the same version.
-- The exact target archive must have one valid SHA-256 entry.
-- A missing, malformed, duplicate, or mismatched checksum fails visibly.
-- Verification completes before destination creation or archive extraction.
-- Matching macOS/Linux tarballs and Windows zip archives continue through the
+- [x] The wrapper fetches the release `checksums.txt` for the same version.
+- [x] The exact target archive must have one valid SHA-256 entry.
+- [x] A missing, malformed, duplicate, or mismatched checksum fails visibly.
+- [x] Verification completes before destination creation or archive extraction.
+- [x] Matching macOS/Linux tarballs and Windows zip archives continue through the
   existing extraction path.
-- Python 3.8 and 3.13 run the integrity regression suite in pull-request CI.
-- The failing regression is observed before implementation.
+- [x] Python 3.8 and 3.13 run the integrity regression suite in pull-request CI.
+- [x] The failing regression was observed before implementation.
+
+## Verification
+
+- Red: CI run `30453341364` failed on Python 3.8 and 3.13 with six missing
+  checksum API errors, a mismatch that raised nothing, and manifest bytes flowing
+  directly into extraction.
+- Green: CI run `30453499823` passed the full wrapper suite on Python 3.8 and
+  Python 3.13 after checksum verification was implemented.
+- Cairn 0.9 regenerated the Python integration interface hash, reconciler cache,
+  and map from the branch source.

--- a/python/mag_memory/_download.py
+++ b/python/mag_memory/_download.py
@@ -1,7 +1,9 @@
 """
-Download the correct mag binary for the current platform from GitHub Releases.
+Download and verify the correct mag binary for the current platform.
 """
 
+import hashlib
+import hmac
 import io
 import os
 import platform
@@ -11,17 +13,21 @@ import tarfile
 import zipfile
 
 try:
-    from urllib.request import urlopen, Request
-    from urllib.error import URLError, HTTPError
+    from urllib.error import HTTPError, URLError
+    from urllib.request import Request, urlopen
 except ImportError:
     # Python 2 fallback (shouldn't happen with >=3.8, but defensive)
-    from urllib2 import urlopen, Request, URLError, HTTPError  # type: ignore[no-redef]
+    from urllib2 import HTTPError, Request, URLError, urlopen  # type: ignore[no-redef]
 
 
 _GITHUB_RELEASE_URL = (
     "https://github.com/George-RD/mag/releases/download/"
     "v{version}/mag-{target}.{ext}"
 )
+_GITHUB_CHECKSUMS_URL = (
+    "https://github.com/George-RD/mag/releases/download/v{version}/checksums.txt"
+)
+_HEX_DIGITS = frozenset("0123456789abcdef")
 
 # Mapping: (sys.platform, platform.machine()) -> Rust target triple
 _TARGET_MAP = {
@@ -68,14 +74,69 @@ def _download_url(url):
     """Download a URL and return its content as bytes."""
     req = Request(url, headers={"User-Agent": "mag-memory-pypi-installer"})
     try:
-        resp = urlopen(req, timeout=120)
-        return resp.read()
+        with urlopen(req, timeout=120) as resp:
+            return resp.read()
     except HTTPError as exc:
         raise RuntimeError(
             "HTTP {} downloading {}: {}".format(exc.code, url, exc.reason)
         )
     except URLError as exc:
         raise RuntimeError("Failed to download {}: {}".format(url, exc.reason))
+
+
+def _parse_checksum_manifest(data, archive_name):
+    # type: (bytes, str) -> str
+    """Return the one SHA-256 digest declared for an exact archive name."""
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        raise RuntimeError("Malformed checksum manifest: not valid UTF-8") from exc
+
+    matches = []
+    for line_number, line in enumerate(text.splitlines(), start=1):
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        parts = line.split(None, 1)
+        if len(parts) != 2:
+            raise RuntimeError(
+                "Malformed checksum manifest line {}: expected digest and filename".format(
+                    line_number
+                )
+            )
+
+        digest, filename = parts
+        digest = digest.lower()
+        filename = filename.strip()
+        if filename.startswith("*"):
+            filename = filename[1:]
+
+        if len(digest) != 64 or any(char not in _HEX_DIGITS for char in digest):
+            raise RuntimeError(
+                "Malformed checksum on line {} for '{}'".format(line_number, filename)
+            )
+
+        if filename == archive_name:
+            matches.append(digest)
+
+    if not matches:
+        raise RuntimeError("No checksum entry for '{}'".format(archive_name))
+    if len(matches) != 1:
+        raise RuntimeError("Duplicate checksum entries for '{}'".format(archive_name))
+    return matches[0]
+
+
+def _verify_archive_checksum(data, expected_digest, archive_name):
+    # type: (bytes, str, str) -> None
+    """Fail unless archive bytes match the expected SHA-256 digest."""
+    actual_digest = hashlib.sha256(data).hexdigest()
+    if not hmac.compare_digest(actual_digest, expected_digest.lower()):
+        raise RuntimeError(
+            "Checksum mismatch for '{}': expected {}, got {}".format(
+                archive_name, expected_digest, actual_digest
+            )
+        )
 
 
 def _extract_tar_gz(data, dest_dir):
@@ -141,7 +202,7 @@ def _extract_zip(data, dest_dir):
 
 def download_binary(version):
     # type: (str) -> str
-    """Download the mag binary for this platform and return its path.
+    """Download a verified mag binary for this platform and return its path.
 
     Args:
         version: The version string (e.g. "0.1.0")
@@ -150,21 +211,35 @@ def download_binary(version):
         Absolute path to the downloaded binary.
     """
     target, ext = _detect_target()
-    url = _GITHUB_RELEASE_URL.format(version=version, target=target, ext=ext)
+    archive_name = "mag-{}.{}".format(target, ext)
+    checksum_url = _GITHUB_CHECKSUMS_URL.format(version=version)
+    archive_url = _GITHUB_RELEASE_URL.format(
+        version=version,
+        target=target,
+        ext=ext,
+    )
 
-    print("mag: downloading {} ...".format(url))
+    print("mag: fetching release checksums ...")
     sys.stdout.flush()
-    data = _download_url(url)
+    manifest = _download_url(checksum_url)
+    expected_digest = _parse_checksum_manifest(manifest, archive_name)
+
+    print("mag: downloading {} ...".format(archive_url))
+    sys.stdout.flush()
+    data = _download_url(archive_url)
     print("mag: downloaded {:.1f} MB".format(len(data) / (1024.0 * 1024.0)))
     sys.stdout.flush()
 
-    # Ensure destination directory exists
+    _verify_archive_checksum(data, expected_digest, archive_name)
+    print("mag: checksum verified")
+    sys.stdout.flush()
+
+    # Create the destination only after the downloaded archive is verified.
     from mag_memory import _binary_dir
 
     dest_dir = _binary_dir()
     os.makedirs(dest_dir, exist_ok=True)
 
-    # Extract
     if ext == "zip":
         binary_path = _extract_zip(data, dest_dir)
     else:

--- a/python/tests/test_download_integrity.py
+++ b/python/tests/test_download_integrity.py
@@ -94,7 +94,7 @@ class VerifiedDownloadFlowTests(unittest.TestCase):
             self.assertFalse(os.path.exists(dest_dir))
 
     @unittest.skipIf(os.name == "nt", "Unix executable permissions are tested on Linux CI")
-    def test_verified_archive_is_installed_after_checksum_validation(self):
+    def test_verified_tar_archive_is_installed_after_checksum_validation(self):
         archive = b"verified archive"
         digest = hashlib.sha256(archive).hexdigest()
         manifest = "{}  {}\n".format(digest, _ARCHIVE_NAME).encode("ascii")
@@ -124,6 +124,40 @@ class VerifiedDownloadFlowTests(unittest.TestCase):
             self.assertEqual(os.path.join(dest_dir, "mag"), binary_path)
             extract_archive.assert_called_once_with(archive, dest_dir)
             self.assertTrue(os.stat(binary_path).st_mode & stat.S_IXUSR)
+
+    def test_verified_zip_archive_uses_the_windows_extractor(self):
+        target = "x86_64-pc-windows-msvc"
+        archive_name = "mag-{}.zip".format(target)
+        archive = b"verified zip archive"
+        digest = hashlib.sha256(archive).hexdigest()
+        manifest = "{}  {}\n".format(digest, archive_name).encode("ascii")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dest_dir = os.path.join(tmp, "bin")
+
+            def extract(data, destination):
+                self.assertEqual(archive, data)
+                self.assertTrue(os.path.isdir(destination))
+                path = os.path.join(destination, "mag.exe")
+                with open(path, "wb") as binary:
+                    binary.write(b"binary")
+                return path
+
+            with mock.patch.object(
+                _download, "_detect_target", return_value=(target, "zip")
+            ), mock.patch.object(
+                _download, "_download_url", side_effect=[manifest, archive]
+            ), mock.patch.object(
+                mag_memory, "_binary_dir", return_value=dest_dir
+            ), mock.patch.object(
+                _download, "_extract_zip", side_effect=extract
+            ) as extract_archive, mock.patch.object(
+                _download.sys, "platform", "win32"
+            ):
+                binary_path = _download.download_binary("1.2.3")
+
+            self.assertEqual(os.path.join(dest_dir, "mag.exe"), binary_path)
+            extract_archive.assert_called_once_with(archive, dest_dir)
 
 
 if __name__ == "__main__":

--- a/python/tests/test_download_integrity.py
+++ b/python/tests/test_download_integrity.py
@@ -1,0 +1,130 @@
+import hashlib
+import os
+import stat
+import tempfile
+import unittest
+from unittest import mock
+
+import mag_memory
+from mag_memory import _download
+
+
+_TARGET = "x86_64-unknown-linux-gnu"
+_ARCHIVE_NAME = "mag-{}.tar.gz".format(_TARGET)
+
+
+class ChecksumManifestTests(unittest.TestCase):
+    def test_selects_the_exact_archive_entry(self):
+        expected = "a" * 64
+        manifest = (
+            "{}  mag-aarch64-unknown-linux-gnu.tar.gz\n"
+            "{}  {}\n"
+        ).format("b" * 64, expected, _ARCHIVE_NAME)
+
+        self.assertEqual(
+            expected,
+            _download._parse_checksum_manifest(manifest.encode("ascii"), _ARCHIVE_NAME),
+        )
+
+    def test_rejects_a_missing_archive_entry(self):
+        manifest = "{}  mag-aarch64-unknown-linux-gnu.tar.gz\n".format("a" * 64)
+
+        with self.assertRaisesRegex(RuntimeError, "No checksum entry"):
+            _download._parse_checksum_manifest(manifest.encode("ascii"), _ARCHIVE_NAME)
+
+    def test_rejects_duplicate_archive_entries(self):
+        manifest = (
+            "{}  {}\n"
+            "{}  {}\n"
+        ).format("a" * 64, _ARCHIVE_NAME, "b" * 64, _ARCHIVE_NAME)
+
+        with self.assertRaisesRegex(RuntimeError, "Duplicate checksum entries"):
+            _download._parse_checksum_manifest(manifest.encode("ascii"), _ARCHIVE_NAME)
+
+    def test_rejects_a_malformed_digest(self):
+        manifest = "not-a-sha256  {}\n".format(_ARCHIVE_NAME)
+
+        with self.assertRaisesRegex(RuntimeError, "Malformed checksum"):
+            _download._parse_checksum_manifest(manifest.encode("ascii"), _ARCHIVE_NAME)
+
+
+class ArchiveChecksumTests(unittest.TestCase):
+    def test_accepts_matching_archive_bytes(self):
+        archive = b"verified archive"
+        expected = hashlib.sha256(archive).hexdigest()
+
+        _download._verify_archive_checksum(archive, expected, _ARCHIVE_NAME)
+
+    def test_rejects_mismatched_archive_bytes(self):
+        archive = b"tampered archive"
+
+        with self.assertRaisesRegex(RuntimeError, "Checksum mismatch"):
+            _download._verify_archive_checksum(archive, "0" * 64, _ARCHIVE_NAME)
+
+
+class VerifiedDownloadFlowTests(unittest.TestCase):
+    def test_checksum_failure_happens_before_install_side_effects(self):
+        archive = b"tampered archive"
+        manifest = "{}  {}\n".format("0" * 64, _ARCHIVE_NAME).encode("ascii")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dest_dir = os.path.join(tmp, "bin")
+            with mock.patch.object(
+                _download, "_detect_target", return_value=(_TARGET, "tar.gz")
+            ), mock.patch.object(
+                _download, "_download_url", side_effect=[manifest, archive]
+            ) as fetch, mock.patch.object(
+                mag_memory, "_binary_dir", return_value=dest_dir
+            ), mock.patch.object(
+                _download, "_extract_tar_gz"
+            ) as extract:
+                with self.assertRaisesRegex(RuntimeError, "Checksum mismatch"):
+                    _download.download_binary("1.2.3")
+
+            self.assertEqual(
+                [
+                    "https://github.com/George-RD/mag/releases/download/v1.2.3/checksums.txt",
+                    "https://github.com/George-RD/mag/releases/download/v1.2.3/{}".format(
+                        _ARCHIVE_NAME
+                    ),
+                ],
+                [call.args[0] for call in fetch.call_args_list],
+            )
+            extract.assert_not_called()
+            self.assertFalse(os.path.exists(dest_dir))
+
+    @unittest.skipIf(os.name == "nt", "Unix executable permissions are tested on Linux CI")
+    def test_verified_archive_is_installed_after_checksum_validation(self):
+        archive = b"verified archive"
+        digest = hashlib.sha256(archive).hexdigest()
+        manifest = "{}  {}\n".format(digest, _ARCHIVE_NAME).encode("ascii")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            dest_dir = os.path.join(tmp, "bin")
+
+            def extract(data, destination):
+                self.assertEqual(archive, data)
+                self.assertTrue(os.path.isdir(destination))
+                path = os.path.join(destination, "mag")
+                with open(path, "wb") as binary:
+                    binary.write(b"binary")
+                return path
+
+            with mock.patch.object(
+                _download, "_detect_target", return_value=(_TARGET, "tar.gz")
+            ), mock.patch.object(
+                _download, "_download_url", side_effect=[manifest, archive]
+            ), mock.patch.object(
+                mag_memory, "_binary_dir", return_value=dest_dir
+            ), mock.patch.object(
+                _download, "_extract_tar_gz", side_effect=extract
+            ) as extract_archive:
+                binary_path = _download.download_binary("1.2.3")
+
+            self.assertEqual(os.path.join(dest_dir, "mag"), binary_path)
+            extract_archive.assert_called_once_with(archive, dest_dir)
+            self.assertTrue(os.stat(binary_path).st_mode & stat.S_IXUSR)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The PyPI wrapper downloaded and extracted native release archives without verifying the release SHA-256 checksum. A corrupt, incomplete, or substituted archive could reach the install path.

## Changes

- fetch the version-matched release `checksums.txt` before the archive;
- parse one exact target entry and reject missing, malformed, or duplicate entries;
- verify SHA-256 before creating the destination directory or extracting;
- retain the existing Unix tar and Windows zip extraction paths only after verification;
- add integrity and install-order regression tests on Python 3.8 and 3.13;
- record the completed work and regenerated interface state through Cairn.

## TDD evidence

**Red:** CI run `30453341364` failed on Python 3.8 and 3.13 with the expected defects:

- checksum parser and verifier APIs did not exist;
- a mismatched archive raised nothing;
- manifest bytes flowed directly into extraction because the installer fetched only one URL.

**Green:** CI run `30453499823` passed the full wrapper suite on Python 3.8 and 3.13 after implementation. The final branch is covered by CI run `30453705581` and Cairn run `30453705980`.

## Roadmap impact

Completes the Python-wrapper checksum-verification slice of the M9 portable native-install path. This improves release integrity without adding a cloud runtime dependency.