### PR TITLE
docs(cairn): complete current runtime architecture audit

### DIFF
--- a/cairn.blueprint
+++ b/cairn.blueprint
@@ -33,7 +33,7 @@ System MAG "Local-first durable memory for AI agents" id "mag" @memory @local-fi
         }
 
         Container Memory "Memory domain, model roles, retrieval, and storage" id "mag.runtime.memory" {
-            Module Domain "Stable memory types, traits, and legacy pipeline surface" id "mag.runtime.memory.domain" {
+            Module Domain "Stable memory types, traits, and compatibility-sensitive CLI pipeline" id "mag.runtime.memory.domain" {
                 path "./src/memory_core/mod.rs"
                 path "./src/memory_core/domain.rs"
                 path "./src/memory_core/traits.rs"
@@ -72,12 +72,12 @@ System MAG "Local-first durable memory for AI agents" id "mag" @memory @local-fi
             }
         }
 
-        Module Substrate "Newer trait-composed orchestration under evaluation" id "mag.runtime.substrate" @architecture-decision-pending {
+        Module Substrate "Feature-gated candidate orchestration used by tests and benchmarks" id "mag.runtime.substrate" @architecture-decision-pending @not-production-wired {
             path "./src/substrate"
             contract "./meta/contracts/runtime.substrate.md"
         }
 
-        Module Daemon "Optional authenticated HTTP deployment adapter" id "mag.runtime.daemon" @optional {
+        Module Daemon "Feature-gated HTTP support primitives without an assembled server" id "mag.runtime.daemon" @experimental @not-production-wired {
             path "./src/daemon.rs"
             path "./src/auth.rs"
             path "./src/idle_timer.rs"
@@ -126,37 +126,37 @@ System MAG "Local-first durable memory for AI agents" id "mag" @memory @local-fi
 # Runtime assembly and public surfaces
 mag.runtime.entrypoints -> mag.runtime.setup "Dispatches setup, configuration, and uninstall commands"
 mag.runtime.entrypoints -> mag.runtime.mcp "Starts and hosts the MCP stdio server"
-mag.runtime.entrypoints -> mag.runtime.memory.domain "Builds the public memory pipeline"
-mag.runtime.entrypoints -> mag.runtime.memory.models "Constructs embedding and optional LLM backends"
-mag.runtime.entrypoints -> mag.runtime.memory.storage.sqlite "Constructs the production storage backend"
-mag.runtime.entrypoints -> mag.runtime.daemon "Starts the optional HTTP adapter"
+mag.runtime.entrypoints -> mag.runtime.memory.domain "Builds the compatibility-sensitive CLI pipeline"
+mag.runtime.entrypoints -> mag.runtime.memory.models "Constructs the production embedding adapter"
+mag.runtime.entrypoints -> mag.runtime.memory.retrieval "Optionally constructs the cross-encoder reranker"
+mag.runtime.entrypoints -> mag.runtime.memory.storage.sqlite "Constructs the production storage and query backend"
 
 # Memory internals
-mag.runtime.mcp -> mag.runtime.memory.domain "Exposes domain operations as validated tools"
-mag.runtime.mcp -> mag.runtime.memory.storage.sqlite "Delegates tool execution to SQLite storage"
+mag.runtime.mcp -> mag.runtime.memory.domain "Uses stable domain inputs and outputs"
+mag.runtime.mcp -> mag.runtime.memory.storage.sqlite "Delegates tool execution directly to SQLite capabilities"
 mag.runtime.memory.models -> mag.runtime.memory.domain "Implements model traits used by memory operations"
 mag.runtime.memory.retrieval -> mag.runtime.memory.domain "Scores and returns domain search results"
 mag.runtime.memory.retrieval -> mag.runtime.memory.models "Uses embeddings and optional rerankers"
 mag.runtime.memory.storage.api -> mag.runtime.memory.domain "Defines backend access around domain contracts"
 mag.runtime.memory.storage.sqlite -> mag.runtime.memory.domain "Persists and queries domain records"
 mag.runtime.memory.storage.sqlite -> mag.runtime.memory.models "Creates and consumes embeddings"
-mag.runtime.memory.storage.sqlite -> mag.runtime.memory.retrieval "Runs the advanced retrieval pipeline"
+mag.runtime.memory.storage.sqlite -> mag.runtime.memory.retrieval "Runs the production advanced retrieval pipeline"
 mag.runtime.memory.storage.memory -> mag.runtime.memory.domain "Implements the reference backend contract"
 
-# Competing orchestration path to be resolved before more production wiring
-mag.runtime.substrate -> mag.runtime.memory.domain "Composes stable memory traits"
-mag.runtime.substrate -> mag.runtime.memory.models "Uses model-role abstractions"
+# Candidate orchestration path to be resolved before more production wiring
+mag.runtime.substrate -> mag.runtime.memory.domain "Composes stable memory traits in tests and benchmarks"
+mag.runtime.substrate -> mag.runtime.memory.models "Uses embedding and optional LLM abstractions"
 mag.runtime.substrate -> mag.runtime.memory.retrieval "Composes retrieval and scoring strategies"
-mag.runtime.substrate -> mag.runtime.memory.storage.sqlite "Bridges to the production backend"
+mag.runtime.substrate -> mag.runtime.memory.storage.sqlite "Bridges experiments to the production backend"
 
 # Deployment and integrations
-mag.runtime.daemon -> mag.runtime.mcp "Serves the same MCP semantics over HTTP"
+mag.runtime.setup -> mag.runtime.daemon "Reads feature-gated daemon metadata; no HTTP process is assembled"
 mag.runtime.setup -> mag.integrations.connectors "Installs and removes connector content"
 mag.integrations.python -> mag.runtime.mcp "Uses MAG through its protocol surface"
 
 # Verification
 mag.quality.tests -> mag.runtime "Verifies runtime behavior and contracts"
 mag.quality.benchmarks -> mag.runtime.memory "Measures memory quality and latency"
-mag.quality.benchmarks -> mag.runtime.substrate "Compares candidate orchestration paths"
+mag.quality.benchmarks -> mag.runtime.substrate "Measures the candidate orchestration path"
 mag.quality.scripts -> mag.quality.tests "Runs repository quality gates"
 mag.quality.scripts -> mag.quality.benchmarks "Runs benchmark and regression gates"

--- a/meta/contracts/memory.domain.md
+++ b/meta/contracts/memory.domain.md
@@ -1,8 +1,14 @@
 ---
-        node: mag.runtime.memory.domain
-        ---
-        # mag.runtime.memory.domain contract
+node: mag.runtime.memory.domain
+---
+# mag.runtime.memory.domain contract
 
-        Domain types and traits are the stable semantic contract of MAG. They may
-not depend on a concrete storage engine, transport, or hosted provider.
-Legacy and replacement orchestration surfaces must not diverge in behavior.
+Domain types and traits are the stable semantic contract of MAG. They may not
+depend on a concrete storage engine, transport, or hosted provider.
+
+`memory_core::Pipeline` is currently a compatibility-sensitive CLI adapter, not
+the universal production composition root. Its placeholder processor changes
+stored content by adding `processed: `, so replacement requires explicit
+behavioural tests and a migration decision. New intelligence must not be added
+to both this adapter and substrate; legacy and replacement orchestration surfaces
+must converge on one accepted behaviour.

--- a/meta/contracts/memory.models.md
+++ b/meta/contracts/memory.models.md
@@ -8,6 +8,13 @@ separate model roles behind explicit interfaces. The core quality baseline must
 run locally without cloud credentials; remote and self-hosted adapters use the
 same memory semantics.
 
+The current production binary constructs the ONNX embedder and may attach the
+cross-encoder to the SQLite retrieval path. `memory_core::llm` is feature-gated
+infrastructure consumed by substrate experiments, tests, and a mock benchmark;
+no production CLI or MCP entrypoint currently constructs an LLM backend.
+Environment defaults must not be documented as active product behaviour until
+the selected composition root wires them behind evaluation gates.
+
 Every production model profile declares its model ID, revision, checksums, role,
 runtime, quantization, output dimensions, pooling, query/document handling,
 maximum input length, licence, and expected local resource envelope. Embedding

--- a/meta/contracts/runtime.daemon.md
+++ b/meta/contracts/runtime.daemon.md
@@ -1,8 +1,14 @@
 ---
-        node: mag.runtime.daemon
-        ---
-        # mag.runtime.daemon contract
+node: mag.runtime.daemon
+---
+# mag.runtime.daemon contract
 
-        The daemon is an optional authenticated deployment adapter. It reuses the
-same domain behavior as local CLI/MCP mode, keeps auth and lifecycle at the
-boundary, and must never become required for local operation.
+The daemon node currently owns feature-gated support primitives: daemon metadata,
+Bearer-token middleware, and idle-lifecycle middleware. It does not currently
+assemble an HTTP router, listener, MCP transport, background process, or metadata
+writer, so it must not be presented as a working deployment adapter.
+
+Any future service mode must reuse the same domain behaviour as local CLI/MCP,
+keep authentication and lifecycle at the transport boundary, provide explicit
+health and shutdown semantics, and remain optional. Local operation must never
+depend on an HTTP daemon, hosted service, or cloud credential.

--- a/meta/contracts/runtime.entrypoints.md
+++ b/meta/contracts/runtime.entrypoints.md
@@ -1,9 +1,16 @@
 ---
-        node: mag.runtime.entrypoints
-        ---
-        # mag.runtime.entrypoints contract
+node: mag.runtime.entrypoints
+---
+# mag.runtime.entrypoints contract
 
-        The entrypoint layer owns process startup, CLI dispatch, and assembly of
-concrete components. It must not contain independent storage, retrieval,
-extraction, or connector semantics. MCP mode keeps stdout exclusively for
-protocol traffic and sends diagnostics to stderr.
+The entrypoint layer owns process startup, CLI dispatch, and assembly of concrete
+components. It must not contain independent storage, retrieval, extraction, or
+connector semantics. MCP mode keeps stdout exclusively for protocol traffic and
+sends diagnostics to stderr.
+
+The current binary constructs the production embedder and `SqliteStorage`.
+`memory_core::Pipeline` is used only as a compatibility-sensitive adapter for a
+subset of CLI commands; MCP and most extended CLI operations delegate directly
+to SQLite capabilities. The entrypoint does not currently construct substrate,
+an LLM backend, or an HTTP server. New production intelligence must enter through
+the selected composition root rather than another command-specific path.

--- a/meta/contracts/runtime.mcp.md
+++ b/meta/contracts/runtime.mcp.md
@@ -1,8 +1,13 @@
 ---
-        node: mag.runtime.mcp
-        ---
-        # mag.runtime.mcp contract
+node: mag.runtime.mcp
+---
+# mag.runtime.mcp contract
 
-        MCP handlers validate protocol inputs and delegate to domain/backend
-capabilities. They do not reimplement memory semantics. Tool schemas and
-errors remain stable, bounded, and safe for stdio transport.
+MCP handlers validate protocol inputs and delegate to domain/backend
+capabilities. They do not reimplement memory semantics. Tool schemas and errors
+remain stable, bounded, and safe for stdio transport.
+
+The current production server is stdio-only and is constructed directly over
+`SqliteStorage`; it does not pass through `memory_core::Pipeline`, substrate, an
+LLM backend, or an HTTP daemon. Any additional transport must preserve the same
+handler semantics and earn its own end-to-end lifecycle and authentication tests.

--- a/meta/contracts/runtime.setup.md
+++ b/meta/contracts/runtime.setup.md
@@ -1,9 +1,16 @@
 ---
-        node: mag.runtime.setup
-        ---
-        # mag.runtime.setup contract
+node: mag.runtime.setup
+---
+# mag.runtime.setup contract
 
-        Setup owns tool detection, generated configuration, data-path resolution,
-installation, and uninstall symmetry. Operations must be idempotent, must
-not silently overwrite user-managed content, and must leave an explicit
-recovery path when setup is partial.
+Setup owns tool detection, generated configuration, data-path resolution,
+installation, and uninstall symmetry. Operations must be idempotent, must not
+silently overwrite user-managed content, and must leave an explicit recovery
+path when setup is partial.
+
+Generated client configuration must reference an executable transport that the
+current binary actually serves. Command transport (`mag serve`) is the current
+verified path. Reading daemon metadata or compiling `daemon-http` does not prove
+that an HTTP process exists; setup must fail visibly or withhold unsupported
+stdio/HTTP configurations until their end-to-end server paths are implemented
+and tested.

--- a/meta/contracts/runtime.substrate.md
+++ b/meta/contracts/runtime.substrate.md
@@ -1,8 +1,15 @@
 ---
-        node: mag.runtime.substrate
-        ---
-        # mag.runtime.substrate contract
+node: mag.runtime.substrate
+---
+# mag.runtime.substrate contract
 
-        Substrate is a candidate composition root, not a second product. Until the
-composition decision is accepted, new production intelligence must not be
-implemented independently in both substrate and the legacy pipeline.
+Substrate is a feature-gated candidate composition root, not a second product.
+It is currently constructed by integration tests and benchmark binaries only;
+no CLI or MCP production entrypoint uses it.
+
+Until the composition decision is accepted, new production intelligence must
+not be implemented independently in both substrate and the legacy/direct SQLite
+paths. Promotion requires public CLI/MCP parity, retrieval-quality and resource
+benchmarks, a reversible migration of live callers, and removal or deliberate
+retention of the superseded adapter. If substrate is not selected, only its
+proven useful boundaries should be folded into the production path.

--- a/meta/contracts/storage.sqlite.md
+++ b/meta/contracts/storage.sqlite.md
@@ -8,6 +8,12 @@ executor, writes are transactional, migrations are additive and idempotent,
 FTS/vector/graph indexes are repairable, and caches never become durability
 authorities.
 
+In the current runtime, SQLite also implements most live retrieval, graph,
+lifecycle, maintenance, and extended CLI/MCP behaviour. This describes the
+audited implementation; it does not settle the composition-root decision. Any
+future boundary change must preserve these behaviours through parity tests and
+benchmarks before call sites move.
+
 The database records the profile and embedding-space identity used for persisted
 vectors. Re-embedding and dimension changes update the memory BLOB and vector
 index through an interruption-safe, recoverable migration. Opening or querying

--- a/meta/decisions/dec.classify-current-runtime-boundaries.md
+++ b/meta/decisions/dec.classify-current-runtime-boundaries.md
@@ -1,0 +1,42 @@
+---
+id: dec.classify-current-runtime-boundaries
+nodes:
+  - mag.runtime.entrypoints
+  - mag.runtime.setup
+  - mag.runtime.mcp
+  - mag.runtime.memory.domain
+  - mag.runtime.memory.models
+  - mag.runtime.memory.storage.sqlite
+  - mag.runtime.substrate
+  - mag.runtime.daemon
+status: accepted
+date: 2026-07-29
+revisit_triggers:
+  - "The production composition-root decision is accepted"
+  - "A production entrypoint constructs substrate or an LLM backend"
+  - "An HTTP MCP server is assembled and verified end to end"
+  - "The legacy CLI Pipeline is removed or changes stored-content behaviour"
+informed_by: [res.architecture-state-audit]
+refines: [dec.baseline-current-module-boundaries, dec.evidence-based-cleanup]
+related: [dec.sequence-architecture-before-llm-wiring]
+---
+# Classify the current runtime boundaries by actual construction
+
+MAG will describe runtime maturity from current production construction rather
+than feature names, compilation, tests, or historical plans.
+
+- `SqliteStorage` is the current production semantic centre for MCP and most CLI
+  capabilities.
+- `memory_core::Pipeline` is a compatibility-sensitive CLI adapter, not the
+  universal composition root.
+- `substrate` is the single candidate orchestration path and is currently used
+  only by tests and benchmarks.
+- the `llm` boundary is experimental infrastructure with no production caller;
+- `daemon-http` contains support primitives but no assembled HTTP server;
+- command transport (`mag serve`) is the only setup transport currently verified
+  end to end.
+
+This classification does not choose the future composition root. It prevents
+new intelligence from being duplicated across current paths, prevents incomplete
+features from being presented as live, and preserves local stdio operation as
+the mandatory independent baseline.

--- a/meta/research/res.architecture-state-audit.md
+++ b/meta/research/res.architecture-state-audit.md
@@ -1,20 +1,166 @@
 ---
 id: res.architecture-state-audit
-nodes: [mag.runtime, mag.runtime.memory, mag.runtime.substrate]
+nodes:
+  - mag.runtime
+  - mag.runtime.entrypoints
+  - mag.runtime.setup
+  - mag.runtime.mcp
+  - mag.runtime.memory.domain
+  - mag.runtime.memory.models
+  - mag.runtime.memory.storage.sqlite
+  - mag.runtime.substrate
+  - mag.runtime.daemon
+  - mag.quality.tests
+  - mag.quality.benchmarks
 sources: [src.mag-agents-guide, src.dead-code-recon, src.source-tree-recon]
-date: 2026-07-28
+date: 2026-07-29
+baseline_commit: 9eba6157a225f244b94eefcf83e883c1309d30ec
 ---
 # Current architecture and cleanup evidence
 
-Two historical recon reports point in different directions. The dead-code report
-describes no unreachable code and justified feature-gated suppressions. The
-source-tree report identifies large modules and concern concentration. Both were
-produced against an older repository shape and reference files that have since
-moved or been split.
+## Scope and method
 
-The current material architecture risk is not proven dead code. It is semantic
-duplication: `memory_core::Pipeline` and the newer `substrate` orchestration
-coexist, while optional LLM intelligence could be wired through either. Deleting
-code before tracing current callers, feature flags, tests, and benchmark paths
-would be unsafe. Cleanup must begin with a current dependency/call-path audit and
-an explicit production-composition decision.
+This audit traces the current production constructors, feature gates, direct
+callers, tests, and benchmarks from the repository state after PR #374. A path
+is classified as **production-wired** only when a user-facing binary entrypoint
+constructs or calls it. Compilation, unit tests, integration tests, and
+benchmarks are recorded separately; they do not by themselves make a path live.
+
+The earlier dead-code and source-tree reports remain useful historical inputs,
+but they predate the current module split and cannot establish present reachability.
+The current risk is not proven bulk dead code. It is three competing shapes:
+
+1. direct `SqliteStorage` calls for most CLI and all MCP semantics;
+2. the legacy `memory_core::Pipeline` wrapper used by a subset of CLI commands;
+3. the feature-gated `substrate` orchestration used by tests and benchmarks only.
+
+## Findings
+
+### 1. SQLite is the current production semantic centre
+
+The binary constructs one `SqliteStorage` from the selected embedder and clones
+it into the other live surfaces. MCP constructs `McpMemoryServer` directly over
+that storage and serves stdio. Most extended CLI commands also call
+`SqliteStorage` capability traits directly. The advanced retrieval, graph,
+lifecycle, backup, profile, reminder, checkpoint, and maintenance behaviour is
+therefore owned by the SQLite backend today.
+
+This is an observation about the current implementation, not a decision that
+storage should permanently own orchestration. New work must first choose a
+composition root rather than adding another direct path.
+
+### 2. `memory_core::Pipeline` is a live CLI adapter, not the universal root
+
+The binary creates `Pipeline` with `PlaceholderPipeline` as both ingestor and
+processor, then clones `SqliteStorage` into storage and search roles. `ingest`
+and `process` call `Pipeline::run`; basic retrieve/search/recent operations also
+use the wrapper. MCP does not. Most advanced CLI operations do not.
+
+`PlaceholderPipeline::process` prefixes content with `processed: `. That visible
+stored-content behaviour is a compatibility surface. Removing or bypassing the
+legacy pipeline requires regression tests and a migration decision; it is not a
+safe dead-code deletion.
+
+### 3. `substrate` is a tested candidate architecture, not production runtime
+
+The `substrate` module is compiled only with the `substrate` feature. Repository
+callers are confined to the module itself, `tests/substrate_pipeline.rs`,
+`benches/substrate_bench.rs`, and `benches/phase2_bench.rs`. Neither the CLI nor
+MCP constructs `SearchPipeline`, `WritePipeline`, or `ConsolidationRunner`.
+
+The integration tests prove an FTS search composition and precomputed-embedding
+write path. The benchmarks measure synthetic substrate search latency and a
+mock-LLM metadata experiment. They do not prove production parity with the
+SQLite advanced-search path, public CLI/MCP compatibility, migration safety, or
+real-model resource use.
+
+### 4. The LLM boundary is implemented but not production-wired
+
+`memory_core::llm` defines providers and local defaults behind the `llm` feature.
+Its only non-test consumer is `substrate::EmbedAndExtractPipeline`, itself not
+constructed by a production entrypoint. `phase2_bench` uses a deterministic mock
+backend. Setting `MAG_LLM_*` variables therefore does not currently change CLI or
+MCP behaviour.
+
+Documentation must describe this as an experimental backend boundary, not an
+active optional production mode, until the composition decision and local eval
+gate are complete.
+
+### 5. `daemon-http` contains support primitives but no HTTP server
+
+The feature gates `daemon.rs`, `auth.rs`, and `idle_timer.rs`. These provide
+metadata, token/auth middleware, and idle-lifecycle primitives with unit tests.
+No production code constructs `AuthLayer` or `IdleTimerLayer`, no code writes a
+live `DaemonInfo`, and no HTTP router or listener composes MCP semantics.
+
+Setup can still generate an HTTP MCP URL. Its daemon check only reads stale
+metadata and prints a suggestion to run `mag serve`; `mag serve` is explicitly a
+stdio server. The separately advertised `stdio` setup mode writes
+`["serve", "--stdio"]`, but the `serve` command has no `--stdio` argument.
+Only command transport (`mag serve`) is currently end-to-end valid.
+
+This is an incomplete experimental deployment surface, not a working optional
+cloud adapter and not a dependency of local operation.
+
+## Current production composition
+
+| Surface | Feature/runtime gate | Constructed path | Current semantic owner | Classification |
+|---|---|---|---|---|
+| CLI ingest/process | default binary | `Pipeline(PlaceholderPipeline, PlaceholderPipeline, SqliteStorage...)` | legacy pipeline plus SQLite | Production-wired; compatibility-sensitive |
+| Basic CLI retrieve/search/recent | default binary | `memory_core::Pipeline` delegating to SQLite roles | SQLite through adapter | Production-wired |
+| Extended CLI operations | default binary | direct `SqliteStorage` capability calls | SQLite | Production-wired |
+| MCP | default binary, stdio | `McpMemoryServer<SqliteStorage>::serve_stdio()` | SQLite plus MCP validation | Production-wired |
+| Embeddings | default `real-embeddings` feature | `OnnxEmbedder`; placeholder when feature disabled | model adapter plus SQLite | Production-wired with explicit fallback build |
+| Cross-encoder | `serve --cross-encoder` and `real-embeddings` | reranker attached to SQLite | SQLite retrieval path | Optional production path |
+| Substrate orchestration | `substrate` | tests and benchmarks only | candidate | Experimental, not production-wired |
+| LLM extraction/generation | `llm` plus substrate consumer | unit tests and mock benchmark | candidate | Experimental, not production-wired |
+| HTTP daemon | `daemon-http` | metadata/auth/idle primitives only | none assembled | Incomplete, not production-wired |
+| In-memory storage | library/test construction | parity and test callers | reference backend | Test/reference path |
+| Connector setup | setup command | tool detection/config writer/plugin hooks | setup/integrations | Production-wired; command transport valid |
+
+## Cleanup and consolidation evidence
+
+| Candidate | Current callers | Feature | Test evidence | Benchmark evidence | Audit disposition |
+|---|---|---|---|---|---|
+| Consolidate `memory_core::Pipeline` into the selected composition root | CLI ingest/process and basic retrieval in `main.rs` | default | pipeline unit tests, CLI tests, smoke coverage | no dedicated behavioural-parity benchmark | Do not delete. First pin current CLI behaviour, especially `processed: `, then migrate one command family at a time. |
+| Promote or fold `substrate` | integration tests and two benchmark binaries; no production caller | `substrate` | `tests/substrate_pipeline.rs` plus module tests | `substrate_bench`, `phase2_bench` | Decide whether its boundaries replace thin adapters or are folded into the SQLite-centred path. Do not maintain a parallel product pipeline. |
+| Remove LLM provider infrastructure | substrate extraction and tests only | `llm` | provider/extraction unit tests | `phase2_bench` uses a mock backend | Keep as a reversible experimental boundary until the composition/eval decision. Stop documenting it as active production behaviour. |
+| Remove daemon/auth/idle modules | setup reads `DaemonInfo`; no assembled server | `daemon-http` | module unit tests | none | Do not advertise as working. Either implement behind an explicit service milestone or remove after the cross-device design decision. |
+| Remove `PlaceholderEmbedder` | non-`real-embeddings` builds, tests, substrate benchmark | feature fallback | broad unit/integration use | substrate synthetic benchmark | Keep as explicit test/fallback implementation; never treat its output as production quality. |
+| Remove in-memory backend | tests/reference callers | default library surface | backend parity and unit tests | none material | Keep as reference backend unless parity coverage is replaced. |
+| Bulk-delete feature-gated or `allow(dead_code)` code | varies | varies | varies | varies | Rejected. Feature gating, test-only use, and benchmark use must be considered individually. |
+
+## Stale or misleading documents
+
+- `docs/strongholds/recon-dead-code.md` and `tech-debt-recon.md` are historical
+  snapshots, not current reachability evidence.
+- `docs/configuration.md` describes `MAG_LLM_*` as though it activates an
+  optional production mode; no production caller currently reads the backend.
+- Setup/CLI documentation that advertises `http` or `stdio` setup transports is
+  ahead of the executable surface. Command transport is the only verified mode.
+- The Cairn blueprint previously stated that entrypoints start an HTTP adapter
+  and that the daemon serves MCP over HTTP. Those edges are not implemented.
+
+## Resulting boundaries
+
+1. Treat `SqliteStorage` as the **current** production semantic centre while the
+   composition decision remains open.
+2. Treat `memory_core::Pipeline` as a compatibility-sensitive CLI adapter, not a
+   target for new intelligence.
+3. Treat `substrate` as the one candidate orchestration source. If selected,
+   migrate live call sites into it; if not, fold only its useful interfaces into
+   the existing path and retire the duplicate.
+4. Treat `llm` and `daemon-http` as experimental, non-production-wired features.
+5. Keep local stdio operation independent of any daemon, hosted service, or
+   generative model.
+6. Correct broken setup transports before expanding cloud/cross-device work.
+
+## Next decisions and checks
+
+- Select the production composition root using CLI/MCP parity, retrieval quality,
+  latency, memory use, migration cost, and reversibility as decision criteria.
+- Add regression tests for setup-generated command lines before disabling or
+  implementing the invalid stdio/HTTP modes.
+- Build the local intelligence eval harness before production LLM wiring.
+- Rationalize stale stronghold and configuration documents after the composition
+  decision establishes the durable vocabulary.

--- a/meta/research/res.architecture-state-audit.md
+++ b/meta/research/res.architecture-state-audit.md
@@ -12,7 +12,11 @@ nodes:
   - mag.runtime.daemon
   - mag.quality.tests
   - mag.quality.benchmarks
-sources: [src.mag-agents-guide, src.dead-code-recon, src.source-tree-recon]
+sources:
+  - src.current-runtime-baseline
+  - src.mag-agents-guide
+  - src.dead-code-recon
+  - src.source-tree-recon
 date: 2026-07-29
 baseline_commit: 9eba6157a225f244b94eefcf83e883c1309d30ec
 ---

--- a/meta/sources/current-runtime-baseline.txt
+++ b/meta/sources/current-runtime-baseline.txt
@@ -1,0 +1,27 @@
+MAG current runtime baseline
+date: 2026-07-29
+commit: 9eba6157a225f244b94eefcf83e883c1309d30ec
+repository: https://github.com/George-RD/mag
+
+Audited production and feature surfaces:
+- Cargo.toml
+- src/lib.rs
+- src/main.rs
+- src/cli.rs
+- src/setup.rs
+- src/config_writer.rs
+- src/mcp/mod.rs
+- src/memory_core/mod.rs
+- src/memory_core/llm.rs
+- src/memory_core/storage/sqlite
+- src/substrate
+- src/daemon.rs
+- src/auth.rs
+- src/idle_timer.rs
+- tests/substrate_pipeline.rs
+- benches/substrate_bench.rs
+- benches/phase2_bench.rs
+
+Method:
+Production construction, feature gates, direct callers, tests, and benchmark
+callers were classified separately against the immutable commit above.

--- a/meta/sources/src.current-runtime-baseline.md
+++ b/meta/sources/src.current-runtime-baseline.md
@@ -1,12 +1,13 @@
 ---
 id: src.current-runtime-baseline
-file: https://github.com/George-RD/mag/tree/9eba6157a225f244b94eefcf83e883c1309d30ec
+file: meta/sources/current-runtime-baseline.txt
+sha256: 2d478a65b172a28ab0a08afb47969cee6bafe9486c3cdc399e2ab72ceab7d76e
 verification: verified
 type: repository snapshot and static call-path audit
 date: 2026-07-29
 ---
 
-Production entrypoints, feature gates, direct callers, tests, and benchmark
-binaries were traced against this immutable repository commit. The audit treats
+The pinned manifest identifies the immutable repository commit and the exact
+production, feature, test, and benchmark surfaces inspected. The audit treats
 compiled, tested, benchmarked, and production-constructed paths as distinct
 states.

--- a/meta/sources/src.current-runtime-baseline.md
+++ b/meta/sources/src.current-runtime-baseline.md
@@ -1,0 +1,12 @@
+---
+id: src.current-runtime-baseline
+file: https://github.com/George-RD/mag/tree/9eba6157a225f244b94eefcf83e883c1309d30ec
+verification: verified
+type: repository snapshot and static call-path audit
+date: 2026-07-29
+---
+
+Production entrypoints, feature gates, direct callers, tests, and benchmark
+binaries were traced against this immutable repository commit. The audit treats
+compiled, tested, benchmarked, and production-constructed paths as distinct
+states.

--- a/meta/todos/audit-current-architecture-and-dead-code.md
+++ b/meta/todos/audit-current-architecture-and-dead-code.md
@@ -1,14 +1,31 @@
 ---
-        node: mag.runtime
-        status: in_progress
-        created: 2026-07-28
-        ---
-        # Audit Current Architecture And Dead Code
+node: mag.runtime
+status: done
+created: 2026-07-28
+completed: 2026-07-29
+satisfies: current-runtime-boundary-audit
+---
+# Audit Current Architecture And Dead Code
 
-        Build a current dependency and feature-usage picture. Confirm which legacy
-pipeline, substrate, daemon, connector, benchmark, and fallback paths are
-live. Identify removable code, semantic duplication, and stale documents.
+The current production constructors, feature gates, direct callers, tests, and
+benchmarks are recorded in `res.architecture-state-audit` against immutable
+commit `9eba6157a225f244b94eefcf83e883c1309d30ec`.
 
-Acceptance: every proposed deletion or consolidation has current caller,
-feature, test, and benchmark evidence. Update the blueprint and contracts
-with the resulting boundaries.
+## Acceptance
+
+- [x] Legacy pipeline, substrate, daemon, connector, benchmark, and fallback paths
+  are classified as production-wired, experimental, test/reference, or incomplete.
+- [x] Every proposed deletion or consolidation records current callers, feature
+  gates, test evidence, benchmark evidence, and a disposition.
+- [x] Semantic duplication and unsafe bulk-deletion assumptions are identified.
+- [x] Stale and misleading documents are identified for the follow-up
+  rationalization task.
+- [x] The Cairn blueprint and runtime contracts reflect the audited boundaries.
+
+## Result
+
+SQLite is the current production semantic centre. The legacy Pipeline remains a
+compatibility-sensitive CLI adapter. Substrate and LLM orchestration are
+feature-gated test/benchmark candidates, and the daemon feature contains support
+primitives without an assembled HTTP server. No bulk code deletion is justified
+before the production composition-root decision and parity evidence.

--- a/meta/todos/correct-setup-transport-surface.md
+++ b/meta/todos/correct-setup-transport-surface.md
@@ -1,0 +1,24 @@
+---
+node: mag.runtime.setup
+status: open
+created: 2026-07-29
+---
+# Correct setup transport surface
+
+Setup currently advertises three transport modes, but only command transport is
+executable end to end:
+
+- `command` writes `mag serve` and reaches the stdio MCP server;
+- `stdio` writes `mag serve --stdio`, but `serve` has no `--stdio` argument;
+- `http` writes an HTTP URL, but no HTTP MCP server is assembled.
+
+## Acceptance criteria
+
+- Tests parse or otherwise validate every generated command against the current
+  CLI surface.
+- Unsupported transports fail before any tool configuration is modified.
+- Existing valid command transport remains idempotent and uninstall-symmetric.
+- User-facing setup and CLI text state which transport is actually available.
+- HTTP remains a separate optional service milestone rather than a local runtime
+  dependency.
+- The regression is observed before implementation.

--- a/meta/todos/rationalize-stale-planning-documents.md
+++ b/meta/todos/rationalize-stale-planning-documents.md
@@ -1,12 +1,19 @@
 ---
-        node: mag
-        status: blocked
-        created: 2026-07-28
-        ---
-        # Rationalize Stale Planning Documents
+node: mag
+status: open
+created: 2026-07-28
+unblocked: 2026-07-29
+---
+# Rationalize Stale Planning Documents
 
-        Blocked by the current architecture audit.
+The current architecture audit identified the first concrete corrections:
 
-Mark historical stronghold and roadmap documents as superseded, archival,
-or still authoritative. Move live decisions/research/todos into Cairn
-artefacts and leave concise pointers rather than competing sources of truth.
+- historical dead-code and tech-debt recon reports must be marked archival;
+- configuration material must not imply that `MAG_LLM_*` activates production
+  behaviour before an LLM backend is wired;
+- setup and CLI material must distinguish verified command transport from the
+  incomplete stdio/HTTP setup modes.
+
+Mark historical stronghold and roadmap documents as superseded, archival, or
+still authoritative. Move live decisions/research/todos into Cairn artefacts and
+leave concise pointers rather than competing sources of truth.

--- a/meta/todos/select-production-composition-root.md
+++ b/meta/todos/select-production-composition-root.md
@@ -1,12 +1,16 @@
 ---
-        node: mag.runtime.substrate
-        status: blocked
-        created: 2026-07-28
-        ---
-        # Select Production Composition Root
+node: mag.runtime.substrate
+status: open
+created: 2026-07-28
+unblocked: 2026-07-29
+---
+# Select Production Composition Root
 
-        Blocked by `todo.audit-current-architecture-and-dead-code`.
+The current architecture audit is complete. Decide whether substrate becomes the
+production composition root or its useful trait boundaries are folded into the
+existing SQLite-centred path.
 
-Decide whether substrate becomes the production composition root or its
-useful trait boundaries are folded into the existing pipeline. Record an
-accepted decision, migration slices, compatibility period, and removal path.
+Record an accepted decision, migration slices, compatibility period, and removal
+path. Compare public CLI/MCP parity, retrieval quality, latency, memory use,
+operational complexity, testability, and reversibility. Preserve the current
+`processed: ` CLI behaviour until a deliberate compatibility decision changes it.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -19,8 +19,8 @@ Common nodes:
 | Setup, configuration, paths, uninstall | `mag.runtime.setup` |
 | MCP protocol and tools | `mag.runtime.mcp` |
 | Memory domain/models/retrieval/storage | `mag.runtime.memory` |
-| Candidate trait-composed orchestration | `mag.runtime.substrate` |
-| Optional HTTP deployment adapter | `mag.runtime.daemon` |
+| Feature-gated candidate orchestration; tests/benchmarks only | `mag.runtime.substrate` |
+| Feature-gated HTTP support primitives; no assembled server | `mag.runtime.daemon` |
 
 Do not use this file as a source-tree map. The blueprint and node contracts are
 the maintained index.
@@ -31,8 +31,12 @@ the maintained index.
 - MCP stdio reserves stdout for JSON-RPC; send logs to stderr.
 - Public CLI or MCP changes require compatibility consideration and tests.
 - Synchronous SQLite work called from async code must use `spawn_blocking`.
-- Do not duplicate new production behaviour across `memory_core::Pipeline` and
-  `substrate` while the composition decision is unresolved.
+- `SqliteStorage` is the audited current production semantic centre;
+  `memory_core::Pipeline` is a compatibility-sensitive CLI adapter.
+- Do not duplicate new production behaviour across the legacy/direct SQLite path
+  and `substrate` while the composition decision is unresolved.
+- Do not advertise a setup transport unless the current binary serves it
+  end-to-end.
 - New files and cross-node calls must be represented in Cairn.
 
 Finish with focused tests, then `cairn scan` and `cairn hook all`.


### PR DESCRIPTION
## Problem

The roadmap blocked production-model wiring and cleanup on a current architecture audit. Existing recon reports predated the present module split, while the Cairn blueprint still described substrate and HTTP paths as though they were production-wired.

## Findings

- `SqliteStorage` is the current production semantic centre for MCP and most CLI capabilities.
- `memory_core::Pipeline` is a live, compatibility-sensitive CLI adapter, not the universal composition root.
- `substrate` and the LLM boundary are exercised by tests/benchmarks but have no production caller.
- `daemon-http` contains metadata/auth/idle primitives but no assembled HTTP server.
- setup advertises invalid or unavailable stdio/HTTP modes; only command transport reaches the current stdio server.

## Changes

- expand `res.architecture-state-audit` with caller, feature, test, benchmark, and cleanup evidence;
- add an immutable verified repository source and accepted boundary decision;
- correct the Cairn blueprint and runtime contracts to match actual production construction;
- complete the audit todo and unblock composition-root/document-rationalization work;
- add a focused setup-transport follow-up todo;
- update the runtime agent guide with the audited boundaries.

## Verification

This is an evidence and architecture-state PR rather than a runtime code change. It will be verified by the full repository CI and Cairn architecture gate. No deletion or production behaviour change is included.

## Roadmap impact

Completes the active P0 architecture/dead-code audit and opens the next two bounded decisions: fix generated transport configs, then select the single production composition root before LLM wiring.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Completes the current runtime architecture audit with a pinned evidence manifest (commit and checksum) and updates the blueprint and contracts to reflect the binary’s actual wiring. Clarifies live boundaries and restricts setup docs to the single executable transport, unblocking the composition‑root decision.

- **Architecture**
  - Added audit evidence and accepted `dec.classify-current-runtime-boundaries` with a pinned repository snapshot and checksum.
  - Updated `cairn.blueprint` and contracts to reflect: `SqliteStorage` as the current semantic center; `memory_core::Pipeline` as a compatibility‑sensitive CLI adapter; `substrate` as tests/benchmarks only; `daemon-http` as support primitives without an assembled server; stdio‑only MCP over SQLite; ONNX embedder and optional cross‑encoder; no production LLM or HTTP wiring.

- **Follow-ups**
  - Opened `correct-setup-transport-surface` to restrict generated transports to `mag serve` and fail unsupported stdio/HTTP modes.
  - Unblocked `select-production-composition-root` and stale‑document rationalization.
  - No runtime code changes. Verified via CI and Cairn gates.

<sup>Written for commit 18b8745391381082c45644b1ef54c69858f7668b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/George-RD/mag/pull/375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

