### PR TITLE
refactor(mcp): route legacy session tools through local runtime

### DIFF
--- a/meta/todos/migrate-mcp-to-local-memory-runtime.md
+++ b/meta/todos/migrate-mcp-to-local-memory-runtime.md
@@ -30,7 +30,13 @@ milestone.
 - [x] Route the unified `memory_session` facade through the same runtime for
   welcome/info, checkpoints, reminders, lessons, and profile state. Minimal-mode
   stdio parity and shared-state visibility with the still-unmigrated `memory`
-  facade remain pinned. Legacy individual session tools remain queued.
+  facade remain pinned.
+- [x] Route the five individual legacy session tools through the same server-owned
+  runtime: `memory_session_info`, `memory_checkpoint`, `memory_remind`,
+  `memory_lessons`, and `memory_profile`. Full-mode stdio parity pins the exact
+  19-tool advertisement, welcome and protocol output, checkpoint continuity,
+  reminder and profile state, lesson payloads, validation errors, and visibility
+  of data written by the still-unmigrated legacy `memory_store` tool.
 
 ## Verification
 
@@ -49,3 +55,11 @@ milestone.
   passed in CI run `30692921429` at commit `d04e929`.
 - Cairn architecture, decision, and interface verification passed in run
   `30692921426` at the same commit.
+- Red: commit `27387a7` passed Rustfmt and then failed CI run `30793307211` with
+  twelve `E0308` type errors because the five legacy session functions still
+  accepted `SqliteStorage` while the parity tests required `LocalMemoryRuntime`.
+- Green: full Rust tests, Rustfmt, Clippy, smoke, npm installation, Python wrappers,
+  installer integrity, version consistency, and the non-applicable benchmark gate
+  passed in CI run `30794130536` at commit `97167bc`.
+- Cairn architecture, decision, and interface verification passed in run
+  `30794130526` at the same commit.

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -473,7 +473,7 @@ impl McpMemoryServer {
         &self,
         params: Parameters<CheckpointRequest>,
     ) -> Result<CallToolResult, McpError> {
-        tools::session::memory_checkpoint(&self.storage, &params.0).await
+        tools::session::memory_checkpoint(self.runtime.as_ref(), &params.0).await
     }
 
     #[tool(
@@ -484,7 +484,7 @@ impl McpMemoryServer {
         &self,
         params: Parameters<RemindRequest>,
     ) -> Result<CallToolResult, McpError> {
-        tools::session::memory_remind(&self.storage, &params.0).await
+        tools::session::memory_remind(self.runtime.as_ref(), &params.0).await
     }
 
     #[tool(
@@ -495,7 +495,7 @@ impl McpMemoryServer {
         &self,
         params: Parameters<LessonsRequest>,
     ) -> Result<CallToolResult, McpError> {
-        tools::session::memory_lessons(&self.storage, &params.0).await
+        tools::session::memory_lessons(self.runtime.as_ref(), &params.0).await
     }
 
     #[tool(
@@ -506,7 +506,7 @@ impl McpMemoryServer {
         &self,
         params: Parameters<ProfileRequest>,
     ) -> Result<CallToolResult, McpError> {
-        tools::session::memory_profile(&self.storage, &params.0).await
+        tools::session::memory_profile(self.runtime.as_ref(), &params.0).await
     }
 
     #[tool(
@@ -517,7 +517,7 @@ impl McpMemoryServer {
         &self,
         params: Parameters<SessionInfoRequest>,
     ) -> Result<CallToolResult, McpError> {
-        tools::session::memory_session_info(&self.storage, &params.0).await
+        tools::session::memory_session_info(self.runtime.as_ref(), &params.0).await
     }
 
     #[tool(

