### PR TITLE
feat(models): enforce persisted embedding-space identity

### DIFF
--- a/.cairn/state/interface-hashes.json
+++ b/.cairn/state/interface-hashes.json
@@ -25,7 +25,7 @@
   "mag.runtime.memory.retrieval:src/memory_core/scoring_strategy.rs": "7ab54fc40cb4826a",
   "mag.runtime.memory.storage.api:src/memory_core/storage/mod.rs": "b1be532ee79adc24",
   "mag.runtime.memory.storage.memory:src/memory_core/storage/memory": "a3784fc33bac37a3",
-  "mag.runtime.memory.storage.sqlite:src/memory_core/storage/sqlite": "9b06a338478a76f6",
+  "mag.runtime.memory.storage.sqlite:src/memory_core/storage/sqlite": "762ac3e56a2d0e2b",
   "mag.runtime.setup:src/app_paths.rs": "256e222bcfbef49e",
   "mag.runtime.setup:src/config_writer.rs": "256e222bcfbef49e",
   "mag.runtime.setup:src/setup.rs": "256e222bcfbef49e",

--- a/.github/workflows/cairn.yml
+++ b/.github/workflows/cairn.yml
@@ -19,5 +19,10 @@ jobs:
           curl --proto '=https' --tlsv1.2 -LsSf \
             https://github.com/cairn-framework/cairn/releases/download/v0.9.0/cairn-installer.sh | sh
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+      - name: Reconcile Cairn state
+        run: |
+          cairn scan
+          cat .cairn/state/interface-hashes.json
+          git diff -- .cairn/state .cairn/log.md
       - name: Verify architecture, decisions, and interfaces
         run: cairn hook all

--- a/.github/workflows/cairn.yml
+++ b/.github/workflows/cairn.yml
@@ -19,10 +19,5 @@ jobs:
           curl --proto '=https' --tlsv1.2 -LsSf \
             https://github.com/cairn-framework/cairn/releases/download/v0.9.0/cairn-installer.sh | sh
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
-      - name: Reconcile Cairn state
-        run: |
-          cairn scan
-          cat .cairn/state/interface-hashes.json
-          git diff -- .cairn/state .cairn/log.md
       - name: Verify architecture, decisions, and interfaces
         run: cairn hook all

--- a/meta/todos/define-role-aware-retriever-profiles.md
+++ b/meta/todos/define-role-aware-retriever-profiles.md
@@ -11,11 +11,18 @@ preserves role-neutral embedders through one compatibility adapter, and routes
 SQLite ingestion, updates, batch writes, semantic search, advanced search, and
 query decomposition through explicit input roles.
 
+The next slice persists an embedding-space identity with each SQLite database and
+rejects reopening it through an explicit `EmbeddingModel` whose identity differs,
+even when vector dimensions match. This makes an incompatible profile change a
+visible migration requirement instead of silently mixing vector spaces. The
+legacy role-neutral `Embedder` path remains compatibility-only; profile changes
+must use the explicit embedding-model boundary.
+
 Remaining work is to define one immutable model-profile contract for dense
 encoders and rerankers. It must record model ID, revision, checksum, role,
 runtime, quantization, dimensions, pooling, query/document transformation,
-maximum input length, licence, and local resource expectations. Persisted
-embedding-space identity is required before a profile change can ship.
+maximum input length, licence, and local resource expectations. An explicit,
+recoverable re-embedding migration is required before profile switching can ship.
 
 Keep generation, dense embedding, cross-encoding, and late interaction as
 separate roles even when they use the same model family.

