### PR TITLE
refactor(cli): route retrieve through local runtime

### DIFF
--- a/meta/todos/migrate-cli-to-local-memory-runtime.md
+++ b/meta/todos/migrate-cli-to-local-memory-runtime.md
@@ -26,6 +26,9 @@ permitted to hide inside a caller migration.
 - [x] `ingest` and `process` route through `LocalMemoryRuntime`; one shared helper
   now owns validation and `MemoryInput` assembly while stdout and the current
   `processed: ` stored-content contract remain pinned by a caller-level test.
-- [ ] Migrate retrieve/delete/update and other basic CRUD.
+- [x] `retrieve` routes through `LocalMemoryRuntime`; the same caller-level test
+  preserves exact JSON and stored content, with red evidence against the legacy
+  entrypoint path before the production change.
+- [ ] Migrate delete/update and other basic CRUD.
 - [ ] Migrate search, semantic/advanced retrieval, graph, session, and
   administration commands.

--- a/src/main.rs
+++ b/src/main.rs
@@ -251,8 +251,8 @@ async fn main() -> anyhow::Result<()> {
         }
         Commands::Retrieve { id } => {
             info!(memory_id = %id, "Retrieving memory");
-            let result = pipeline.retrieve(id).await?;
-            info!(memory_id = %id, content_len = result.len(), "Retrieved memory");
+            let result = local_runtime.retrieve(id).await?;
+            info!(memory_id = %id, content_len = result.len(), "Retrieved through local memory runtime");
             println!("{}", json!({ "id": id, "content": result }));
         }
         Commands::Delete { id } => {

--- a/tests/cli_store_runtime_migration.rs
+++ b/tests/cli_store_runtime_migration.rs
@@ -62,8 +62,8 @@ fn assert_store_command_contract(home: &Path, command: &str, content: &str) -> a
     );
 
     let retrieve = run_cli(home, &["retrieve", id])?;
-    let retrieve_stderr = String::from_utf8(retrieve.stderr.clone())?;
     let retrieve_payload: serde_json::Value = serde_json::from_slice(retrieve.stdout.as_slice())?;
+    let retrieve_stderr = String::from_utf8(retrieve.stderr)?;
     let expected_content = format!("processed: {content}");
     assert_eq!(retrieve_payload["id"].as_str(), Some(id));
     assert_eq!(

--- a/tests/cli_store_runtime_migration.rs
+++ b/tests/cli_store_runtime_migration.rs
@@ -62,6 +62,7 @@ fn assert_store_command_contract(home: &Path, command: &str, content: &str) -> a
     );
 
     let retrieve = run_cli(home, &["retrieve", id])?;
+    let retrieve_stderr = String::from_utf8(retrieve.stderr.clone())?;
     let retrieve_payload: serde_json::Value = serde_json::from_slice(retrieve.stdout.as_slice())?;
     let expected_content = format!("processed: {content}");
     assert_eq!(retrieve_payload["id"].as_str(), Some(id));
@@ -69,12 +70,16 @@ fn assert_store_command_contract(home: &Path, command: &str, content: &str) -> a
         retrieve_payload["content"].as_str(),
         Some(expected_content.as_str())
     );
+    assert!(
+        retrieve_stderr.contains("Retrieved through local memory runtime"),
+        "retrieve did not report the selected runtime path: {retrieve_stderr}"
+    );
 
     Ok(())
 }
 
 #[test]
-fn ingest_and_process_use_local_runtime_without_contract_drift() -> anyhow::Result<()> {
+fn store_and_retrieve_commands_use_local_runtime_without_contract_drift() -> anyhow::Result<()> {
     let home = std::env::temp_dir().join(format!("mag-cli-store-runtime-{}", uuid::Uuid::new_v4()));
     std::fs::create_dir_all(&home)?;
 


### PR DESCRIPTION
## Scope

Implements the next bounded slice of `todo.migrate-cli-to-local-memory-runtime`:

- route the basic `retrieve` command through `LocalMemoryRuntime`;
- preserve exact compact JSON stdout and the current stored-content contract;
- reuse the existing caller-level store/retrieve regression;
- avoid an unnecessary stderr buffer clone in that test;
- leave delete/update, search, advanced retrieval, MCP, storage, ranking, schemas, and model behaviour unchanged.

## TDD evidence

- **Red:** commit `569ec535174fe435ab7cb43b9b136277717b3795` changed only the caller-level regression. CI run `30520665092`, job `90800069486`, failed because `retrieve` still reported the legacy path while its JSON and stored content remained correct.
- **Green:** the production caller now delegates to `LocalMemoryRuntime::retrieve`; the same test passes without changing the output contract.
- **Refactor:** the test consumes stderr directly instead of cloning its buffer.

## Verification

Exact head `a6b70645485b6e1a259de57b87f966af9aa2ffa5`:

- CI `30521335813`: formatting, Clippy, full all-feature Rust tests, smoke, npm installation, Python 3.8/3.13 wrappers, version consistency, and all shell-installer integrity variants passed.
- Cairn architecture gate `30521335811`: passed.
- Benchmark gate: correctly skipped because no retrieval ranking, scoring, reranking, or storage-query implementation changed.
- No unresolved review threads.

## Cairn

Updates `todo.migrate-cli-to-local-memory-runtime` to record `retrieve` as complete. Delete/update and the remaining command families stay as separately reviewable follow-ups.