--- a/src/mcp/tools/legacy_session_runtime_migration_tests.rs
+++ b/src/mcp/tools/legacy_session_runtime_migration_tests.rs
@@ -1,0 +1,219 @@
+use serde::de::DeserializeOwned;
+use serde_json::json;
+
+use super::session;
+use crate::mcp::{
+    McpMemoryServer,
+    request_types::{
+        CheckpointRequest, LessonsRequest, ProfileRequest, RemindRequest, SessionInfoRequest,
+    },
+};
+use crate::memory_core::storage::SqliteStorage;
+use crate::memory_core::{EventType, MemoryInput, Storage};
+
+fn request<T: DeserializeOwned>(value: serde_json::Value) -> T {
+    serde_json::from_value(value).expect("legacy session request should deserialize")
+}
+
+fn result_text(result: &rmcp::model::CallToolResult) -> String {
+    assert_eq!(result.content.len(), 1, "expected one text content item");
+    result.content[0]
+        .as_text()
+        .expect("expected text content")
+        .text
+        .clone()
+}
+
+#[tokio::test]
+async fn legacy_session_tools_route_all_subfamilies_through_the_server_runtime() {
+    let storage = SqliteStorage::new_in_memory().expect("in-memory storage should initialize");
+    let lesson = MemoryInput {
+        id: Some("legacy-session-runtime-lesson".to_string()),
+        content: "preserve the legacy session protocol contract".to_string(),
+        event_type: Some(EventType::LessonLearned),
+        project: Some("mcp-runtime".to_string()),
+        ..MemoryInput::default()
+    };
+    <SqliteStorage as Storage>::store(
+        &storage,
+        "legacy-session-runtime-lesson",
+        "preserve the legacy session protocol contract",
+        &lesson,
+    )
+    .await
+    .expect("lesson fixture should store");
+
+    let server = McpMemoryServer::new(storage);
+
+    let welcome = session::memory_session_info(
+        server.runtime.as_ref(),
+        &request::<SessionInfoRequest>(json!({"project": "mcp-runtime"})),
+    )
+    .await
+    .expect("legacy welcome should succeed");
+    let welcome_payload: serde_json::Value =
+        serde_json::from_str(&result_text(&welcome)).expect("welcome should be JSON");
+    assert_eq!(welcome_payload["memory_count"], 1);
+    assert!(
+        welcome_payload["recent_memories"]
+            .as_array()
+            .expect("recent_memories should be an array")
+            .iter()
+            .any(|memory| memory["id"] == "legacy-session-runtime-lesson")
+    );
+
+    let protocol = session::memory_session_info(
+        server.runtime.as_ref(),
+        &request::<SessionInfoRequest>(json!({"mode": "protocol"})),
+    )
+    .await
+    .expect("legacy protocol response should succeed");
+    let protocol_text = result_text(&protocol);
+    assert!(protocol_text.starts_with("# MAG Protocol\n"));
+    assert!(protocol_text.contains("**memory_session_info**"));
+
+    let checkpoint = session::memory_checkpoint(
+        server.runtime.as_ref(),
+        &request::<CheckpointRequest>(json!({
+            "task_title": "migrate legacy session tools",
+            "progress": "runtime boundary is under test",
+            "project": "mcp-runtime"
+        })),
+    )
+    .await
+    .expect("legacy checkpoint save should succeed");
+    let checkpoint_payload: serde_json::Value =
+        serde_json::from_str(&result_text(&checkpoint)).expect("checkpoint should be JSON");
+    assert_eq!(checkpoint_payload["checkpoint_number"], 1);
+    assert!(checkpoint_payload["memory_id"].as_str().is_some());
+
+    let resumed = session::memory_checkpoint(
+        server.runtime.as_ref(),
+        &request::<CheckpointRequest>(json!({
+            "action": "resume",
+            "task_title": "migrate legacy session tools",
+            "project": "mcp-runtime",
+            "limit": 1
+        })),
+    )
+    .await
+    .expect("legacy checkpoint resume should succeed");
+    let resumed_text = result_text(&resumed);
+    assert!(resumed_text.contains("migrate legacy session tools"));
+    assert!(resumed_text.contains("runtime boundary is under test"));
+
+    let reminder = session::memory_remind(
+        server.runtime.as_ref(),
+        &request::<RemindRequest>(json!({
+            "text": "finish the legacy session migration",
+            "duration": "1h",
+            "project": "mcp-runtime"
+        })),
+    )
+    .await
+    .expect("legacy reminder set should succeed");
+    let reminder_payload: serde_json::Value =
+        serde_json::from_str(&result_text(&reminder)).expect("reminder should be JSON");
+    let reminder_id = reminder_payload["reminder_id"]
+        .as_str()
+        .expect("reminder should return its id");
+
+    let reminders = session::memory_remind(
+        server.runtime.as_ref(),
+        &request::<RemindRequest>(json!({"action": "list"})),
+    )
+    .await
+    .expect("legacy reminder list should succeed");
+    let reminders_payload: serde_json::Value =
+        serde_json::from_str(&result_text(&reminders)).expect("reminder list should be JSON");
+    assert!(
+        reminders_payload["results"]
+            .as_array()
+            .expect("reminder results should be an array")
+            .iter()
+            .any(|entry| entry["reminder_id"] == reminder_id)
+    );
+
+    let dismissed = session::memory_remind(
+        server.runtime.as_ref(),
+        &request::<RemindRequest>(json!({
+            "action": "dismiss",
+            "reminder_id": reminder_id
+        })),
+    )
+    .await
+    .expect("legacy reminder dismiss should succeed");
+    let dismissed_payload: serde_json::Value =
+        serde_json::from_str(&result_text(&dismissed)).expect("dismiss result should be JSON");
+    assert_eq!(dismissed_payload["status"], "dismissed");
+
+    let lessons = session::memory_lessons(
+        server.runtime.as_ref(),
+        &request::<LessonsRequest>(json!({
+            "project": "mcp-runtime",
+            "limit": 5
+        })),
+    )
+    .await
+    .expect("legacy lesson query should succeed");
+    let lessons_payload: serde_json::Value =
+        serde_json::from_str(&result_text(&lessons)).expect("lessons should be JSON");
+    assert!(
+        lessons_payload["results"]
+            .as_array()
+            .expect("lesson results should be an array")
+            .iter()
+            .any(|entry| entry["lesson_id"] == "legacy-session-runtime-lesson")
+    );
+
+    let profile_update = session::memory_profile(
+        server.runtime.as_ref(),
+        &request::<ProfileRequest>(json!({
+            "action": "update",
+            "update": {"preferred_editor": "helix"}
+        })),
+    )
+    .await
+    .expect("legacy profile update should succeed");
+    assert_eq!(result_text(&profile_update), r#"{"updated":true}"#);
+
+    let profile = session::memory_profile(
+        server.runtime.as_ref(),
+        &request::<ProfileRequest>(json!({})),
+    )
+    .await
+    .expect("legacy profile read should succeed");
+    let profile_payload: serde_json::Value =
+        serde_json::from_str(&result_text(&profile)).expect("profile should be JSON");
+    assert_eq!(profile_payload["preferred_editor"], "helix");
+}
+
+#[tokio::test]
+async fn legacy_session_tools_preserve_validation_errors_at_the_runtime_boundary() {
+    let server = McpMemoryServer::new(
+        SqliteStorage::new_in_memory().expect("in-memory storage should initialize"),
+    );
+
+    let missing_title = session::memory_checkpoint(
+        server.runtime.as_ref(),
+        &request::<CheckpointRequest>(json!({"progress": "missing title"})),
+    )
+    .await
+    .expect_err("legacy checkpoint title should remain required");
+    assert!(
+        format!("{missing_title:?}").contains("task_title is required for action=save"),
+        "unexpected checkpoint validation error: {missing_title:?}"
+    );
+
+    let invalid_mode = session::memory_session_info(
+        server.runtime.as_ref(),
+        &request::<SessionInfoRequest>(json!({"mode": "summary"})),
+    )
+    .await
+    .expect_err("unknown legacy session info mode should remain invalid");
+    assert!(
+        format!("{invalid_mode:?}")
+            .contains("unknown session info mode: summary (expected welcome|protocol)"),
+        "unexpected session-info validation error: {invalid_mode:?}"
+    );
+}

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -6,6 +6,8 @@ pub(crate) mod session;
 pub(crate) mod storage;
 
 #[cfg(test)]
+mod legacy_session_runtime_migration_tests;
+#[cfg(test)]
 mod runtime_migration_tests;
 #[cfg(test)]
 mod session_runtime_migration_tests;

--- a/src/mcp/tools/session.rs
+++ b/src/mcp/tools/session.rs
@@ -4,11 +4,8 @@ use rmcp::{
 };
 use serde_json::json;
 
-use crate::memory_core::storage::SqliteStorage;
-use crate::memory_core::{
-    CheckpointInput, CheckpointManager, LessonQuerier, ProfileManager, ReminderManager,
-    WelcomeProvider,
-};
+use crate::LocalMemoryRuntime;
+use crate::memory_core::{CheckpointInput, WelcomeOptions};
 
 use super::super::generate_protocol_markdown;
 use super::super::request_types::{
@@ -19,7 +16,7 @@ use super::super::validation::MAX_RESULT_LIMIT;
 // ── memory_checkpoint ──
 
 pub(crate) async fn memory_checkpoint(
-    storage: &SqliteStorage,
+    runtime: &LocalMemoryRuntime,
     req: &CheckpointRequest,
 ) -> Result<CallToolResult, McpError> {
     let action = req.action.as_deref().unwrap_or("save");
@@ -43,22 +40,19 @@ pub(crate) async fn memory_checkpoint(
                 session_id: req.session_id.clone(),
                 project: req.project.clone(),
             };
-            let memory_id = <SqliteStorage as CheckpointManager>::save_checkpoint(storage, input)
+            let memory_id = runtime.save_checkpoint(input).await.map_err(|e| {
+                McpError::internal_error(format!("failed to save checkpoint: {e}"), None)
+            })?;
+
+            let latest = runtime
+                .resume_task(task_title, req.project.as_deref(), 1)
                 .await
                 .map_err(|e| {
-                    McpError::internal_error(format!("failed to save checkpoint: {e}"), None)
+                    McpError::internal_error(
+                        format!("failed to resolve checkpoint number: {e}"),
+                        None,
+                    )
                 })?;
-
-            let latest = <SqliteStorage as CheckpointManager>::resume_task(
-                storage,
-                task_title,
-                req.project.as_deref(),
-                1,
-            )
-            .await
-            .map_err(|e| {
-                McpError::internal_error(format!("failed to resolve checkpoint number: {e}"), None)
-            })?;
             let checkpoint_number = latest
                 .first()
                 .and_then(|entry| entry.get("metadata"))
@@ -74,14 +68,12 @@ pub(crate) async fn memory_checkpoint(
         "resume" => {
             let query = req.task_title.clone().unwrap_or_default();
             let limit = req.limit.unwrap_or(1).min(MAX_RESULT_LIMIT);
-            let results = <SqliteStorage as CheckpointManager>::resume_task(
-                storage,
-                &query,
-                req.project.as_deref(),
-                limit,
-            )
-            .await
-            .map_err(|e| McpError::internal_error(format!("failed to resume task: {e}"), None))?;
+            let results = runtime
+                .resume_task(&query, req.project.as_deref(), limit)
+                .await
+                .map_err(|e| {
+                    McpError::internal_error(format!("failed to resume task: {e}"), None)
+                })?;
 
             let mut markdown = String::new();
             for (index, entry) in results.iter().enumerate() {
@@ -108,7 +100,7 @@ pub(crate) async fn memory_checkpoint(
 // ── memory_remind ──
 
 pub(crate) async fn memory_remind(
-    storage: &SqliteStorage,
+    runtime: &LocalMemoryRuntime,
     req: &RemindRequest,
 ) -> Result<CallToolResult, McpError> {
     let action = req.action.as_deref().unwrap_or("set");
@@ -121,29 +113,29 @@ pub(crate) async fn memory_remind(
             let duration = req.duration.as_deref().ok_or_else(|| {
                 McpError::invalid_params("duration is required for action=set", None)
             })?;
-            let result = <SqliteStorage as ReminderManager>::create_reminder(
-                storage,
-                text,
-                duration,
-                req.context.as_deref(),
-                req.session_id.as_deref(),
-                req.project.as_deref(),
-            )
-            .await
-            .map_err(|e| {
-                McpError::internal_error(format!("failed to create reminder: {e}"), None)
-            })?;
+            let result = runtime
+                .create_reminder(
+                    text,
+                    duration,
+                    req.context.as_deref(),
+                    req.session_id.as_deref(),
+                    req.project.as_deref(),
+                )
+                .await
+                .map_err(|e| {
+                    McpError::internal_error(format!("failed to create reminder: {e}"), None)
+                })?;
             Ok(CallToolResult::success(vec![Content::text(
                 result.to_string(),
             )]))
         }
         "list" => {
-            let result =
-                <SqliteStorage as ReminderManager>::list_reminders(storage, req.status.as_deref())
-                    .await
-                    .map_err(|e| {
-                        McpError::internal_error(format!("failed to list reminders: {e}"), None)
-                    })?;
+            let result = runtime
+                .list_reminders(req.status.as_deref())
+                .await
+                .map_err(|e| {
+                    McpError::internal_error(format!("failed to list reminders: {e}"), None)
+                })?;
             Ok(CallToolResult::success(vec![Content::text(
                 json!({ "results": result }).to_string(),
             )]))
@@ -152,11 +144,9 @@ pub(crate) async fn memory_remind(
             let reminder_id = req.reminder_id.as_deref().ok_or_else(|| {
                 McpError::invalid_params("reminder_id is required for action=dismiss", None)
             })?;
-            let result = <SqliteStorage as ReminderManager>::dismiss_reminder(storage, reminder_id)
-                .await
-                .map_err(|e| {
-                    McpError::internal_error(format!("failed to dismiss reminder: {e}"), None)
-                })?;
+            let result = runtime.dismiss_reminder(reminder_id).await.map_err(|e| {
+                McpError::internal_error(format!("failed to dismiss reminder: {e}"), None)
+            })?;
             Ok(CallToolResult::success(vec![Content::text(
                 result.to_string(),
             )]))
@@ -171,20 +161,20 @@ pub(crate) async fn memory_remind(
 // ── memory_lessons ──
 
 pub(crate) async fn memory_lessons(
-    storage: &SqliteStorage,
+    runtime: &LocalMemoryRuntime,
     req: &LessonsRequest,
 ) -> Result<CallToolResult, McpError> {
     let limit = req.limit.unwrap_or(5).min(MAX_RESULT_LIMIT);
-    let lessons = <SqliteStorage as LessonQuerier>::query_lessons(
-        storage,
-        req.task.as_deref(),
-        req.project.as_deref(),
-        req.exclude_session.as_deref(),
-        req.agent_type.as_deref(),
-        limit,
-    )
-    .await
-    .map_err(|e| McpError::internal_error(format!("failed to query lessons: {e}"), None))?;
+    let lessons = runtime
+        .query_lessons(
+            req.task.as_deref(),
+            req.project.as_deref(),
+            req.exclude_session.as_deref(),
+            req.agent_type.as_deref(),
+            limit,
+        )
+        .await
+        .map_err(|e| McpError::internal_error(format!("failed to query lessons: {e}"), None))?;
 
     Ok(CallToolResult::success(vec![Content::text(
         json!({ "results": lessons }).to_string(),
@@ -194,17 +184,15 @@ pub(crate) async fn memory_lessons(
 // ── memory_profile ──
 
 pub(crate) async fn memory_profile(
-    storage: &SqliteStorage,
+    runtime: &LocalMemoryRuntime,
     req: &ProfileRequest,
 ) -> Result<CallToolResult, McpError> {
     let action = req.action.as_deref().unwrap_or("read");
     match action {
         "read" => {
-            let profile = <SqliteStorage as ProfileManager>::get_profile(storage)
-                .await
-                .map_err(|e| {
-                    McpError::internal_error(format!("failed to read profile: {e}"), None)
-                })?;
+            let profile = runtime.get_profile().await.map_err(|e| {
+                McpError::internal_error(format!("failed to read profile: {e}"), None)
+            })?;
             Ok(CallToolResult::success(vec![Content::text(
                 profile.to_string(),
             )]))
@@ -213,11 +201,9 @@ pub(crate) async fn memory_profile(
             let updates = req.update.as_ref().ok_or_else(|| {
                 McpError::invalid_params("update payload is required for action=update", None)
             })?;
-            <SqliteStorage as ProfileManager>::set_profile(storage, updates)
-                .await
-                .map_err(|e| {
-                    McpError::internal_error(format!("failed to update profile: {e}"), None)
-                })?;
+            runtime.set_profile(updates).await.map_err(|e| {
+                McpError::internal_error(format!("failed to update profile: {e}"), None)
+            })?;
             Ok(CallToolResult::success(vec![Content::text(
                 json!({ "updated": true }).to_string(),
             )]))
@@ -232,13 +218,18 @@ pub(crate) async fn memory_profile(
 // ── memory_session_info ──
 
 pub(crate) async fn memory_session_info(
-    storage: &SqliteStorage,
+    runtime: &LocalMemoryRuntime,
     req: &SessionInfoRequest,
 ) -> Result<CallToolResult, McpError> {
     match req.mode.as_deref().unwrap_or("welcome") {
         "welcome" => {
-            let result = storage
-                .welcome(req.session_id.as_deref(), req.project.as_deref())
+            let options = WelcomeOptions {
+                session_id: req.session_id.clone(),
+                project: req.project.clone(),
+                ..WelcomeOptions::default()
+            };
+            let result = runtime
+                .welcome_scoped(&options)
                 .await
                 .map_err(|e| McpError::internal_error(format!("welcome failed: {e}"), None))?;
 

--- a/tests/mcp_legacy_session_runtime_migration.rs
+++ b/tests/mcp_legacy_session_runtime_migration.rs
@@ -51,10 +51,8 @@ fn text_json(result: &rmcp::model::CallToolResult) -> serde_json::Value {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn full_mode_preserves_legacy_session_tools_through_the_local_runtime()
 -> Result<(), Box<dyn std::error::Error>> {
-    let test_home = std::env::temp_dir().join(format!(
-        "mag-mcp-legacy-session-{}",
-        uuid::Uuid::new_v4()
-    ));
+    let test_home =
+        std::env::temp_dir().join(format!("mag-mcp-legacy-session-{}", uuid::Uuid::new_v4()));
     fs::create_dir_all(&test_home)?;
 
     let mut service = ()
@@ -264,10 +262,7 @@ async fn full_mode_preserves_legacy_session_tools_through_the_local_runtime()
         }),
     )
     .await??;
-    assert_eq!(
-        text_contents(&profile_update),
-        vec![r#"{"updated":true}"#]
-    );
+    assert_eq!(text_contents(&profile_update), vec![r#"{"updated":true}"#]);
 
     let profile = timeout(
         Duration::from_secs(20),

--- a/tests/mcp_legacy_session_runtime_migration.rs
+++ b/tests/mcp_legacy_session_runtime_migration.rs
@@ -1,0 +1,327 @@
+use std::{fs, time::Duration};
+
+use rmcp::{
+    ServiceExt,
+    model::CallToolRequestParams,
+    transport::{ConfigureCommandExt, TokioChildProcess},
+};
+use tokio::{process::Command, time::timeout};
+
+const FULL_TOOL_NAMES: &[&str] = &[
+    "memory",
+    "memory_admin",
+    "memory_checkpoint",
+    "memory_delete",
+    "memory_feedback",
+    "memory_lessons",
+    "memory_lifecycle",
+    "memory_list",
+    "memory_manage",
+    "memory_profile",
+    "memory_relations",
+    "memory_remind",
+    "memory_retrieve",
+    "memory_search",
+    "memory_session",
+    "memory_session_info",
+    "memory_store",
+    "memory_store_batch",
+    "memory_update",
+];
+
+fn arguments(value: serde_json::Value) -> serde_json::Map<String, serde_json::Value> {
+    value
+        .as_object()
+        .expect("tool arguments should be an object")
+        .clone()
+}
+
+fn text_contents(result: &rmcp::model::CallToolResult) -> Vec<String> {
+    result
+        .content
+        .iter()
+        .filter_map(|content| content.as_text().map(|text| text.text.clone()))
+        .collect()
+}
+
+fn text_json(result: &rmcp::model::CallToolResult) -> serde_json::Value {
+    serde_json::from_str(&text_contents(result).join("")).expect("tool result should be JSON")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn full_mode_preserves_legacy_session_tools_through_the_local_runtime()
+-> Result<(), Box<dyn std::error::Error>> {
+    let test_home = std::env::temp_dir().join(format!(
+        "mag-mcp-legacy-session-{}",
+        uuid::Uuid::new_v4()
+    ));
+    fs::create_dir_all(&test_home)?;
+
+    let mut service = ()
+        .serve(TokioChildProcess::new(
+            Command::new(env!("CARGO_BIN_EXE_mag")).configure(|cmd| {
+                cmd.current_dir(env!("CARGO_MANIFEST_DIR"));
+                cmd.arg("serve");
+                cmd.env("HOME", &test_home);
+                cmd.env("USERPROFILE", &test_home);
+            }),
+        )?)
+        .await?;
+
+    let tools = timeout(
+        Duration::from_secs(20),
+        service.list_tools(Default::default()),
+    )
+    .await??;
+    let mut tool_names: Vec<String> = tools
+        .tools
+        .iter()
+        .map(|tool| tool.name.to_string())
+        .collect();
+    tool_names.sort();
+    assert_eq!(tool_names, FULL_TOOL_NAMES);
+
+    let stored = timeout(
+        Duration::from_secs(20),
+        service.call_tool(CallToolRequestParams {
+            meta: None,
+            name: "memory_store".into(),
+            arguments: Some(arguments(serde_json::json!({
+                "content": "protocol-visible legacy session lesson",
+                "id": "mcp-legacy-session-lesson",
+                "event_type": "lesson_learned",
+                "project": "mcp-legacy-session"
+            }))),
+            task: None,
+        }),
+    )
+    .await??;
+    assert_eq!(
+        text_contents(&stored),
+        vec![r#"{"id":"mcp-legacy-session-lesson"}"#]
+    );
+
+    let welcome = timeout(
+        Duration::from_secs(20),
+        service.call_tool(CallToolRequestParams {
+            meta: None,
+            name: "memory_session_info".into(),
+            arguments: Some(arguments(serde_json::json!({
+                "project": "mcp-legacy-session"
+            }))),
+            task: None,
+        }),
+    )
+    .await??;
+    let welcome_payload = text_json(&welcome);
+    assert_eq!(welcome_payload["memory_count"], 1);
+    assert!(
+        welcome_payload["recent_memories"]
+            .as_array()
+            .expect("recent_memories should be an array")
+            .iter()
+            .any(|memory| memory["id"] == "mcp-legacy-session-lesson")
+    );
+
+    let protocol = timeout(
+        Duration::from_secs(20),
+        service.call_tool(CallToolRequestParams {
+            meta: None,
+            name: "memory_session_info".into(),
+            arguments: Some(arguments(serde_json::json!({"mode": "protocol"}))),
+            task: None,
+        }),
+    )
+    .await??;
+    let protocol_text = text_contents(&protocol).join("");
+    assert!(protocol_text.starts_with("# MAG Protocol\n"));
+    assert!(protocol_text.contains("**memory_session_info**"));
+
+    let checkpoint = timeout(
+        Duration::from_secs(20),
+        service.call_tool(CallToolRequestParams {
+            meta: None,
+            name: "memory_checkpoint".into(),
+            arguments: Some(arguments(serde_json::json!({
+                "task_title": "migrate legacy session tools",
+                "progress": "stdio contract is pinned",
+                "project": "mcp-legacy-session"
+            }))),
+            task: None,
+        }),
+    )
+    .await??;
+    let checkpoint_payload = text_json(&checkpoint);
+    assert_eq!(checkpoint_payload["checkpoint_number"], 1);
+    assert!(checkpoint_payload["memory_id"].as_str().is_some());
+
+    let resumed = timeout(
+        Duration::from_secs(20),
+        service.call_tool(CallToolRequestParams {
+            meta: None,
+            name: "memory_checkpoint".into(),
+            arguments: Some(arguments(serde_json::json!({
+                "action": "resume",
+                "task_title": "migrate legacy session tools",
+                "project": "mcp-legacy-session",
+                "limit": 1
+            }))),
+            task: None,
+        }),
+    )
+    .await??;
+    let resumed_text = text_contents(&resumed).join("");
+    assert!(resumed_text.contains("migrate legacy session tools"));
+    assert!(resumed_text.contains("stdio contract is pinned"));
+
+    let reminder = timeout(
+        Duration::from_secs(20),
+        service.call_tool(CallToolRequestParams {
+            meta: None,
+            name: "memory_remind".into(),
+            arguments: Some(arguments(serde_json::json!({
+                "text": "finish the legacy session migration",
+                "duration": "1h",
+                "project": "mcp-legacy-session"
+            }))),
+            task: None,
+        }),
+    )
+    .await??;
+    let reminder_payload = text_json(&reminder);
+    let reminder_id = reminder_payload["reminder_id"]
+        .as_str()
+        .expect("reminder should return its id")
+        .to_string();
+
+    let reminders = timeout(
+        Duration::from_secs(20),
+        service.call_tool(CallToolRequestParams {
+            meta: None,
+            name: "memory_remind".into(),
+            arguments: Some(arguments(serde_json::json!({"action": "list"}))),
+            task: None,
+        }),
+    )
+    .await??;
+    assert!(
+        text_json(&reminders)["results"]
+            .as_array()
+            .expect("reminder results should be an array")
+            .iter()
+            .any(|entry| entry["reminder_id"] == reminder_id)
+    );
+
+    let dismissed = timeout(
+        Duration::from_secs(20),
+        service.call_tool(CallToolRequestParams {
+            meta: None,
+            name: "memory_remind".into(),
+            arguments: Some(arguments(serde_json::json!({
+                "action": "dismiss",
+                "reminder_id": reminder_id
+            }))),
+            task: None,
+        }),
+    )
+    .await??;
+    assert_eq!(text_json(&dismissed)["status"], "dismissed");
+
+    let lessons = timeout(
+        Duration::from_secs(20),
+        service.call_tool(CallToolRequestParams {
+            meta: None,
+            name: "memory_lessons".into(),
+            arguments: Some(arguments(serde_json::json!({
+                "project": "mcp-legacy-session",
+                "limit": 5
+            }))),
+            task: None,
+        }),
+    )
+    .await??;
+    assert!(
+        text_json(&lessons)["results"]
+            .as_array()
+            .expect("lesson results should be an array")
+            .iter()
+            .any(|entry| {
+                entry["lesson_id"] == "mcp-legacy-session-lesson"
+                    && entry["content"] == "protocol-visible legacy session lesson"
+            })
+    );
+
+    let profile_update = timeout(
+        Duration::from_secs(20),
+        service.call_tool(CallToolRequestParams {
+            meta: None,
+            name: "memory_profile".into(),
+            arguments: Some(arguments(serde_json::json!({
+                "action": "update",
+                "update": {"preferred_editor": "helix"}
+            }))),
+            task: None,
+        }),
+    )
+    .await??;
+    assert_eq!(
+        text_contents(&profile_update),
+        vec![r#"{"updated":true}"#]
+    );
+
+    let profile = timeout(
+        Duration::from_secs(20),
+        service.call_tool(CallToolRequestParams {
+            meta: None,
+            name: "memory_profile".into(),
+            arguments: Some(arguments(serde_json::json!({}))),
+            task: None,
+        }),
+    )
+    .await??;
+    assert_eq!(text_json(&profile)["preferred_editor"], "helix");
+
+    let missing_title = timeout(
+        Duration::from_secs(20),
+        service.call_tool(CallToolRequestParams {
+            meta: None,
+            name: "memory_checkpoint".into(),
+            arguments: Some(arguments(serde_json::json!({
+                "progress": "missing title"
+            }))),
+            task: None,
+        }),
+    )
+    .await?
+    .expect_err("legacy checkpoint title should remain a protocol invalid-params error");
+    assert!(
+        format!("{missing_title:?}").contains("task_title is required for action=save"),
+        "unexpected protocol checkpoint error: {missing_title:?}"
+    );
+
+    let invalid_mode = timeout(
+        Duration::from_secs(20),
+        service.call_tool(CallToolRequestParams {
+            meta: None,
+            name: "memory_session_info".into(),
+            arguments: Some(arguments(serde_json::json!({"mode": "summary"}))),
+            task: None,
+        }),
+    )
+    .await?
+    .expect_err("unknown legacy session info mode should remain invalid");
+    assert!(
+        format!("{invalid_mode:?}")
+            .contains("unknown session info mode: summary (expected welcome|protocol)"),
+        "unexpected protocol session-info error: {invalid_mode:?}"
+    );
+
+    let shutdown = timeout(
+        Duration::from_secs(20),
+        service.close_with_timeout(Duration::from_secs(5)),
+    )
+    .await?;
+    assert!(shutdown?.is_some());
+    let _ = fs::remove_dir_all(&test_home);
+    Ok(())
+}


### PR DESCRIPTION
## Scope

Continue `todo.migrate-mcp-to-local-memory-runtime` with the five individual legacy session tools:

- `memory_session_info`
- `memory_checkpoint`
- `memory_remind`
- `memory_lessons`
- `memory_profile`

## Implementation

- Replaced direct `SqliteStorage` trait calls in the five legacy handlers with the corresponding `LocalMemoryRuntime` delegates.
- Routed all five `McpMemoryServer` tool methods through the server-owned runtime.
- Preserved request validation, exact JSON and markdown payloads, reminder/checkpoint/profile state, protocol output, and full-mode tool advertisement.
- Recorded the completed slice in the authoritative Cairn todo; the broader MCP migration remains `in_progress`.

## TDD

- **Red:** commit `27387a7` passed Rustfmt and then failed CI run `30793307211` with twelve `E0308` errors because the handlers still required `SqliteStorage` while the tests required `LocalMemoryRuntime`.
- **Green:** commit `97167bc` passed full Rust tests, Rustfmt, Clippy, smoke, npm installation, Python wrappers, installer integrity, version consistency, and the non-applicable benchmark gate in CI run `30794130536`.
- **Cairn:** architecture, decision, and interface verification passed in run `30794130526` at the green implementation commit.

## Contract evidence

- Direct wrapper tests exercise welcome/protocol, checkpoint save/resume, reminder set/list/dismiss, lesson queries, profile read/update, and legacy validation errors through the server runtime.
- A real full-mode stdio test pins all 19 advertised tools and verifies shared visibility with the still-unmigrated legacy `memory_store` path.

## Boundaries

- No storage, retrieval, scoring, schema, model, HTTP, daemon, hosted, authentication, or cloud behavior changes.
- Unified `memory_session` remains unchanged.
- Other legacy MCP families remain separate bounded slices.