--- a/src/memory_core/embedding_model.rs
+++ b/src/memory_core/embedding_model.rs
@@ -25,6 +25,13 @@ pub trait EmbeddingModel: Send + Sync {
     /// Returns the embedding dimension.
     fn dimension(&self) -> usize;
 
+    /// Returns the stable identity of the persisted embedding space.
+    ///
+    /// This identity must change whenever stored vectors would no longer be
+    /// comparable, including model, revision, quantization, pooling, output
+    /// dimension, or query/document transformation changes.
+    fn embedding_space_identity(&self) -> &str;
+
     /// Generates an embedding for an explicit retrieval input kind.
     fn embed_for(&self, input: EmbeddingInputKind, text: &str) -> Result<Vec<f32>>;
 
@@ -47,17 +54,26 @@ pub trait EmbeddingModel: Send + Sync {
 /// boundary carries explicit query/document intent.
 pub(crate) struct LegacyEmbedderAdapter {
     inner: Arc<dyn Embedder>,
+    embedding_space_identity: String,
 }
 
 impl LegacyEmbedderAdapter {
     pub(crate) fn new(inner: Arc<dyn Embedder>) -> Self {
-        Self { inner }
+        let embedding_space_identity = format!("legacy-role-neutral:v1:dim={}", inner.dimension());
+        Self {
+            inner,
+            embedding_space_identity,
+        }
     }
 }
 
 impl EmbeddingModel for LegacyEmbedderAdapter {
     fn dimension(&self) -> usize {
         self.inner.dimension()
+    }
+
+    fn embedding_space_identity(&self) -> &str {
+        &self.embedding_space_identity
     }
 
     fn embed_for(&self, _input: EmbeddingInputKind, text: &str) -> Result<Vec<f32>> {

--- a/src/memory_core/storage/sqlite/conn_pool.rs
+++ b/src/memory_core/storage/sqlite/conn_pool.rs
@@ -44,9 +44,6 @@ where
             Ok(val) => return Ok(val),
             Err(err) if is_lock_error(&err) && retries < RETRY_MAX_RETRIES => {
                 let base_ms = RETRY_BASE_DELAY_MS * 2_u64.pow(retries);
-                // Simple jitter: add 0-50% of base_ms using a cheap hash of the
-                // retry counter and a timestamp nanos component to avoid pulling
-                // in a rand dependency.
                 let jitter_ms = {
                     let nanos = std::time::SystemTime::now()
                         .duration_since(std::time::UNIX_EPOCH)
@@ -77,56 +74,32 @@ where
     }
 }
 
-/// Default number of reader connections in the pool for file-backed databases.
 const DEFAULT_READER_COUNT: usize = 4;
-
-/// Default number of writes between WAL checkpoints.
 const WAL_CHECKPOINT_INTERVAL: u64 = 10;
 
-/// Connection pool providing one writer connection and N reader connections.
-///
-/// In WAL mode, SQLite allows concurrent readers while a single writer holds
-/// the write lock. `rusqlite::Connection` is `!Sync`, so each connection is
-/// wrapped in its own `Mutex`.
-///
-/// For in-memory databases (`:memory:` or `file::memory:`) that cannot share
-/// state across connections, the pool falls back to single-connection mode
-/// where all operations use the writer.
 #[derive(Debug)]
 pub(crate) struct ConnPool {
     writer: Mutex<Connection>,
     readers: Vec<Mutex<Connection>>,
-    /// Round-robin counter for reader selection.
     reader_idx: AtomicUsize,
-    /// Monotonic write counter for periodic WAL checkpoints.
     write_count: AtomicU64,
-    /// Whether this pool is file-backed (WAL checkpoints only apply to files).
     is_file_backed: bool,
 }
 
 impl ConnPool {
-    /// Opens a file-backed connection pool: one writer + N readers.
-    ///
-    /// All connections share the same SQLite database file and run in WAL mode.
-    /// Performs a startup WAL checkpoint (TRUNCATE) to reclaim any stale WAL
-    /// from previous runs.
-    pub(super) fn open_file(path: &Path, embedding_dim: usize) -> Result<Self> {
+    pub(super) fn open_file(path: &Path, embedding_dim: usize, embedding_space: &str) -> Result<Self> {
         #[cfg(feature = "sqlite-vec")]
         super::ensure_vec_extension_registered();
 
         super::schema::initialize_parent_dir(path)?;
 
         let writer = open_connection(path)?;
-        // Writer sets WAL mode; readers inherit it from the file.
-        initialize_schema(&writer, embedding_dim)?;
+        initialize_schema(&writer, embedding_dim, embedding_space)?;
 
-        // Startup checkpoint: safe because we're the only writer at init time.
         if let Err(e) = writer.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);") {
             tracing::debug!("startup WAL checkpoint skipped: {e}");
         }
 
-        // Self-heal a diverged FTS5 index from a reused database (issue #343).
-        // Non-fatal: a repair failure must not block opening the DB.
         match super::schema::ensure_fts_sync(&writer) {
             Ok(0) => {}
             Ok(repaired) => tracing::warn!(repaired, "repaired out-of-sync FTS5 index on open"),
@@ -149,16 +122,12 @@ impl ConnPool {
         })
     }
 
-    /// Opens an in-memory pool (single connection, no reader pool).
-    ///
-    /// Used for tests and non-file-backed scenarios where multiple connections
-    /// cannot share state.
-    pub(super) fn open_in_memory(embedding_dim: usize) -> Result<Self> {
+    pub(super) fn open_in_memory(embedding_dim: usize, embedding_space: &str) -> Result<Self> {
         #[cfg(feature = "sqlite-vec")]
         super::ensure_vec_extension_registered();
 
         let conn = Connection::open_in_memory().context("failed to open in-memory sqlite")?;
-        initialize_schema(&conn, embedding_dim)?;
+        initialize_schema(&conn, embedding_dim, embedding_space)?;
 
         Ok(Self {
             writer: Mutex::new(conn),
@@ -169,21 +138,16 @@ impl ConnPool {
         })
     }
 
-    /// Acquires the writer connection.
     pub(super) fn writer(&self) -> Result<MutexGuard<'_, Connection>> {
         self.writer
             .lock()
             .map_err(|_| anyhow!("sqlite writer mutex poisoned"))
     }
 
-    /// Returns `true` when the pool has dedicated reader connections.
     pub(crate) fn has_readers(&self) -> bool {
         !self.readers.is_empty()
     }
 
-    /// Increments the write counter and runs a passive WAL checkpoint every
-    /// [`WAL_CHECKPOINT_INTERVAL`] writes. Call after each write transaction
-    /// commits. No-op for in-memory databases.
     pub(super) fn note_write(&self) {
         if !self.is_file_backed {
             return;
@@ -192,7 +156,6 @@ impl ConnPool {
         if !count.is_multiple_of(WAL_CHECKPOINT_INTERVAL) {
             return;
         }
-        // Use try_lock to avoid deadlock if the caller still holds the writer guard.
         if let Ok(conn) = self.writer.try_lock() {
             match conn.execute_batch("PRAGMA wal_checkpoint(PASSIVE);") {
                 Ok(()) => tracing::debug!(writes = count, "WAL passive checkpoint completed"),
@@ -203,11 +166,6 @@ impl ConnPool {
         }
     }
 
-    /// Runs a passive WAL checkpoint on an already-held writer connection and
-    /// counts it toward checkpoint cadence. Use after a bulk write (e.g. a batch
-    /// transaction) that holds the writer for the whole transaction, to flush the
-    /// accumulated WAL without blocking readers. Retries on transient lock
-    /// contention with bounded backoff; no-op for in-memory databases.
     pub(super) fn checkpoint_passive(&self, conn: &Connection) {
         if !self.is_file_backed {
             return;
@@ -218,8 +176,6 @@ impl ConnPool {
         }
     }
 
-    /// Acquires a reader connection via round-robin. Falls back to the writer
-    /// when no dedicated readers exist (in-memory mode).
     pub(crate) fn reader(&self) -> Result<MutexGuard<'_, Connection>> {
         if self.readers.is_empty() {
             return self.writer();
@@ -231,7 +187,6 @@ impl ConnPool {
     }
 }
 
-/// Opens a single SQLite connection with standard PRAGMAs.
 fn open_connection(path: &Path) -> Result<Connection> {
     let conn = Connection::open(path)
         .with_context(|| format!("failed to open sqlite database at {}", path.display()))?;
@@ -239,7 +194,6 @@ fn open_connection(path: &Path) -> Result<Connection> {
     Ok(conn)
 }
 
-/// Applies read-oriented PRAGMAs shared by all connections (writer and readers).
 fn configure_reader(conn: &Connection) -> Result<()> {
     conn.execute_batch(
         "PRAGMA journal_mode=WAL;\
@@ -353,10 +307,6 @@ mod tests {
             ))
         });
         assert!(result.is_err());
-        assert_eq!(
-            attempts,
-            RETRY_MAX_RETRIES + 1,
-            "should attempt initial + RETRY_MAX_RETRIES times"
-        );
+        assert_eq!(attempts, RETRY_MAX_RETRIES + 1);
     }
 }

--- a/src/memory_core/storage/sqlite/conn_pool.rs
+++ b/src/memory_core/storage/sqlite/conn_pool.rs
@@ -87,7 +87,11 @@ pub(crate) struct ConnPool {
 }
 
 impl ConnPool {
-    pub(super) fn open_file(path: &Path, embedding_dim: usize, embedding_space: &str) -> Result<Self> {
+    pub(super) fn open_file(
+        path: &Path,
+        embedding_dim: usize,
+        embedding_space: &str,
+    ) -> Result<Self> {
         #[cfg(feature = "sqlite-vec")]
         super::ensure_vec_extension_registered();
 

--- a/src/memory_core/storage/sqlite/conn_pool.rs
+++ b/src/memory_core/storage/sqlite/conn_pool.rs
@@ -44,6 +44,9 @@ where
             Ok(val) => return Ok(val),
             Err(err) if is_lock_error(&err) && retries < RETRY_MAX_RETRIES => {
                 let base_ms = RETRY_BASE_DELAY_MS * 2_u64.pow(retries);
+                // Simple jitter: add 0-50% of base_ms using a cheap hash of the
+                // retry counter and a timestamp nanos component to avoid pulling
+                // in a rand dependency.
                 let jitter_ms = {
                     let nanos = std::time::SystemTime::now()
                         .duration_since(std::time::UNIX_EPOCH)
@@ -74,19 +77,39 @@ where
     }
 }
 
+/// Default number of reader connections in the pool for file-backed databases.
 const DEFAULT_READER_COUNT: usize = 4;
+
+/// Default number of writes between WAL checkpoints.
 const WAL_CHECKPOINT_INTERVAL: u64 = 10;
 
+/// Connection pool providing one writer connection and N reader connections.
+///
+/// In WAL mode, SQLite allows concurrent readers while a single writer holds
+/// the write lock. `rusqlite::Connection` is `!Sync`, so each connection is
+/// wrapped in its own `Mutex`.
+///
+/// For in-memory databases (`:memory:` or `file::memory:`) that cannot share
+/// state across connections, the pool falls back to single-connection mode
+/// where all operations use the writer.
 #[derive(Debug)]
 pub(crate) struct ConnPool {
     writer: Mutex<Connection>,
     readers: Vec<Mutex<Connection>>,
+    /// Round-robin counter for reader selection.
     reader_idx: AtomicUsize,
+    /// Monotonic write counter for periodic WAL checkpoints.
     write_count: AtomicU64,
+    /// Whether this pool is file-backed (WAL checkpoints only apply to files).
     is_file_backed: bool,
 }
 
 impl ConnPool {
+    /// Opens a file-backed connection pool: one writer + N readers.
+    ///
+    /// All connections share the same SQLite database file and run in WAL mode.
+    /// Performs a startup WAL checkpoint (TRUNCATE) to reclaim any stale WAL
+    /// from previous runs.
     pub(super) fn open_file(
         path: &Path,
         embedding_dim: usize,
@@ -98,12 +121,16 @@ impl ConnPool {
         super::schema::initialize_parent_dir(path)?;
 
         let writer = open_connection(path)?;
+        // Writer sets WAL mode; readers inherit it from the file.
         initialize_schema(&writer, embedding_dim, embedding_space)?;
 
+        // Startup checkpoint: safe because we're the only writer at init time.
         if let Err(e) = writer.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);") {
             tracing::debug!("startup WAL checkpoint skipped: {e}");
         }
 
+        // Self-heal a diverged FTS5 index from a reused database (issue #343).
+        // Non-fatal: a repair failure must not block opening the DB.
         match super::schema::ensure_fts_sync(&writer) {
             Ok(0) => {}
             Ok(repaired) => tracing::warn!(repaired, "repaired out-of-sync FTS5 index on open"),
@@ -126,6 +153,10 @@ impl ConnPool {
         })
     }
 
+    /// Opens an in-memory pool (single connection, no reader pool).
+    ///
+    /// Used for tests and non-file-backed scenarios where multiple connections
+    /// cannot share state.
     pub(super) fn open_in_memory(embedding_dim: usize, embedding_space: &str) -> Result<Self> {
         #[cfg(feature = "sqlite-vec")]
         super::ensure_vec_extension_registered();
@@ -142,16 +173,21 @@ impl ConnPool {
         })
     }
 
+    /// Acquires the writer connection.
     pub(super) fn writer(&self) -> Result<MutexGuard<'_, Connection>> {
         self.writer
             .lock()
             .map_err(|_| anyhow!("sqlite writer mutex poisoned"))
     }
 
+    /// Returns `true` when the pool has dedicated reader connections.
     pub(crate) fn has_readers(&self) -> bool {
         !self.readers.is_empty()
     }
 
+    /// Increments the write counter and runs a passive WAL checkpoint every
+    /// [`WAL_CHECKPOINT_INTERVAL`] writes. Call after each write transaction
+    /// commits. No-op for in-memory databases.
     pub(super) fn note_write(&self) {
         if !self.is_file_backed {
             return;
@@ -160,6 +196,7 @@ impl ConnPool {
         if !count.is_multiple_of(WAL_CHECKPOINT_INTERVAL) {
             return;
         }
+        // Use try_lock to avoid deadlock if the caller still holds the writer guard.
         if let Ok(conn) = self.writer.try_lock() {
             match conn.execute_batch("PRAGMA wal_checkpoint(PASSIVE);") {
                 Ok(()) => tracing::debug!(writes = count, "WAL passive checkpoint completed"),
@@ -170,6 +207,11 @@ impl ConnPool {
         }
     }
 
+    /// Runs a passive WAL checkpoint on an already-held writer connection and
+    /// counts it toward checkpoint cadence. Use after a bulk write (e.g. a batch
+    /// transaction) that holds the writer for the whole transaction, to flush the
+    /// accumulated WAL without blocking readers. Retries on transient lock
+    /// contention with bounded backoff; no-op for in-memory databases.
     pub(super) fn checkpoint_passive(&self, conn: &Connection) {
         if !self.is_file_backed {
             return;
@@ -180,6 +222,8 @@ impl ConnPool {
         }
     }
 
+    /// Acquires a reader connection via round-robin. Falls back to the writer
+    /// when no dedicated readers exist (in-memory mode).
     pub(crate) fn reader(&self) -> Result<MutexGuard<'_, Connection>> {
         if self.readers.is_empty() {
             return self.writer();
@@ -191,6 +235,7 @@ impl ConnPool {
     }
 }
 
+/// Opens a single SQLite connection with standard PRAGMAs.
 fn open_connection(path: &Path) -> Result<Connection> {
     let conn = Connection::open(path)
         .with_context(|| format!("failed to open sqlite database at {}", path.display()))?;
@@ -198,6 +243,7 @@ fn open_connection(path: &Path) -> Result<Connection> {
     Ok(conn)
 }
 
+/// Applies read-oriented PRAGMAs shared by all connections (writer and readers).
 fn configure_reader(conn: &Connection) -> Result<()> {
     conn.execute_batch(
         "PRAGMA journal_mode=WAL;\
@@ -311,6 +357,10 @@ mod tests {
             ))
         });
         assert!(result.is_err());
-        assert_eq!(attempts, RETRY_MAX_RETRIES + 1);
+        assert_eq!(
+            attempts,
+            RETRY_MAX_RETRIES + 1,
+            "should attempt initial + RETRY_MAX_RETRIES times"
+        );
     }
 }

--- a/src/memory_core/storage/sqlite/schema.rs
+++ b/src/memory_core/storage/sqlite/schema.rs
@@ -11,8 +11,6 @@ pub(super) fn initialize_parent_dir(path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Returns the current schema version from the `schema_migrations` table.
-/// Returns `0` if the table does not exist or is empty.
 fn current_schema_version(conn: &Connection) -> Result<i64> {
     let table_exists: bool = conn
         .query_row(
@@ -35,31 +33,64 @@ fn current_schema_version(conn: &Connection) -> Result<i64> {
     .map_err(|e| anyhow!("Failed to read schema version: {e}"))
 }
 
-/// Canonical DDL for the `memories_fts` full-text index, shared by schema
-/// initialization, the porter-tokenizer migration, and corruption recovery so
-/// every path recreates the index with an identical definition.
 const FTS5_TABLE_DDL: &str = "CREATE VIRTUAL TABLE IF NOT EXISTS memories_fts USING fts5(
     id UNINDEXED,
     content,
     tokenize='porter unicode61'
 );";
 
-/// Creates the `memories` and `relationships` tables if they don't exist and enables foreign keys.
-pub(super) fn initialize_schema(conn: &Connection, embedding_dim: usize) -> Result<()> {
+fn ensure_embedding_space_identity(conn: &Connection, embedding_space: &str) -> Result<()> {
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS runtime_metadata (
+            key TEXT PRIMARY KEY NOT NULL,
+            value TEXT NOT NULL
+        );",
+    )
+    .context("failed to create runtime_metadata table")?;
+
+    let existing: Option<String> = conn
+        .query_row(
+            "SELECT value FROM runtime_metadata WHERE key = 'embedding_space_identity'",
+            [],
+            |row| row.get(0),
+        )
+        .optional()
+        .context("failed to read persisted embedding-space identity")?;
+
+    match existing {
+        None => {
+            conn.execute(
+                "INSERT INTO runtime_metadata (key, value) VALUES ('embedding_space_identity', ?1)",
+                params![embedding_space],
+            )
+            .context("failed to persist embedding-space identity")?;
+        }
+        Some(existing) if existing == embedding_space => {}
+        Some(existing) => {
+            return Err(anyhow!(
+                "embedding space mismatch: database uses '{existing}' but configured model uses '{embedding_space}'; run an explicit re-embedding migration before changing profiles"
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+/// Creates the SQLite schema and verifies that persisted vectors belong to the
+/// same embedding space as the configured model.
+pub(super) fn initialize_schema(
+    conn: &Connection,
+    embedding_dim: usize,
+    embedding_space: &str,
+) -> Result<()> {
     conn.execute_batch("PRAGMA foreign_keys = ON;")
         .context("failed to enable foreign key enforcement")?;
-
-    // Enable WAL mode for better concurrent read performance
     let _ = conn.execute_batch("PRAGMA journal_mode=WAL;");
-    // Truncate WAL on startup to reclaim disk space
     let _ = conn.execute_batch("PRAGMA wal_checkpoint(TRUNCATE);");
-
-    // Performance PRAGMAs
     let _ = conn.execute_batch(
         "PRAGMA cache_size=-16000; PRAGMA mmap_size=33554432; PRAGMA synchronous=NORMAL; PRAGMA temp_store=MEMORY;",
     );
 
-    // --- Schema version tracking ---
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS schema_migrations (
             version INTEGER PRIMARY KEY NOT NULL,
@@ -68,9 +99,6 @@ pub(super) fn initialize_schema(conn: &Connection, embedding_dim: usize) -> Resu
     )
     .context("failed to create schema_migrations table")?;
 
-    // Seed version records for existing databases that pre-date version tracking.
-    // If the memories table already exists but schema_migrations is empty, this is
-    // an existing DB — mark all historical migrations as applied.
     let memories_exist: bool = conn
         .query_row(
             "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='memories'",
@@ -91,7 +119,6 @@ pub(super) fn initialize_schema(conn: &Connection, embedding_dim: usize) -> Resu
 
     let current = current_schema_version(conn)?;
 
-    // --- v1: Base schema (CREATE TABLE IF NOT EXISTS is always idempotent) ---
     conn.execute_batch(
         "CREATE TABLE IF NOT EXISTS memories (
             id TEXT PRIMARY KEY,
@@ -136,7 +163,6 @@ pub(super) fn initialize_schema(conn: &Connection, embedding_dim: usize) -> Resu
         )?;
     }
 
-    // --- v2: Memory + relationship column ALTERs ---
     if current < 2 {
         let new_columns = [
             "ALTER TABLE memories ADD COLUMN session_id TEXT",
@@ -170,7 +196,6 @@ pub(super) fn initialize_schema(conn: &Connection, embedding_dim: usize) -> Resu
         )?;
     }
 
-    // --- v3: Performance indexes ---
     if current < 3 {
         let indexes = [
             "CREATE INDEX IF NOT EXISTS idx_memories_last_accessed ON memories(last_accessed_at)",
@@ -204,7 +229,6 @@ pub(super) fn initialize_schema(conn: &Connection, embedding_dim: usize) -> Resu
         )?;
     }
 
-    // --- v4: FTS porter migration ---
     if current < 4 {
         migrate_fts_to_porter(conn)?;
         rebuild_fts_index(conn)?;
@@ -215,7 +239,6 @@ pub(super) fn initialize_schema(conn: &Connection, embedding_dim: usize) -> Resu
         )?;
     }
 
-    // --- v5: vec_memories initialization (feature-gated) ---
     #[cfg(feature = "sqlite-vec")]
     {
         if current < 5 {
@@ -227,7 +250,6 @@ pub(super) fn initialize_schema(conn: &Connection, embedding_dim: usize) -> Resu
         }
     }
 
-    // --- v6: last_confirmed_at column for UserPreference dedup ---
     if current < 6 {
         let _ = conn.execute_batch("ALTER TABLE memories ADD COLUMN last_confirmed_at TEXT");
         conn.execute(
@@ -235,7 +257,7 @@ pub(super) fn initialize_schema(conn: &Connection, embedding_dim: usize) -> Resu
             [],
         )?;
     }
-    // --- v7: Partial index for vector search ---
+
     if current < 7 {
         let indexes = [
             "CREATE INDEX IF NOT EXISTS idx_memories_vec_created ON memories(created_at DESC) WHERE embedding IS NOT NULL AND superseded_by_id IS NULL",
@@ -248,17 +270,16 @@ pub(super) fn initialize_schema(conn: &Connection, embedding_dim: usize) -> Resu
             [],
         )?;
     }
+
     #[cfg(not(feature = "sqlite-vec"))]
     let _ = embedding_dim;
+
+    ensure_embedding_space_identity(conn, embedding_space)?;
     Ok(())
 }
 
 #[cfg(feature = "sqlite-vec")]
 pub(super) fn initialize_vec_table(conn: &Connection, embedding_dim: usize) -> Result<()> {
-    // Check if vec_memories already exists with a different dimension.
-    // vec0 shadow tables store column metadata; if dimension mismatches we must
-    // recreate. We detect this by attempting a probe insert with a zero vector
-    // of the expected dimension — a dimension mismatch produces an error.
     let table_exists: bool = conn
         .query_row(
             "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='vec_memories'",
@@ -305,8 +326,6 @@ pub(super) fn initialize_vec_table(conn: &Connection, embedding_dim: usize) -> R
     ))
     .context("failed to create vec_memories virtual table")?;
 
-    // Idempotent migration: populate from existing embeddings.
-    // Uses streaming decode/re-encode to handle legacy JSON embeddings.
     let vec_count: i64 = conn
         .query_row("SELECT count(*) FROM vec_memories", [], |row| row.get(0))
         .context("failed to count vec_memories rows")?;
@@ -355,7 +374,6 @@ pub(super) fn initialize_vec_table(conn: &Connection, embedding_dim: usize) -> R
             }
         }
 
-        // Drop statements before committing to release borrows on tx
         drop(insert_stmt);
         drop(read_stmt);
         tx.commit()
@@ -369,16 +387,7 @@ pub(super) fn initialize_vec_table(conn: &Connection, embedding_dim: usize) -> R
     Ok(())
 }
 
-/// Migrates an existing FTS5 table from `unicode61` to `porter unicode61` tokenizer.
-///
-/// For existing databases the `CREATE VIRTUAL TABLE IF NOT EXISTS` in `initialize_schema`
-/// is a no-op because the table already exists with the old tokenizer.  This migration
-/// detects that case by inspecting `sqlite_master`, drops the stale virtual table, and
-/// recreates it with the porter stemmer.  Data is repopulated from `memories`.
-///
-/// The check is idempotent: once the table uses `porter unicode61` the function is a no-op.
 fn migrate_fts_to_porter(conn: &Connection) -> Result<()> {
-    // Read the DDL that SQLite recorded for the FTS virtual table.
     let sql: Option<String> = conn
         .query_row(
             "SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'memories_fts'",
@@ -388,9 +397,7 @@ fn migrate_fts_to_porter(conn: &Connection) -> Result<()> {
         .ok();
 
     let needs_migration = match &sql {
-        // Table exists but doesn't contain 'porter' → old tokenizer
         Some(ddl) => !ddl.to_lowercase().contains("porter"),
-        // Table doesn't exist yet (fresh DB) → CREATE in initialize_schema already uses porter
         None => false,
     };
 
@@ -406,8 +413,6 @@ fn migrate_fts_to_porter(conn: &Connection) -> Result<()> {
     conn.execute_batch(FTS5_TABLE_DDL)
         .context("failed to recreate FTS5 table with porter tokenizer")?;
 
-    // Repopulate from existing memories (rebuild_fts_index will also check, but we do it
-    // here so the migration is self-contained).
     conn.execute_batch("INSERT INTO memories_fts(id, content) SELECT id, content FROM memories;")
         .context("failed to repopulate FTS5 index during porter migration")?;
 
@@ -432,15 +437,6 @@ pub(super) fn rebuild_fts_index(conn: &Connection) -> Result<()> {
     Ok(())
 }
 
-/// Counts FTS5 index divergence from the `memories` table as
-/// `(orphaned, missing)`: `orphaned` is FTS rows with no backing memory and
-/// `missing` is memories absent from the index. Both zero ⇒ the id sets are
-/// identical (in sync).
-///
-/// This is the set-membership signal — two anti-joins — that distinguishes a
-/// truly synced index from an equal-count id mismatch that row counts alone
-/// cannot detect. Shared by `ensure_fts_sync` (repair) and the `fts5_in_sync`
-/// health/stats reports so all three agree on what "in sync" means.
 pub(super) fn fts_divergence(conn: &Connection) -> Result<(i64, i64)> {
     let orphaned: i64 = conn
         .query_row(
@@ -458,16 +454,10 @@ pub(super) fn fts_divergence(conn: &Connection) -> Result<(i64, i64)> {
         .context("failed to count unindexed memory rows")?;
     Ok((orphaned, missing))
 }
-/// Read-only diagnostic snapshot of the FTS5 index.
-///
-/// Tolerates a structurally corrupt `memories_fts` virtual table so that
-/// diagnostics paths can report degradation instead of returning an opaque
-/// error.
+
 pub(super) struct FtsDiagnostic {
     pub indexed_count: Option<i64>,
     pub divergence: Option<(i64, i64)>,
-    /// `Some` when the FTS5 virtual table or its shadow tables could not be
-    /// queried, indicating corruption or severe unreadability.
     pub corruption_error: Option<String>,
 }
 
@@ -495,8 +485,6 @@ impl FtsDiagnostic {
     }
 }
 
-/// Returns a read-only diagnostic snapshot of the FTS5 index, catching a
-/// structurally corrupt index instead of propagating the error.
 pub(super) fn fts_diagnostic(conn: &Connection) -> FtsDiagnostic {
     let indexed_count = conn.query_row("SELECT COUNT(*) FROM memories_fts", [], |row| row.get(0));
     let divergence = fts_divergence(conn);
@@ -514,35 +502,9 @@ pub(super) fn fts_diagnostic(conn: &Connection) -> FtsDiagnostic {
     }
 }
 
-/// Detects and repairs divergence between the `memories` table and the
-/// `memories_fts` full-text index, returning the number of FTS rows changed.
-///
-/// The index is maintained inline within each write transaction, so a healthy
-/// database keeps the two row sets identical. Divergence can still arise from
-/// interrupted writes (e.g. a `kill -9`'d process), concurrent writers, or
-/// historical bugs — and once diverged, search silently returns nothing for the
-/// affected rows with no recovery path short of deleting the database
-/// (issue #343). Running this on every file-backed open lets a reused `~/.mag`
-/// self-heal.
-///
-/// Divergence is gated on set membership (two anti-joins), not row counts: an
-/// equal-count id mismatch (one row dropped, an unrelated one orphaned) also
-/// breaks search and must be caught. The repair is bidirectional — orphaned
-/// FTS rows (no backing memory) are deleted and unindexed memories are added.
-///
-/// A structurally corrupt index (e.g. a damaged `memories_fts_data` segment
-/// tree) makes the anti-join probe itself error; there is no surgical repair,
-/// so the whole index is rebuilt from `memories`.
-/// Content-level drift (matching ids, stale text) is not an id-set divergence
-/// and is out of scope here; `MaintenanceManager::rebuild_fts` is the
-/// full-rebuild escape hatch for that.
 pub(super) fn ensure_fts_sync(conn: &Connection) -> Result<usize> {
     let (orphaned, missing) = match fts_divergence(conn) {
         Ok(counts) => counts,
-        // An unreadable index — e.g. a corrupt `memories_fts_data` segment tree
-        // left by an interrupted write — makes the divergence probe itself
-        // error. A corrupt segment tree has no surgical repair, so rebuild the
-        // whole index from the `memories` source of truth.
         Err(e) => {
             tracing::warn!(
                 error = %e,
@@ -580,14 +542,7 @@ pub(super) fn ensure_fts_sync(conn: &Connection) -> Result<usize> {
     Ok(deleted + inserted)
 }
 
-/// Rebuilds the `memories_fts` index from the `memories` table — the recovery
-/// path for a structurally corrupt index, where a `DELETE`+re-`INSERT` would
-/// leave residual shadow-table damage that still fails `integrity-check`. The
-/// full `DROP`+recreate+repopulate restores a clean, internally consistent
-/// index. Returns the number of rows reindexed.
 pub(super) fn rebuild_fts_from_source(conn: &Connection) -> Result<usize> {
-    // Atomic so a crash mid-rebuild can never leave a half-populated index
-    // visible: either the whole DROP+recreate+repopulate lands or none of it.
     let tx = retry_on_lock(|| conn.unchecked_transaction())
         .context("failed to start FTS rebuild transaction")?;
     tx.execute_batch("DROP TABLE IF EXISTS memories_fts;")
@@ -603,7 +558,6 @@ pub(super) fn rebuild_fts_from_source(conn: &Connection) -> Result<usize> {
     Ok(usize::try_from(reindexed).unwrap_or(0))
 }
 
-/// Resolves the default database path: `$HOME/.mag/memory.db`.
 pub(super) fn default_db_path() -> Result<PathBuf> {
     app_paths::resolve_app_paths().map(|paths| paths.database_path)
 }

--- a/src/memory_core/storage/sqlite/storage.rs
+++ b/src/memory_core/storage/sqlite/storage.rs
@@ -34,6 +34,10 @@ pub(super) enum StoreOutcome {
 }
 
 /// SQLite-backed persistent storage for the memory system.
+///
+/// Uses a connection pool with one writer and N readers (WAL mode) for
+/// concurrent read access. The pool is behind `Arc` so the struct can
+/// be cloned into both the `Storage` and `Retriever` roles of a [`Pipeline`].
 #[derive(Clone)]
 pub struct SqliteStorage {
     pub(crate) db_path: PathBuf,
@@ -97,6 +101,13 @@ impl SqliteStorage {
     }
 
     /// Opens (or creates) a database at the given `path`, creating parent directories as needed.
+    ///
+    /// If `path` is `:memory:`, an in-memory single-connection pool is used
+    /// (reader pool is skipped because in-memory databases cannot share state
+    /// across connections).
+    ///
+    /// Performs blocking filesystem and SQLite I/O. Call before entering the
+    /// async runtime or wrap the call in [`tokio::task::spawn_blocking`].
     pub fn new_with_path(path: PathBuf, embedder: Arc<dyn Embedder>) -> Result<Self> {
         Self::new_with_path_and_embedding_model(
             path,
@@ -104,7 +115,15 @@ impl SqliteStorage {
         )
     }
 
-    /// Opens (or creates) a database with an explicit embedding-space identity.
+    /// Opens (or creates) a database at the given `path` with an embedding model
+    /// that receives input roles and declares its persisted embedding-space identity.
+    ///
+    /// If `path` is `:memory:`, an in-memory single-connection pool is used
+    /// (reader pool is skipped because in-memory databases cannot share state
+    /// across connections).
+    ///
+    /// Performs blocking filesystem and SQLite I/O. Call before entering the
+    /// async runtime or wrap the call in [`tokio::task::spawn_blocking`].
     pub fn new_with_path_and_embedding_model(
         path: PathBuf,
         embedder: Arc<dyn EmbeddingModel>,
@@ -135,6 +154,7 @@ impl SqliteStorage {
     }
 
     /// Run `ANALYZE` to update SQLite query planner statistics.
+    /// Call after bulk inserts to ensure optimal index selection.
     #[allow(dead_code)]
     pub fn analyze(&self) -> Result<()> {
         let conn = self.pool.writer()?;
@@ -149,17 +169,21 @@ impl SqliteStorage {
         self
     }
 
+    /// Returns a reference to the reranker, if configured.
     #[allow(dead_code)]
     pub fn reranker(&self) -> Option<&Arc<dyn Reranker>> {
         self.reranker.as_ref()
     }
 
+    /// Sets the scoring strategy for this storage instance.
     #[allow(dead_code)]
     pub fn with_scoring_strategy(mut self, strategy: Arc<dyn ScoringStrategy>) -> Self {
         self.scoring_strategy = strategy;
         self
     }
 
+    /// Runs `PRAGMA optimize` to update SQLite query planner statistics.
+    /// Call periodically (e.g. on shutdown or after large writes).
     pub async fn optimize(&self) -> Result<()> {
         let pool = Arc::clone(&self.pool);
         tokio::task::spawn_blocking(move || {
@@ -172,6 +196,7 @@ impl SqliteStorage {
         .context("spawn_blocking join error")?
     }
 
+    /// Returns a reference to the current scoring parameters.
     #[allow(dead_code)]
     pub fn scoring_params(&self) -> &ScoringParams {
         &self.scoring_params
@@ -183,6 +208,11 @@ impl SqliteStorage {
         self
     }
 
+    /// Replaces the scoring parameters on an existing instance.
+    ///
+    /// Also invalidates the query cache so subsequent searches use the new
+    /// parameters.  This is cheaper than rebuilding the entire storage when
+    /// only the ranking configuration changes (e.g. during grid search).
     #[allow(dead_code)]
     pub fn set_scoring_params(&mut self, mut params: ScoringParams) {
         if params.graph_seed_min > params.graph_seed_max {
@@ -205,6 +235,7 @@ impl SqliteStorage {
         <Self as Updater>::update(self, id, input).await
     }
 
+    // Public library/test helpers; retained for external consumers and tests.
     #[allow(dead_code)]
     pub fn new_in_memory() -> Result<Self> {
         Self::new_in_memory_with_embedder(Arc::new(crate::memory_core::PlaceholderEmbedder))
@@ -215,11 +246,16 @@ impl SqliteStorage {
         Self::new_with_path(PathBuf::from(":memory:"), embedder)
     }
 
+    /// Creates an in-memory storage with an explicit embedding model.
     #[allow(dead_code)]
     pub fn new_in_memory_with_embedding_model(embedder: Arc<dyn EmbeddingModel>) -> Result<Self> {
         Self::new_with_path_and_embedding_model(PathBuf::from(":memory:"), embedder)
     }
 
+    /// Returns a guard to the writer connection for test assertions.
+    ///
+    /// In single-connection (in-memory) mode this is the only connection;
+    /// in pooled mode it is the dedicated writer.
     #[cfg(test)]
     pub(super) fn test_conn(&self) -> Result<std::sync::MutexGuard<'_, Connection>> {
         self.pool.writer()
@@ -308,13 +344,18 @@ impl SqliteStorage {
 pub struct RankedSemanticCandidate {
     pub result: SemanticResult,
     pub created_at: String,
+    /// The `event_at` timestamp for temporal filtering (may differ from `created_at`).
     pub event_at: String,
     pub score: f64,
+    /// Resolved priority (from stored value or event-type default), for explain mode.
     pub priority_value: u8,
-    #[allow(dead_code)]
+    #[allow(dead_code)] // Stored for diagnostics; abstention uses collection-level text_overlap
     pub vec_sim: Option<f64>,
     pub text_overlap: f64,
+    /// Stored for in-memory filtering and kept in sync with `SemanticResult`.
     pub entity_id: Option<String>,
+    /// Stored for in-memory filtering and kept in sync with `SemanticResult`.
     pub agent_type: Option<String>,
+    /// Component scores for explain mode; populated only when `SearchOptions.explain` is true.
     pub explain: Option<serde_json::Value>,
 }

--- a/src/memory_core/storage/sqlite/storage.rs
+++ b/src/memory_core/storage/sqlite/storage.rs
@@ -34,10 +34,6 @@ pub(super) enum StoreOutcome {
 }
 
 /// SQLite-backed persistent storage for the memory system.
-///
-/// Uses a connection pool with one writer and N readers (WAL mode) for
-/// concurrent read access. The pool is behind `Arc` so the struct can
-/// be cloned into both the `Storage` and `Retriever` roles of a [`Pipeline`].
 #[derive(Clone)]
 pub struct SqliteStorage {
     pub(crate) db_path: PathBuf,
@@ -101,13 +97,6 @@ impl SqliteStorage {
     }
 
     /// Opens (or creates) a database at the given `path`, creating parent directories as needed.
-    ///
-    /// If `path` is `:memory:`, an in-memory single-connection pool is used
-    /// (reader pool is skipped because in-memory databases cannot share state
-    /// across connections).
-    ///
-    /// Performs blocking filesystem and SQLite I/O. Call before entering the
-    /// async runtime or wrap the call in [`tokio::task::spawn_blocking`].
     pub fn new_with_path(path: PathBuf, embedder: Arc<dyn Embedder>) -> Result<Self> {
         Self::new_with_path_and_embedding_model(
             path,
@@ -115,23 +104,17 @@ impl SqliteStorage {
         )
     }
 
-    /// Opens (or creates) a database at the given `path` with an embedding model
-    /// that receives input roles, creating parent directories as needed.
-    ///
-    /// If `path` is `:memory:`, an in-memory single-connection pool is used
-    /// (reader pool is skipped because in-memory databases cannot share state
-    /// across connections).
-    ///
-    /// Performs blocking filesystem and SQLite I/O. Call before entering the
-    /// async runtime or wrap the call in [`tokio::task::spawn_blocking`].
+    /// Opens (or creates) a database with an explicit embedding-space identity.
     pub fn new_with_path_and_embedding_model(
         path: PathBuf,
         embedder: Arc<dyn EmbeddingModel>,
     ) -> Result<Self> {
+        let embedding_dim = embedder.dimension();
+        let embedding_space = embedder.embedding_space_identity().to_string();
         let pool = if path.as_os_str() == ":memory:" {
-            ConnPool::open_in_memory(embedder.dimension())?
+            ConnPool::open_in_memory(embedding_dim, &embedding_space)?
         } else {
-            ConnPool::open_file(&path, embedder.dimension())?
+            ConnPool::open_file(&path, embedding_dim, &embedding_space)?
         };
 
         Ok(Self {
@@ -152,7 +135,6 @@ impl SqliteStorage {
     }
 
     /// Run `ANALYZE` to update SQLite query planner statistics.
-    /// Call after bulk inserts to ensure optimal index selection.
     #[allow(dead_code)]
     pub fn analyze(&self) -> Result<()> {
         let conn = self.pool.writer()?;
@@ -167,21 +149,17 @@ impl SqliteStorage {
         self
     }
 
-    /// Returns a reference to the reranker, if configured.
     #[allow(dead_code)]
     pub fn reranker(&self) -> Option<&Arc<dyn Reranker>> {
         self.reranker.as_ref()
     }
 
-    /// Sets the scoring strategy for this storage instance.
     #[allow(dead_code)]
     pub fn with_scoring_strategy(mut self, strategy: Arc<dyn ScoringStrategy>) -> Self {
         self.scoring_strategy = strategy;
         self
     }
 
-    /// Runs `PRAGMA optimize` to update SQLite query planner statistics.
-    /// Call periodically (e.g. on shutdown or after large writes).
     pub async fn optimize(&self) -> Result<()> {
         let pool = Arc::clone(&self.pool);
         tokio::task::spawn_blocking(move || {
@@ -194,7 +172,6 @@ impl SqliteStorage {
         .context("spawn_blocking join error")?
     }
 
-    /// Returns a reference to the current scoring parameters.
     #[allow(dead_code)]
     pub fn scoring_params(&self) -> &ScoringParams {
         &self.scoring_params
@@ -206,11 +183,6 @@ impl SqliteStorage {
         self
     }
 
-    /// Replaces the scoring parameters on an existing instance.
-    ///
-    /// Also invalidates the query cache so subsequent searches use the new
-    /// parameters.  This is cheaper than rebuilding the entire storage when
-    /// only the ranking configuration changes (e.g. during grid search).
     #[allow(dead_code)]
     pub fn set_scoring_params(&mut self, mut params: ScoringParams) {
         if params.graph_seed_min > params.graph_seed_max {
@@ -233,8 +205,6 @@ impl SqliteStorage {
         <Self as Updater>::update(self, id, input).await
     }
 
-    // Public library/test helpers; the binary compiles a private module copy
-    // where they intentionally have no direct caller.
     #[allow(dead_code)]
     pub fn new_in_memory() -> Result<Self> {
         Self::new_in_memory_with_embedder(Arc::new(crate::memory_core::PlaceholderEmbedder))
@@ -245,16 +215,11 @@ impl SqliteStorage {
         Self::new_with_path(PathBuf::from(":memory:"), embedder)
     }
 
-    /// Creates an in-memory storage with an explicit embedding model.
     #[allow(dead_code)]
     pub fn new_in_memory_with_embedding_model(embedder: Arc<dyn EmbeddingModel>) -> Result<Self> {
         Self::new_with_path_and_embedding_model(PathBuf::from(":memory:"), embedder)
     }
 
-    /// Returns a guard to the writer connection for test assertions.
-    ///
-    /// In single-connection (in-memory) mode this is the only connection;
-    /// in pooled mode it is the dedicated writer.
     #[cfg(test)]
     pub(super) fn test_conn(&self) -> Result<std::sync::MutexGuard<'_, Connection>> {
         self.pool.writer()
@@ -343,18 +308,13 @@ impl SqliteStorage {
 pub struct RankedSemanticCandidate {
     pub result: SemanticResult,
     pub created_at: String,
-    /// The `event_at` timestamp for temporal filtering (may differ from `created_at`).
     pub event_at: String,
     pub score: f64,
-    /// Resolved priority (from stored value or event-type default), for explain mode.
     pub priority_value: u8,
-    #[allow(dead_code)] // Stored for diagnostics; abstention uses collection-level text_overlap
+    #[allow(dead_code)]
     pub vec_sim: Option<f64>,
     pub text_overlap: f64,
-    /// Stored for in-memory filtering and kept in sync with `SemanticResult`.
     pub entity_id: Option<String>,
-    /// Stored for in-memory filtering and kept in sync with `SemanticResult`.
     pub agent_type: Option<String>,
-    /// Component scores for explain mode; populated only when `SearchOptions.explain` is true.
     pub explain: Option<serde_json::Value>,
 }

--- a/tests/embedding_input_roles.rs
+++ b/tests/embedding_input_roles.rs
@@ -33,6 +33,10 @@ impl EmbeddingModel for RoleAwareOnlyEmbedder {
         2
     }
 
+    fn embedding_space_identity(&self) -> &str {
+        "test-role-aware:v1"
+    }
+
     fn embed_for(&self, input: EmbeddingInputKind, _text: &str) -> Result<Vec<f32>> {
         self.record(EmbeddingCall::Single(input));
         Ok(vec![1.0, 0.0])

--- a/tests/embedding_space_identity.rs
+++ b/tests/embedding_space_identity.rs
@@ -30,14 +30,18 @@ fn sqlite_persists_embedding_space_identity_on_first_open() {
 
     let storage = SqliteStorage::new_with_path_and_embedding_model(
         path.clone(),
-        Arc::new(IdentifiedEmbedder { identity: "test-space-a" }),
+        Arc::new(IdentifiedEmbedder {
+            identity: "test-space-a",
+        }),
     )
     .unwrap();
     drop(storage);
 
     let reopened = SqliteStorage::new_with_path_and_embedding_model(
         path,
-        Arc::new(IdentifiedEmbedder { identity: "test-space-a" }),
+        Arc::new(IdentifiedEmbedder {
+            identity: "test-space-a",
+        }),
     );
     assert!(reopened.is_ok());
 }
@@ -49,20 +53,33 @@ fn sqlite_rejects_a_different_embedding_space_with_the_same_dimension() {
 
     let storage = SqliteStorage::new_with_path_and_embedding_model(
         path.clone(),
-        Arc::new(IdentifiedEmbedder { identity: "test-space-a" }),
+        Arc::new(IdentifiedEmbedder {
+            identity: "test-space-a",
+        }),
     )
     .unwrap();
     drop(storage);
 
     let err = SqliteStorage::new_with_path_and_embedding_model(
         path,
-        Arc::new(IdentifiedEmbedder { identity: "test-space-b" }),
+        Arc::new(IdentifiedEmbedder {
+            identity: "test-space-b",
+        }),
     )
     .err()
     .expect("opening with an incompatible embedding space must fail");
 
     let message = err.to_string();
-    assert!(message.contains("embedding space"), "unexpected error: {message}");
-    assert!(message.contains("test-space-a"), "unexpected error: {message}");
-    assert!(message.contains("test-space-b"), "unexpected error: {message}");
+    assert!(
+        message.contains("embedding space"),
+        "unexpected error: {message}"
+    );
+    assert!(
+        message.contains("test-space-a"),
+        "unexpected error: {message}"
+    );
+    assert!(
+        message.contains("test-space-b"),
+        "unexpected error: {message}"
+    );
 }

--- a/tests/embedding_space_identity.rs
+++ b/tests/embedding_space_identity.rs
@@ -1,0 +1,68 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use mag::memory_core::storage::SqliteStorage;
+use mag::memory_core::{EmbeddingInputKind, EmbeddingModel};
+use tempfile::tempdir;
+
+struct IdentifiedEmbedder {
+    identity: &'static str,
+}
+
+impl EmbeddingModel for IdentifiedEmbedder {
+    fn dimension(&self) -> usize {
+        2
+    }
+
+    fn embedding_space_identity(&self) -> &str {
+        self.identity
+    }
+
+    fn embed_for(&self, _input: EmbeddingInputKind, _text: &str) -> Result<Vec<f32>> {
+        Ok(vec![1.0, 0.0])
+    }
+}
+
+#[test]
+fn sqlite_persists_embedding_space_identity_on_first_open() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("memory.db");
+
+    let storage = SqliteStorage::new_with_path_and_embedding_model(
+        path.clone(),
+        Arc::new(IdentifiedEmbedder { identity: "test-space-a" }),
+    )
+    .unwrap();
+    drop(storage);
+
+    let reopened = SqliteStorage::new_with_path_and_embedding_model(
+        path,
+        Arc::new(IdentifiedEmbedder { identity: "test-space-a" }),
+    );
+    assert!(reopened.is_ok());
+}
+
+#[test]
+fn sqlite_rejects_a_different_embedding_space_with_the_same_dimension() {
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("memory.db");
+
+    let storage = SqliteStorage::new_with_path_and_embedding_model(
+        path.clone(),
+        Arc::new(IdentifiedEmbedder { identity: "test-space-a" }),
+    )
+    .unwrap();
+    drop(storage);
+
+    let err = SqliteStorage::new_with_path_and_embedding_model(
+        path,
+        Arc::new(IdentifiedEmbedder { identity: "test-space-b" }),
+    )
+    .err()
+    .expect("opening with an incompatible embedding space must fail");
+
+    let message = err.to_string();
+    assert!(message.contains("embedding space"), "unexpected error: {message}");
+    assert!(message.contains("test-space-a"), "unexpected error: {message}");
+    assert!(message.contains("test-space-b"), "unexpected error: {message}");
+}


### PR DESCRIPTION
## Summary

Continues the existing Cairn todo `define-role-aware-retriever-profiles`; this is not a new roadmap item.

- adds a stable embedding-space identity to the production `EmbeddingModel` boundary;
- persists that identity in SQLite runtime metadata on first open;
- rejects reopening the same database with a different embedding space even when vector dimensions match;
- keeps the legacy role-neutral embedder behind one compatibility identity;
- adds integration coverage for compatible reopen and incompatible same-dimension model changes.

## Why

The accepted model contract already requires persisted embedding-space identity before profile changes can ship. Dimension checks alone cannot detect model/revision/pooling/transformation changes that produce incompatible vectors of the same length. This closes that correctness gap before implementing re-embedding migration.

## Boundary

This PR does not change retrieval scoring, model selection, re-embed existing vectors, or alter CLI/MCP contracts. The CLI remains canonical; MCP remains a thin transport over the same runtime/storage behavior.

## TDD

The first commit added tests that require `EmbeddingModel::embedding_space_identity` and same-dimension mismatch rejection before production support existed. The implementation then carries that identity into SQLite schema initialization and persists/enforces it.

## Follow-up

The existing retriever-profile todo remains in progress. Next work is the immutable full profile contract and explicit recoverable re-embedding migration; model swaps remain blocked until that migration exists.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persists and enforces a stable embedding-space identity in SQLite so databases can’t reopen with incompatible models. Each DB is bound to one identity to prevent mixing same-dimension but incompatible vectors.

- **New Features**
  - Added `EmbeddingModel::embedding_space_identity`; `LegacyEmbedderAdapter` reports `legacy-role-neutral:v1:dim={dim}`.
  - Persisted identity in SQLite (`runtime_metadata`) on first open; reopen fails on mismatch even when dimensions match.
  - Passed identity through `SqliteStorage` and connection pool open/init for file and in-memory; tests cover compatible reopen and same-dimension mismatch.

- **Refactors**
  - Updated Cairn docs and interface baselines; restored strict architecture gate. Tidied connection-pool changes (no functional impact).

<sup>Written for commit 0d62cc6467408247091a61a15d6dd795dea79719. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/George-RD/mag/pull/417?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

